### PR TITLE
fix(css): safelist missing md utilities and add responsive position/visibility classes

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -4604,6 +4604,26 @@
       line-height: var(--tw-leading, var(--text-sm--line-height));
     }
   }
+  .md\:absolute {
+    @media (width >= 48rem) {
+      position: absolute;
+    }
+  }
+  .md\:fixed {
+    @media (width >= 48rem) {
+      position: fixed;
+    }
+  }
+  .md\:relative {
+    @media (width >= 48rem) {
+      position: relative;
+    }
+  }
+  .md\:sticky {
+    @media (width >= 48rem) {
+      position: sticky;
+    }
+  }
   .md\:top-\[unset\] {
     @media (width >= 48rem) {
       top: unset;
@@ -4629,6 +4649,26 @@
       left: unset;
     }
   }
+  .md\:block {
+    @media (width >= 48rem) {
+      display: block;
+    }
+  }
+  .md\:flex {
+    @media (width >= 48rem) {
+      display: flex;
+    }
+  }
+  .md\:grid {
+    @media (width >= 48rem) {
+      display: grid;
+    }
+  }
+  .md\:hidden {
+    @media (width >= 48rem) {
+      display: none;
+    }
+  }
   .md\:size-6 {
     @media (width >= 48rem) {
       width: calc(var(--spacing) * 6);
@@ -4645,6 +4685,11 @@
       height: 100%;
     }
   }
+  .md\:w-64 {
+    @media (width >= 48rem) {
+      width: calc(var(--spacing) * 64);
+    }
+  }
   .md\:max-w-\[90vw\] {
     @media (width >= 48rem) {
       max-width: 90vw;
@@ -4653,6 +4698,12 @@
   .md\:max-w-sm {
     @media (width >= 48rem) {
       max-width: var(--container-sm);
+    }
+  }
+  .md\:translate-x-0 {
+    @media (width >= 48rem) {
+      --tw-translate-x: calc(var(--spacing) * 0);
+      translate: var(--tw-translate-x) var(--tw-translate-y);
     }
   }
   .md\:translate-x-24 {

--- a/css/main.css
+++ b/css/main.css
@@ -25,6 +25,17 @@
    the JIT only emits color vars for shades actually used by themes. */
 @source inline("bg-{red,orange,amber,yellow,lime,green,emerald,teal,cyan,sky,blue,indigo,violet,purple,fuchsia,pink,rose,slate,gray,zinc,neutral,stone}-{50,100,200,300,400,500,600,700,800,900,950}");
 
+/* Safelist responsive position + visibility variants that tks-console
+   relies on. tks-console imports the full goshtoso-base.css, which means
+   goshtoso's tailwind utilities get emitted AFTER tks-console's own. Any
+   `md:*` override that tks-console uses on top of a base utility goshtoso
+   also emits (e.g. `fixed md:relative` on the sidebar) needs a matching
+   `md:*` rule in goshtoso's output — otherwise goshtoso's `.fixed` wins
+   at every viewport and the sidebar overlays the main column. */
+@source inline("md:{relative,fixed,absolute,sticky,hidden,block,flex,grid}");
+@source inline("md:translate-x-0");
+@source inline("md:w-64");
+
 /* ============================================
    THEME SYSTEM
    Imported from all-themes.css which provides:


### PR DESCRIPTION
Rolling subtree-sync for prefix `goshtoso` (base `main`).

## Included monorepo merges

- `de783d3cb268` — https://github.com/guilycst/totvs-work/commit/de783d3cb26819487667a5363ee104ba6a09a8af (goshtoso)