### PR TITLE
docs: bring every component demo page up to the docs-page pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,11 @@ the `data-toc-heading` headings the helpers emit. Give each variant container a
 unique ID (`<name>-default`, `<name>-split`, …). Rebuild Tailwind + `go build`
 after introducing any new utility class (CSS is embedded).
 
+All 36 component demo pages follow this pattern (API reference via a bottom
+`demo.APIReference` call, or the inline `Props:` field on `ComponentDemoProps` —
+both render the same table). The only exempt pages are the non-component
+specials: **getting-started**, **landing**, and **theme** (no variants/API).
+
 **Full reference + skeleton + pitfalls:** the **`component-docs` skill**
 (`.claude/skills/component-docs/SKILL.md`). Canonical example:
 `internal/pages/demo/components/accordion.templ`. Invoke the skill before

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -5,6 +5,7 @@
   :root, :host {
     --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
     'Noto Color Emoji';
+    --font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
     --color-red-50: oklch(97.1% 0.013 17.38);
@@ -249,9 +250,60 @@
     --color-stone-800: oklch(26.8% 0.007 34.298);
     --color-stone-900: oklch(21.6% 0.006 56.043);
     --color-stone-950: oklch(14.7% 0.004 49.25);
+    --color-mauve-50: oklch(98.5% 0 0);
+    --color-mauve-100: oklch(96% 0.003 325.6);
+    --color-mauve-200: oklch(92.2% 0.005 325.62);
+    --color-mauve-300: oklch(86.5% 0.012 325.68);
+    --color-mauve-400: oklch(71.1% 0.019 323.02);
+    --color-mauve-500: oklch(54.2% 0.034 322.5);
+    --color-mauve-600: oklch(43.5% 0.029 321.78);
+    --color-mauve-700: oklch(36.4% 0.029 323.89);
+    --color-mauve-800: oklch(26.3% 0.024 320.12);
+    --color-mauve-900: oklch(21.2% 0.019 322.12);
+    --color-mauve-950: oklch(14.5% 0.008 326);
+    --color-olive-50: oklch(98.8% 0.003 106.5);
+    --color-olive-100: oklch(96.6% 0.005 106.5);
+    --color-olive-200: oklch(93% 0.007 106.5);
+    --color-olive-300: oklch(88% 0.011 106.6);
+    --color-olive-400: oklch(73.7% 0.021 106.9);
+    --color-olive-500: oklch(58% 0.031 107.3);
+    --color-olive-600: oklch(46.6% 0.025 107.3);
+    --color-olive-700: oklch(39.4% 0.023 107.4);
+    --color-olive-800: oklch(28.6% 0.016 107.4);
+    --color-olive-900: oklch(22.8% 0.013 107.4);
+    --color-olive-950: oklch(15.3% 0.006 107.1);
+    --color-mist-50: oklch(98.7% 0.002 197.1);
+    --color-mist-100: oklch(96.3% 0.002 197.1);
+    --color-mist-200: oklch(92.5% 0.005 214.3);
+    --color-mist-300: oklch(87.2% 0.007 219.6);
+    --color-mist-400: oklch(72.3% 0.014 214.4);
+    --color-mist-500: oklch(56% 0.021 213.5);
+    --color-mist-600: oklch(45% 0.017 213.2);
+    --color-mist-700: oklch(37.8% 0.015 216);
+    --color-mist-800: oklch(27.5% 0.011 216.9);
+    --color-mist-900: oklch(21.8% 0.008 223.9);
+    --color-mist-950: oklch(14.8% 0.004 228.8);
+    --color-taupe-50: oklch(98.6% 0.002 67.8);
+    --color-taupe-100: oklch(96% 0.002 17.2);
+    --color-taupe-200: oklch(92.2% 0.005 34.3);
+    --color-taupe-300: oklch(86.8% 0.007 39.5);
+    --color-taupe-400: oklch(71.4% 0.014 41.2);
+    --color-taupe-500: oklch(54.7% 0.021 43.1);
+    --color-taupe-600: oklch(43.8% 0.017 39.3);
+    --color-taupe-700: oklch(36.7% 0.016 35.7);
+    --color-taupe-800: oklch(26.8% 0.011 36.5);
+    --color-taupe-900: oklch(21.4% 0.009 43.1);
+    --color-taupe-950: oklch(14.7% 0.004 49.3);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
+    --breakpoint-sm: 40rem;
+    --breakpoint-md: 48rem;
+    --breakpoint-lg: 64rem;
+    --breakpoint-xl: 80rem;
+    --breakpoint-2xl: 96rem;
+    --container-3xs: 16rem;
+    --container-2xs: 18rem;
     --container-xs: 20rem;
     --container-sm: 24rem;
     --container-md: 28rem;
@@ -261,6 +313,7 @@
     --container-3xl: 48rem;
     --container-4xl: 56rem;
     --container-5xl: 64rem;
+    --container-6xl: 72rem;
     --container-7xl: 80rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
@@ -288,27 +341,75 @@
     --text-8xl--line-height: 1;
     --text-9xl: 8rem;
     --text-9xl--line-height: 1;
+    --font-weight-thin: 100;
+    --font-weight-extralight: 200;
+    --font-weight-light: 300;
     --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
+    --font-weight-extrabold: 800;
+    --font-weight-black: 900;
+    --tracking-tighter: -0.05em;
     --tracking-tight: -0.025em;
+    --tracking-normal: 0em;
     --tracking-wide: 0.025em;
     --tracking-wider: 0.05em;
     --tracking-widest: 0.1em;
+    --leading-tight: 1.25;
+    --leading-snug: 1.375;
+    --leading-normal: 1.5;
     --leading-relaxed: 1.625;
+    --leading-loose: 2;
+    --radius-xs: 0.125rem;
     --radius-sm: 0.25rem;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --radius-xl: 0.75rem;
     --radius-2xl: 1rem;
+    --radius-3xl: 1.5rem;
+    --radius-4xl: 2rem;
+    --shadow-2xs: 0 1px rgb(0 0 0 / 0.05);
+    --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    --shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+    --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+    --shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.25);
+    --inset-shadow-2xs: inset 0 1px rgb(0 0 0 / 0.05);
+    --inset-shadow-xs: inset 0 1px 1px rgb(0 0 0 / 0.05);
+    --inset-shadow-sm: inset 0 2px 4px rgb(0 0 0 / 0.05);
+    --drop-shadow-xs: 0 1px 1px rgb(0 0 0 / 0.05);
+    --drop-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.15);
+    --drop-shadow-md: 0 3px 3px rgb(0 0 0 / 0.12);
+    --drop-shadow-lg: 0 4px 4px rgb(0 0 0 / 0.15);
+    --drop-shadow-xl: 0 9px 7px rgb(0 0 0 / 0.1);
+    --drop-shadow-2xl: 0 25px 25px rgb(0 0 0 / 0.15);
+    --text-shadow-2xs: 0px 1px 0px rgb(0 0 0 / 0.15);
+    --text-shadow-xs: 0px 1px 1px rgb(0 0 0 / 0.2);
+    --text-shadow-sm: 0px 1px 0px rgb(0 0 0 / 0.075), 0px 1px 1px rgb(0 0 0 / 0.075), 0px 2px 2px rgb(0 0 0 / 0.075);
+    --text-shadow-md: 0px 1px 1px rgb(0 0 0 / 0.1), 0px 1px 2px rgb(0 0 0 / 0.1), 0px 2px 4px rgb(0 0 0 / 0.1);
+    --text-shadow-lg: 0px 1px 2px rgb(0 0 0 / 0.1), 0px 3px 2px rgb(0 0 0 / 0.1), 0px 4px 8px rgb(0 0 0 / 0.1);
     --ease-in: cubic-bezier(0.4, 0, 1, 1);
     --ease-out: cubic-bezier(0, 0, 0.2, 1);
     --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
     --animate-spin: spin 1s linear infinite;
     --animate-ping: ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+    --animate-pulse: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
     --animate-bounce: bounce 1s infinite;
+    --blur-xs: 4px;
+    --blur-sm: 8px;
     --blur-md: 12px;
+    --blur-lg: 16px;
+    --blur-xl: 24px;
+    --blur-2xl: 40px;
+    --blur-3xl: 64px;
+    --perspective-dramatic: 100px;
+    --perspective-near: 300px;
+    --perspective-normal: 500px;
+    --perspective-midrange: 800px;
+    --perspective-distant: 1200px;
+    --aspect-video: 16 / 9;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
@@ -504,6 +605,10 @@
   }
 }
 @layer utilities {
+  .\@container\/card-header {
+    container-type: inline-size;
+    container-name: card-header;
+  }
   .\@container {
     container-type: inline-size;
   }
@@ -535,6 +640,16 @@
     clip-path: inset(50%);
     white-space: nowrap;
     border-width: 0;
+  }
+  .not-sr-only {
+    position: static;
+    width: auto;
+    height: auto;
+    padding: 0;
+    margin: 0;
+    overflow: visible;
+    clip-path: none;
+    white-space: normal;
   }
   .absolute {
     position: absolute;
@@ -668,6 +783,12 @@
   .left-full {
     left: 100%;
   }
+  .isolate {
+    isolation: isolate;
+  }
+  .isolation-auto {
+    isolation: auto;
+  }
   .z-10 {
     z-index: 10;
   }
@@ -686,11 +807,59 @@
   .z-99 {
     z-index: 99;
   }
+  .order-0 {
+    order: 0;
+  }
+  .order-none {
+    order: 0;
+  }
   .col-span-3 {
     grid-column: span 3 / span 3;
   }
   .col-span-5 {
     grid-column: span 5 / span 5;
+  }
+  .col-start-2 {
+    grid-column-start: 2;
+  }
+  .row-span-2 {
+    grid-row: span 2 / span 2;
+  }
+  .row-start-1 {
+    grid-row-start: 1;
+  }
+  .float-end {
+    float: inline-end;
+  }
+  .float-left {
+    float: left;
+  }
+  .float-none {
+    float: none;
+  }
+  .float-right {
+    float: right;
+  }
+  .float-start {
+    float: inline-start;
+  }
+  .clear-both {
+    clear: both;
+  }
+  .clear-end {
+    clear: inline-end;
+  }
+  .clear-left {
+    clear: left;
+  }
+  .clear-none {
+    clear: none;
+  }
+  .clear-right {
+    clear: right;
+  }
+  .clear-start {
+    clear: inline-start;
   }
   .container {
     width: 100%;
@@ -710,14 +879,26 @@
       max-width: 96rem;
     }
   }
+  .m-0 {
+    margin: calc(var(--spacing) * 0);
+  }
+  .-mx-1 {
+    margin-inline: calc(var(--spacing) * -1);
+  }
   .-mx-4 {
     margin-inline: calc(var(--spacing) * -4);
   }
   .mx-auto {
     margin-inline: auto;
   }
+  .my-1 {
+    margin-block: calc(var(--spacing) * 1);
+  }
   .my-2 {
     margin-block: calc(var(--spacing) * 2);
+  }
+  .my-4 {
+    margin-block: calc(var(--spacing) * 4);
   }
   .mt-0\.5 {
     margin-top: calc(var(--spacing) * 0.5);
@@ -794,6 +975,12 @@
   .ml-auto {
     margin-left: auto;
   }
+  .box-border {
+    box-sizing: border-box;
+  }
+  .box-content {
+    box-sizing: content-box;
+  }
   .block {
     display: block;
   }
@@ -802,6 +989,9 @@
   }
   .flex {
     display: flex;
+  }
+  .flow-root {
+    display: flow-root;
   }
   .grid {
     display: grid;
@@ -821,8 +1011,44 @@
   .inline-grid {
     display: inline-grid;
   }
+  .inline-table {
+    display: inline-table;
+  }
+  .list-item {
+    display: list-item;
+  }
   .table {
     display: table;
+  }
+  .table-caption {
+    display: table-caption;
+  }
+  .table-cell {
+    display: table-cell;
+  }
+  .table-column {
+    display: table-column;
+  }
+  .table-column-group {
+    display: table-column-group;
+  }
+  .table-footer-group {
+    display: table-footer-group;
+  }
+  .table-header-group {
+    display: table-header-group;
+  }
+  .table-row {
+    display: table-row;
+  }
+  .table-row-group {
+    display: table-row-group;
+  }
+  .field-sizing-content {
+    field-sizing: content;
+  }
+  .field-sizing-fixed {
+    field-sizing: fixed;
   }
   .size-1\.5 {
     width: calc(var(--spacing) * 1.5);
@@ -892,6 +1118,10 @@
     width: calc(var(--spacing) * 32);
     height: calc(var(--spacing) * 32);
   }
+  .size-auto {
+    width: auto;
+    height: auto;
+  }
   .h-0\.5 {
     height: calc(var(--spacing) * 0.5);
   }
@@ -928,6 +1158,12 @@
   .h-16 {
     height: calc(var(--spacing) * 16);
   }
+  .h-24 {
+    height: calc(var(--spacing) * 24);
+  }
+  .h-36 {
+    height: calc(var(--spacing) * 36);
+  }
   .h-44 {
     height: calc(var(--spacing) * 44);
   }
@@ -946,17 +1182,29 @@
   .h-\[calc\(100vh-4rem\)\] {
     height: calc(100vh - 4rem);
   }
+  .h-\[var\(--radix-select-trigger-height\)\] {
+    height: var(--radix-select-trigger-height);
+  }
   .h-auto {
     height: auto;
   }
   .h-full {
     height: 100%;
   }
+  .h-lh {
+    height: 1lh;
+  }
   .h-min {
     height: min-content;
   }
+  .h-px {
+    height: 1px;
+  }
   .h-screen {
     height: 100vh;
+  }
+  .max-h-\(--radix-select-content-available-height\) {
+    max-height: var(--radix-select-content-available-height);
   }
   .max-h-44 {
     max-height: calc(var(--spacing) * 44);
@@ -967,6 +1215,15 @@
   .max-h-80 {
     max-height: calc(var(--spacing) * 80);
   }
+  .max-h-lh {
+    max-height: 1lh;
+  }
+  .max-h-none {
+    max-height: none;
+  }
+  .max-h-screen {
+    max-height: 100vh;
+  }
   .max-h-svh {
     max-height: 100svh;
   }
@@ -976,11 +1233,23 @@
   .min-h-5 {
     min-height: calc(var(--spacing) * 5);
   }
+  .min-h-16 {
+    min-height: calc(var(--spacing) * 16);
+  }
   .min-h-\[1\.5rem\] {
     min-height: 1.5rem;
   }
   .min-h-\[50svh\] {
     min-height: 50svh;
+  }
+  .min-h-\[140px\] {
+    min-height: 140px;
+  }
+  .min-h-auto {
+    min-height: auto;
+  }
+  .min-h-lh {
+    min-height: 1lh;
   }
   .min-h-screen {
     min-height: 100vh;
@@ -1072,6 +1341,12 @@
   .w-\[78\%\] {
     width: 78%;
   }
+  .w-\[100px\] {
+    width: 100px;
+  }
+  .w-auto {
+    width: auto;
+  }
   .w-fit {
     width: fit-content;
   }
@@ -1083,6 +1358,9 @@
   }
   .w-min {
     width: min-content;
+  }
+  .w-screen {
+    width: 100vw;
   }
   .max-w-2xl {
     max-width: var(--container-2xl);
@@ -1126,6 +1404,9 @@
   .max-w-prose {
     max-width: 65ch;
   }
+  .max-w-screen {
+    max-width: 100vw;
+  }
   .max-w-sm {
     max-width: var(--container-sm);
   }
@@ -1156,14 +1437,41 @@
   .min-w-52 {
     min-width: calc(var(--spacing) * 52);
   }
+  .min-w-\[0px\] {
+    min-width: 0px;
+  }
+  .min-w-\[8rem\] {
+    min-width: 8rem;
+  }
   .min-w-\[200px\] {
     min-width: 200px;
+  }
+  .min-w-\[320px\] {
+    min-width: 320px;
+  }
+  .min-w-\[var\(--radix-select-trigger-width\)\] {
+    min-width: var(--radix-select-trigger-width);
+  }
+  .min-w-auto {
+    min-width: auto;
   }
   .min-w-full {
     min-width: 100%;
   }
+  .min-w-screen {
+    min-width: 100vw;
+  }
   .flex-1 {
     flex: 1;
+  }
+  .flex-auto {
+    flex: auto;
+  }
+  .flex-initial {
+    flex: 0 auto;
+  }
+  .flex-none {
+    flex: none;
   }
   .flex-shrink {
     flex-shrink: 1;
@@ -1174,8 +1482,29 @@
   .shrink-0 {
     flex-shrink: 0;
   }
+  .flex-grow {
+    flex-grow: 1;
+  }
   .grow {
     flex-grow: 1;
+  }
+  .basis-auto {
+    flex-basis: auto;
+  }
+  .basis-full {
+    flex-basis: 100%;
+  }
+  .table-auto {
+    table-layout: auto;
+  }
+  .table-fixed {
+    table-layout: fixed;
+  }
+  .caption-bottom {
+    caption-side: bottom;
+  }
+  .caption-top {
+    caption-side: top;
   }
   .border-collapse {
     border-collapse: collapse;
@@ -1187,6 +1516,19 @@
     --tw-border-spacing-x: calc(var(--spacing) * 0);
     --tw-border-spacing-y: calc(var(--spacing) * 0);
     border-spacing: var(--tw-border-spacing-x) var(--tw-border-spacing-y);
+  }
+  .origin-\(--radix-select-content-transform-origin\) {
+    transform-origin: var(--radix-select-content-transform-origin);
+  }
+  .-translate-full {
+    --tw-translate-x: -100%;
+    --tw-translate-y: -100%;
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .translate-full {
+    --tw-translate-x: 100%;
+    --tw-translate-y: 100%;
+    translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .-translate-x-1\/2 {
     --tw-translate-x: calc(calc(1 / 2 * 100%) * -1);
@@ -1236,6 +1578,12 @@
     --tw-translate-y: calc(var(--spacing) * 8);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
+  .translate-3d {
+    translate: var(--tw-translate-x) var(--tw-translate-y) var(--tw-translate-z);
+  }
+  .translate-none {
+    translate: none;
+  }
   .scale-0 {
     --tw-scale-x: 0%;
     --tw-scale-y: 0%;
@@ -1260,14 +1608,44 @@
     --tw-scale-z: 100%;
     scale: var(--tw-scale-x) var(--tw-scale-y);
   }
+  .scale-120 {
+    --tw-scale-x: 120%;
+    --tw-scale-y: 120%;
+    --tw-scale-z: 120%;
+    scale: var(--tw-scale-x) var(--tw-scale-y);
+  }
+  .scale-3d {
+    scale: var(--tw-scale-x) var(--tw-scale-y) var(--tw-scale-z);
+  }
+  .scale-none {
+    scale: none;
+  }
   .rotate-0 {
     rotate: 0deg;
   }
   .rotate-180 {
     rotate: 180deg;
   }
+  .rotate-none {
+    rotate: none;
+  }
   .transform {
     transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
+  }
+  .transform-cpu {
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
+  }
+  .transform-gpu {
+    transform: translateZ(0) var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
+  }
+  .transform-none {
+    transform: none;
+  }
+  .\[animation\:spin_20s_linear_infinite\] {
+    animation: spin 20s linear infinite;
+  }
+  .animate-\[spin_20s_linear_infinite\] {
+    animation: spin 20s linear infinite;
   }
   .animate-bounce {
     animation: var(--animate-bounce);
@@ -1278,11 +1656,18 @@
   .animate-spin {
     animation: var(--animate-spin);
   }
+  .cursor-default {
+    cursor: default;
+  }
   .cursor-not-allowed {
     cursor: not-allowed;
   }
   .cursor-pointer {
     cursor: pointer;
+  }
+  .touch-pinch-zoom {
+    --tw-pinch-zoom: pinch-zoom;
+    touch-action: var(--tw-pan-x,) var(--tw-pan-y,) var(--tw-pinch-zoom,);
   }
   .resize {
     resize: both;
@@ -1290,11 +1675,68 @@
   .resize-none {
     resize: none;
   }
+  .resize-x {
+    resize: horizontal;
+  }
+  .resize-y {
+    resize: vertical;
+  }
+  .snap-none {
+    scroll-snap-type: none;
+  }
+  .snap-mandatory {
+    --tw-scroll-snap-strictness: mandatory;
+  }
+  .snap-proximity {
+    --tw-scroll-snap-strictness: proximity;
+  }
+  .snap-align-none {
+    scroll-snap-align: none;
+  }
+  .snap-center {
+    scroll-snap-align: center;
+  }
+  .snap-end {
+    scroll-snap-align: end;
+  }
+  .snap-start {
+    scroll-snap-align: start;
+  }
+  .snap-always {
+    scroll-snap-stop: always;
+  }
+  .snap-normal {
+    scroll-snap-stop: normal;
+  }
+  .scroll-my-1 {
+    scroll-margin-block: calc(var(--spacing) * 1);
+  }
   .scroll-mt-8 {
     scroll-margin-top: calc(var(--spacing) * 8);
   }
+  .scrollbar-auto {
+    scrollbar-width: auto;
+  }
+  .scrollbar-none {
+    scrollbar-width: none;
+  }
+  .scrollbar-thin {
+    scrollbar-width: thin;
+  }
+  .scrollbar-gutter-auto {
+    scrollbar-gutter: auto;
+  }
+  .scrollbar-gutter-both {
+    scrollbar-gutter: stable both-edges;
+  }
+  .scrollbar-gutter-stable {
+    scrollbar-gutter: stable;
+  }
   .list-inside {
     list-style-position: inside;
+  }
+  .list-outside {
+    list-style-position: outside;
   }
   .list-disc {
     list-style-type: disc;
@@ -1302,8 +1744,29 @@
   .list-none {
     list-style-type: none;
   }
+  .appearance-auto {
+    appearance: auto;
+  }
   .appearance-none {
     appearance: none;
+  }
+  .grid-flow-col {
+    grid-auto-flow: column;
+  }
+  .grid-flow-col-dense {
+    grid-auto-flow: column dense;
+  }
+  .grid-flow-dense {
+    grid-auto-flow: dense;
+  }
+  .grid-flow-row {
+    grid-auto-flow: row;
+  }
+  .grid-flow-row-dense {
+    grid-auto-flow: row dense;
+  }
+  .auto-rows-min {
+    grid-auto-rows: min-content;
   }
   .grid-cols-1 {
     grid-template-columns: repeat(1, minmax(0, 1fr));
@@ -1311,32 +1774,143 @@
   .grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+  .grid-rows-\[auto_auto\] {
+    grid-template-rows: auto auto;
+  }
   .flex-col {
     flex-direction: column;
   }
   .flex-col-reverse {
     flex-direction: column-reverse;
   }
+  .flex-row {
+    flex-direction: row;
+  }
+  .flex-row-reverse {
+    flex-direction: row-reverse;
+  }
+  .flex-nowrap {
+    flex-wrap: nowrap;
+  }
   .flex-wrap {
     flex-wrap: wrap;
+  }
+  .flex-wrap-reverse {
+    flex-wrap: wrap-reverse;
+  }
+  .place-content-around {
+    place-content: space-around;
+  }
+  .place-content-baseline {
+    place-content: baseline;
+  }
+  .place-content-between {
+    place-content: space-between;
+  }
+  .place-content-center {
+    place-content: center;
+  }
+  .place-content-center-safe {
+    place-content: safe center;
+  }
+  .place-content-end {
+    place-content: end;
+  }
+  .place-content-end-safe {
+    place-content: safe end;
   }
   .place-content-evenly {
     place-content: space-evenly;
   }
+  .place-content-start {
+    place-content: start;
+  }
+  .place-content-stretch {
+    place-content: stretch;
+  }
+  .place-items-baseline {
+    place-items: baseline;
+  }
   .place-items-center {
     place-items: center;
+  }
+  .place-items-center-safe {
+    place-items: safe center;
+  }
+  .place-items-end {
+    place-items: end;
+  }
+  .place-items-end-safe {
+    place-items: safe end;
+  }
+  .place-items-start {
+    place-items: start;
+  }
+  .place-items-stretch {
+    place-items: stretch;
+  }
+  .content-around {
+    align-content: space-around;
+  }
+  .content-baseline {
+    align-content: baseline;
+  }
+  .content-between {
+    align-content: space-between;
+  }
+  .content-center {
+    align-content: center;
+  }
+  .content-center-safe {
+    align-content: safe center;
+  }
+  .content-end {
+    align-content: flex-end;
+  }
+  .content-end-safe {
+    align-content: safe flex-end;
+  }
+  .content-evenly {
+    align-content: space-evenly;
+  }
+  .content-normal {
+    align-content: normal;
+  }
+  .content-start {
+    align-content: flex-start;
+  }
+  .content-stretch {
+    align-content: stretch;
   }
   .items-baseline {
     align-items: baseline;
   }
+  .items-baseline-last {
+    align-items: last baseline;
+  }
   .items-center {
     align-items: center;
+  }
+  .items-center-safe {
+    align-items: safe center;
   }
   .items-end {
     align-items: flex-end;
   }
+  .items-end-safe {
+    align-items: safe flex-end;
+  }
   .items-start {
     align-items: flex-start;
+  }
+  .items-stretch {
+    align-items: stretch;
+  }
+  .justify-around {
+    justify-content: space-around;
+  }
+  .justify-baseline {
+    justify-content: baseline;
   }
   .justify-between {
     justify-content: space-between;
@@ -1344,8 +1918,47 @@
   .justify-center {
     justify-content: center;
   }
+  .justify-center-safe {
+    justify-content: safe center;
+  }
   .justify-end {
     justify-content: flex-end;
+  }
+  .justify-end-safe {
+    justify-content: safe flex-end;
+  }
+  .justify-evenly {
+    justify-content: space-evenly;
+  }
+  .justify-normal {
+    justify-content: normal;
+  }
+  .justify-start {
+    justify-content: flex-start;
+  }
+  .justify-stretch {
+    justify-content: stretch;
+  }
+  .justify-items-center {
+    justify-items: center;
+  }
+  .justify-items-center-safe {
+    justify-items: safe center;
+  }
+  .justify-items-end {
+    justify-items: end;
+  }
+  .justify-items-end-safe {
+    justify-items: safe end;
+  }
+  .justify-items-normal {
+    justify-items: normal;
+  }
+  .justify-items-start {
+    justify-items: start;
+  }
+  .justify-items-stretch {
+    justify-items: stretch;
   }
   .gap-0\.5 {
     gap: calc(var(--spacing) * 0.5);
@@ -1460,6 +2073,11 @@
       margin-block-end: calc(calc(var(--spacing) * 16) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
+  .space-y-reverse {
+    :where(& > :not(:last-child)) {
+      --tw-space-y-reverse: 1;
+    }
+  }
   .gap-x-2 {
     column-gap: calc(var(--spacing) * 2);
   }
@@ -1468,6 +2086,11 @@
   }
   .gap-x-6 {
     column-gap: calc(var(--spacing) * 6);
+  }
+  .space-x-reverse {
+    :where(& > :not(:last-child)) {
+      --tw-space-x-reverse: 1;
+    }
   }
   .gap-y-1 {
     row-gap: calc(var(--spacing) * 1);
@@ -1495,13 +2118,84 @@
       border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
     }
   }
+  .divide-y-reverse {
+    :where(& > :not(:last-child)) {
+      --tw-divide-y-reverse: 1;
+    }
+  }
   .divide-outline {
     :where(& > :not(:last-child)) {
       border-color: var(--color-outline);
     }
   }
+  .place-self-auto {
+    place-self: auto;
+  }
+  .place-self-center {
+    place-self: center;
+  }
+  .place-self-center-safe {
+    place-self: safe center;
+  }
+  .place-self-end {
+    place-self: end;
+  }
+  .place-self-end-safe {
+    place-self: safe end;
+  }
+  .place-self-start {
+    place-self: start;
+  }
+  .place-self-stretch {
+    place-self: stretch;
+  }
+  .self-auto {
+    align-self: auto;
+  }
+  .self-baseline {
+    align-self: baseline;
+  }
+  .self-baseline-last {
+    align-self: last baseline;
+  }
+  .self-center {
+    align-self: center;
+  }
+  .self-center-safe {
+    align-self: safe center;
+  }
+  .self-end {
+    align-self: flex-end;
+  }
+  .self-end-safe {
+    align-self: safe flex-end;
+  }
   .self-start {
     align-self: flex-start;
+  }
+  .self-stretch {
+    align-self: stretch;
+  }
+  .justify-self-auto {
+    justify-self: auto;
+  }
+  .justify-self-center {
+    justify-self: center;
+  }
+  .justify-self-center-safe {
+    justify-self: safe center;
+  }
+  .justify-self-end {
+    justify-self: flex-end;
+  }
+  .justify-self-end-safe {
+    justify-self: safe flex-end;
+  }
+  .justify-self-start {
+    justify-self: flex-start;
+  }
+  .justify-self-stretch {
+    justify-self: stretch;
   }
   .truncate {
     overflow: hidden;
@@ -1526,6 +2220,12 @@
   .overflow-y-clip {
     overflow-y: clip;
   }
+  .scroll-auto {
+    scroll-behavior: auto;
+  }
+  .scroll-smooth {
+    scroll-behavior: smooth;
+  }
   .rounded {
     border-radius: 0.25rem;
   }
@@ -1547,21 +2247,100 @@
   .rounded-sm {
     border-radius: var(--radius-sm);
   }
+  .rounded-xl {
+    border-radius: var(--radius-xl);
+  }
+  .rounded-s {
+    border-start-start-radius: 0.25rem;
+    border-end-start-radius: 0.25rem;
+  }
+  .rounded-ss {
+    border-start-start-radius: 0.25rem;
+  }
+  .rounded-e {
+    border-start-end-radius: 0.25rem;
+    border-end-end-radius: 0.25rem;
+  }
+  .rounded-se {
+    border-start-end-radius: 0.25rem;
+  }
+  .rounded-ee {
+    border-end-end-radius: 0.25rem;
+  }
+  .rounded-es {
+    border-end-start-radius: 0.25rem;
+  }
+  .rounded-t {
+    border-top-left-radius: 0.25rem;
+    border-top-right-radius: 0.25rem;
+  }
   .rounded-t-radius {
     border-top-left-radius: var(--radius-radius);
     border-top-right-radius: var(--radius-radius);
+  }
+  .rounded-l {
+    border-top-left-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
+  }
+  .rounded-tl {
+    border-top-left-radius: 0.25rem;
+  }
+  .rounded-r {
+    border-top-right-radius: 0.25rem;
+    border-bottom-right-radius: 0.25rem;
+  }
+  .rounded-tr {
+    border-top-right-radius: 0.25rem;
+  }
+  .rounded-b {
+    border-bottom-right-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
   }
   .rounded-b-radius {
     border-bottom-right-radius: var(--radius-radius);
     border-bottom-left-radius: var(--radius-radius);
   }
+  .rounded-br {
+    border-bottom-right-radius: 0.25rem;
+  }
+  .rounded-bl {
+    border-bottom-left-radius: 0.25rem;
+  }
   .border {
     border-style: var(--tw-border-style);
     border-width: 1px;
   }
+  .border-0 {
+    border-style: var(--tw-border-style);
+    border-width: 0px;
+  }
   .border-2 {
     border-style: var(--tw-border-style);
     border-width: 2px;
+  }
+  .border-x {
+    border-inline-style: var(--tw-border-style);
+    border-inline-width: 1px;
+  }
+  .border-y {
+    border-block-style: var(--tw-border-style);
+    border-block-width: 1px;
+  }
+  .border-s {
+    border-inline-start-style: var(--tw-border-style);
+    border-inline-start-width: 1px;
+  }
+  .border-e {
+    border-inline-end-style: var(--tw-border-style);
+    border-inline-end-width: 1px;
+  }
+  .border-bs {
+    border-block-start-style: var(--tw-border-style);
+    border-block-start-width: 1px;
+  }
+  .border-be {
+    border-block-end-style: var(--tw-border-style);
+    border-block-end-width: 1px;
   }
   .border-t {
     border-top-style: var(--tw-border-style);
@@ -1591,9 +2370,28 @@
     --tw-border-style: dashed;
     border-style: dashed;
   }
+  .border-dotted {
+    --tw-border-style: dotted;
+    border-style: dotted;
+  }
+  .border-double {
+    --tw-border-style: double;
+    border-style: double;
+  }
+  .border-hidden {
+    --tw-border-style: hidden;
+    border-style: hidden;
+  }
   .border-none {
     --tw-border-style: none;
     border-style: none;
+  }
+  .border-solid {
+    --tw-border-style: solid;
+    border-style: solid;
+  }
+  .border-\[\#fbf0df\] {
+    border-color: #fbf0df;
   }
   .border-danger {
     border-color: var(--color-danger);
@@ -1652,8 +2450,17 @@
   .border-warning {
     border-color: var(--color-warning);
   }
+  .bg-\[\#1a1a1a\] {
+    background-color: #1a1a1a;
+  }
+  .bg-\[\#242424\] {
+    background-color: #242424;
+  }
   .bg-\[\#f5f0e6\] {
     background-color: #f5f0e6;
+  }
+  .bg-\[\#fbf0df\] {
+    background-color: #fbf0df;
   }
   .bg-\[rgb\(245_240_230\)\] {
     background-color: rgb(245 240 230);
@@ -2652,6 +3459,24 @@
     }
     background-image: linear-gradient(var(--tw-gradient-stops));
   }
+  .-bg-conic {
+    --tw-gradient-position: in oklab;
+    background-image: conic-gradient(var(--tw-gradient-stops));
+  }
+  .bg-conic {
+    --tw-gradient-position: in oklab;
+    background-image: conic-gradient(var(--tw-gradient-stops));
+  }
+  .bg-radial {
+    --tw-gradient-position: in oklab;
+    background-image: radial-gradient(var(--tw-gradient-stops));
+  }
+  .bg-none {
+    background-image: none;
+  }
+  .via-none {
+    --tw-gradient-via-stops: initial;
+  }
   .from-surface-dark\/85 {
     --tw-gradient-from: color-mix(in srgb, oklch(26.9% 0 0) 85%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -2663,14 +3488,294 @@
     --tw-gradient-to: transparent;
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
+  .mask-none {
+    mask-image: none;
+  }
+  .mask-circle {
+    --tw-mask-radial-shape: circle;
+  }
+  .mask-ellipse {
+    --tw-mask-radial-shape: ellipse;
+  }
+  .mask-radial-closest-corner {
+    --tw-mask-radial-size: closest-corner;
+  }
+  .mask-radial-closest-side {
+    --tw-mask-radial-size: closest-side;
+  }
+  .mask-radial-farthest-corner {
+    --tw-mask-radial-size: farthest-corner;
+  }
+  .mask-radial-farthest-side {
+    --tw-mask-radial-size: farthest-side;
+  }
+  .mask-radial-at-bottom {
+    --tw-mask-radial-position: bottom;
+  }
+  .mask-radial-at-bottom-left {
+    --tw-mask-radial-position: bottom left;
+  }
+  .mask-radial-at-bottom-right {
+    --tw-mask-radial-position: bottom right;
+  }
+  .mask-radial-at-center {
+    --tw-mask-radial-position: center;
+  }
+  .mask-radial-at-left {
+    --tw-mask-radial-position: left;
+  }
+  .mask-radial-at-right {
+    --tw-mask-radial-position: right;
+  }
+  .mask-radial-at-top {
+    --tw-mask-radial-position: top;
+  }
+  .mask-radial-at-top-left {
+    --tw-mask-radial-position: top left;
+  }
+  .mask-radial-at-top-right {
+    --tw-mask-radial-position: top right;
+  }
+  .box-decoration-clone {
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+  }
+  .box-decoration-slice {
+    -webkit-box-decoration-break: slice;
+    box-decoration-break: slice;
+  }
+  .decoration-clone {
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+  }
+  .decoration-slice {
+    -webkit-box-decoration-break: slice;
+    box-decoration-break: slice;
+  }
+  .bg-auto {
+    background-size: auto;
+  }
+  .bg-contain {
+    background-size: contain;
+  }
+  .bg-cover {
+    background-size: cover;
+  }
+  .bg-fixed {
+    background-attachment: fixed;
+  }
+  .bg-local {
+    background-attachment: local;
+  }
+  .bg-scroll {
+    background-attachment: scroll;
+  }
+  .bg-clip-border {
+    background-clip: border-box;
+  }
+  .bg-clip-content {
+    background-clip: content-box;
+  }
+  .bg-clip-padding {
+    background-clip: padding-box;
+  }
   .bg-clip-text {
     background-clip: text;
+  }
+  .bg-bottom {
+    background-position: bottom;
+  }
+  .bg-bottom-left {
+    background-position: left bottom;
+  }
+  .bg-bottom-right {
+    background-position: right bottom;
+  }
+  .bg-center {
+    background-position: center;
+  }
+  .bg-left {
+    background-position: left;
+  }
+  .bg-left-bottom {
+    background-position: left bottom;
+  }
+  .bg-left-top {
+    background-position: left top;
+  }
+  .bg-right {
+    background-position: right;
+  }
+  .bg-right-bottom {
+    background-position: right bottom;
+  }
+  .bg-right-top {
+    background-position: right top;
+  }
+  .bg-top {
+    background-position: top;
+  }
+  .bg-top-left {
+    background-position: left top;
+  }
+  .bg-top-right {
+    background-position: right top;
+  }
+  .bg-no-repeat {
+    background-repeat: no-repeat;
+  }
+  .bg-repeat {
+    background-repeat: repeat;
+  }
+  .bg-repeat-round {
+    background-repeat: round;
+  }
+  .bg-repeat-space {
+    background-repeat: space;
+  }
+  .bg-repeat-x {
+    background-repeat: repeat-x;
+  }
+  .bg-repeat-y {
+    background-repeat: repeat-y;
+  }
+  .bg-origin-border {
+    background-origin: border-box;
+  }
+  .bg-origin-content {
+    background-origin: content-box;
+  }
+  .bg-origin-padding {
+    background-origin: padding-box;
+  }
+  .mask-add {
+    mask-composite: add;
+  }
+  .mask-exclude {
+    mask-composite: exclude;
+  }
+  .mask-intersect {
+    mask-composite: intersect;
+  }
+  .mask-subtract {
+    mask-composite: subtract;
+  }
+  .mask-alpha {
+    mask-mode: alpha;
+  }
+  .mask-luminance {
+    mask-mode: luminance;
+  }
+  .mask-match {
+    mask-mode: match-source;
+  }
+  .mask-type-alpha {
+    mask-type: alpha;
+  }
+  .mask-type-luminance {
+    mask-type: luminance;
+  }
+  .mask-auto {
+    mask-size: auto;
+  }
+  .mask-contain {
+    mask-size: contain;
+  }
+  .mask-cover {
+    mask-size: cover;
+  }
+  .mask-clip-border {
+    mask-clip: border-box;
+  }
+  .mask-clip-content {
+    mask-clip: content-box;
+  }
+  .mask-clip-fill {
+    mask-clip: fill-box;
+  }
+  .mask-clip-padding {
+    mask-clip: padding-box;
+  }
+  .mask-clip-stroke {
+    mask-clip: stroke-box;
+  }
+  .mask-clip-view {
+    mask-clip: view-box;
+  }
+  .mask-no-clip {
+    mask-clip: no-clip;
+  }
+  .mask-bottom {
+    mask-position: bottom;
+  }
+  .mask-bottom-left {
+    mask-position: left bottom;
+  }
+  .mask-bottom-right {
+    mask-position: right bottom;
+  }
+  .mask-center {
+    mask-position: center;
+  }
+  .mask-left {
+    mask-position: left;
+  }
+  .mask-right {
+    mask-position: right;
+  }
+  .mask-top {
+    mask-position: top;
+  }
+  .mask-top-left {
+    mask-position: left top;
+  }
+  .mask-top-right {
+    mask-position: right top;
+  }
+  .mask-no-repeat {
+    mask-repeat: no-repeat;
+  }
+  .mask-repeat {
+    mask-repeat: repeat;
+  }
+  .mask-repeat-round {
+    mask-repeat: round;
+  }
+  .mask-repeat-space {
+    mask-repeat: space;
+  }
+  .mask-repeat-x {
+    mask-repeat: repeat-x;
+  }
+  .mask-repeat-y {
+    mask-repeat: repeat-y;
+  }
+  .mask-origin-border {
+    mask-origin: border-box;
+  }
+  .mask-origin-content {
+    mask-origin: content-box;
+  }
+  .mask-origin-fill {
+    mask-origin: fill-box;
+  }
+  .mask-origin-padding {
+    mask-origin: padding-box;
+  }
+  .mask-origin-stroke {
+    mask-origin: stroke-box;
+  }
+  .mask-origin-view {
+    mask-origin: view-box;
   }
   .fill-danger {
     fill: var(--color-danger);
   }
   .fill-info {
     fill: var(--color-info);
+  }
+  .fill-none {
+    fill: none;
   }
   .fill-on-surface {
     fill: var(--color-on-surface);
@@ -2687,11 +3792,38 @@
   .fill-warning {
     fill: var(--color-warning);
   }
+  .stroke-none {
+    stroke: none;
+  }
+  .object-contain {
+    object-fit: contain;
+  }
   .object-cover {
     object-fit: cover;
   }
+  .object-fill {
+    object-fit: fill;
+  }
+  .object-none {
+    object-fit: none;
+  }
+  .object-scale-down {
+    object-fit: scale-down;
+  }
   .object-center {
     object-position: center;
+  }
+  .object-left-bottom {
+    object-position: left bottom;
+  }
+  .object-left-top {
+    object-position: left top;
+  }
+  .object-right-bottom {
+    object-position: right bottom;
+  }
+  .object-right-top {
+    object-position: right top;
   }
   .p-0\.5 {
     padding: calc(var(--spacing) * 0.5);
@@ -2741,6 +3873,9 @@
   .px-4 {
     padding-inline: calc(var(--spacing) * 4);
   }
+  .px-5 {
+    padding-inline: calc(var(--spacing) * 5);
+  }
   .px-6 {
     padding-inline: calc(var(--spacing) * 6);
   }
@@ -2749,6 +3884,9 @@
   }
   .px-16 {
     padding-inline: calc(var(--spacing) * 16);
+  }
+  .px-\[0\.3rem\] {
+    padding-inline: 0.3rem;
   }
   .py-0\.5 {
     padding-block: calc(var(--spacing) * 0.5);
@@ -2782,6 +3920,9 @@
   }
   .py-16 {
     padding-block: calc(var(--spacing) * 16);
+  }
+  .py-\[0\.2rem\] {
+    padding-block: 0.2rem;
   }
   .pt-1 {
     padding-top: calc(var(--spacing) * 1);
@@ -2867,14 +4008,44 @@
   .text-center {
     text-align: center;
   }
+  .text-end {
+    text-align: end;
+  }
+  .text-justify {
+    text-align: justify;
+  }
   .text-left {
     text-align: left;
   }
   .text-right {
     text-align: right;
   }
+  .text-start {
+    text-align: start;
+  }
+  .align-baseline {
+    vertical-align: baseline;
+  }
   .align-bottom {
     vertical-align: bottom;
+  }
+  .align-middle {
+    vertical-align: middle;
+  }
+  .align-sub {
+    vertical-align: sub;
+  }
+  .align-super {
+    vertical-align: super;
+  }
+  .align-text-bottom {
+    vertical-align: text-bottom;
+  }
+  .align-text-top {
+    vertical-align: text-top;
+  }
+  .align-top {
+    vertical-align: top;
   }
   .font-mono {
     font-family: var(--font-mono);
@@ -2944,9 +4115,17 @@
     --tw-leading: calc(var(--spacing) * 4);
     line-height: calc(var(--spacing) * 4);
   }
+  .leading-none {
+    --tw-leading: 1;
+    line-height: 1;
+  }
   .leading-relaxed {
     --tw-leading: var(--leading-relaxed);
     line-height: var(--leading-relaxed);
+  }
+  .leading-tight {
+    --tw-leading: var(--leading-tight);
+    line-height: var(--leading-tight);
   }
   .font-bold {
     --tw-font-weight: var(--font-weight-bold);
@@ -2979,14 +4158,84 @@
   .text-balance {
     text-wrap: balance;
   }
+  .text-nowrap {
+    text-wrap: nowrap;
+  }
   .text-pretty {
     text-wrap: pretty;
   }
   .text-wrap {
     text-wrap: wrap;
   }
+  .break-normal {
+    overflow-wrap: normal;
+    word-break: normal;
+  }
+  .break-words {
+    overflow-wrap: break-word;
+  }
+  .wrap-anywhere {
+    overflow-wrap: anywhere;
+  }
+  .wrap-break-word {
+    overflow-wrap: break-word;
+  }
+  .wrap-normal {
+    overflow-wrap: normal;
+  }
+  .break-all {
+    word-break: break-all;
+  }
+  .break-keep {
+    word-break: keep-all;
+  }
+  .overflow-ellipsis {
+    text-overflow: ellipsis;
+  }
+  .text-clip {
+    text-overflow: clip;
+  }
+  .text-ellipsis {
+    text-overflow: ellipsis;
+  }
+  .hyphens-auto {
+    -webkit-hyphens: auto;
+    hyphens: auto;
+  }
+  .hyphens-manual {
+    -webkit-hyphens: manual;
+    hyphens: manual;
+  }
+  .hyphens-none {
+    -webkit-hyphens: none;
+    hyphens: none;
+  }
+  .whitespace-break-spaces {
+    white-space: break-spaces;
+  }
+  .whitespace-normal {
+    white-space: normal;
+  }
   .whitespace-nowrap {
     white-space: nowrap;
+  }
+  .whitespace-pre {
+    white-space: pre;
+  }
+  .whitespace-pre-line {
+    white-space: pre-line;
+  }
+  .whitespace-pre-wrap {
+    white-space: pre-wrap;
+  }
+  .text-\[\#1a1a1a\] {
+    color: #1a1a1a;
+  }
+  .text-\[\#fbf0df\] {
+    color: #fbf0df;
+  }
+  .text-\[rgba\(255\,255\,255\,0\.87\)\] {
+    color: rgba(255,255,255,0.87);
   }
   .text-amber-500 {
     color: var(--color-amber-500);
@@ -3144,21 +4393,152 @@
   .lowercase {
     text-transform: lowercase;
   }
+  .normal-case {
+    text-transform: none;
+  }
   .uppercase {
     text-transform: uppercase;
   }
   .italic {
     font-style: italic;
   }
+  .not-italic {
+    font-style: normal;
+  }
+  .font-stretch-condensed {
+    font-stretch: condensed;
+  }
+  .font-stretch-expanded {
+    font-stretch: expanded;
+  }
+  .font-stretch-extra-condensed {
+    font-stretch: extra-condensed;
+  }
+  .font-stretch-extra-expanded {
+    font-stretch: extra-expanded;
+  }
+  .font-stretch-normal {
+    font-stretch: normal;
+  }
+  .font-stretch-semi-condensed {
+    font-stretch: semi-condensed;
+  }
+  .font-stretch-semi-expanded {
+    font-stretch: semi-expanded;
+  }
+  .font-stretch-ultra-condensed {
+    font-stretch: ultra-condensed;
+  }
+  .font-stretch-ultra-expanded {
+    font-stretch: ultra-expanded;
+  }
+  .diagonal-fractions {
+    --tw-numeric-fraction: diagonal-fractions;
+    font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
+  }
+  .lining-nums {
+    --tw-numeric-figure: lining-nums;
+    font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
+  }
+  .oldstyle-nums {
+    --tw-numeric-figure: oldstyle-nums;
+    font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
+  }
+  .ordinal {
+    --tw-ordinal: ordinal;
+    font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
+  }
+  .proportional-nums {
+    --tw-numeric-spacing: proportional-nums;
+    font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
+  }
+  .slashed-zero {
+    --tw-slashed-zero: slashed-zero;
+    font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
+  }
+  .stacked-fractions {
+    --tw-numeric-fraction: stacked-fractions;
+    font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
+  }
   .tabular-nums {
     --tw-numeric-spacing: tabular-nums;
     font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
   }
+  .normal-nums {
+    font-variant-numeric: normal;
+  }
+  .line-through {
+    text-decoration-line: line-through;
+  }
+  .no-underline {
+    text-decoration-line: none;
+  }
+  .overline {
+    text-decoration-line: overline;
+  }
   .underline {
     text-decoration-line: underline;
   }
+  .decoration-dashed {
+    text-decoration-style: dashed;
+  }
+  .decoration-dotted {
+    text-decoration-style: dotted;
+  }
+  .decoration-double {
+    text-decoration-style: double;
+  }
+  .decoration-solid {
+    text-decoration-style: solid;
+  }
+  .decoration-wavy {
+    text-decoration-style: wavy;
+  }
+  .decoration-auto {
+    text-decoration-thickness: auto;
+  }
+  .decoration-from-font {
+    text-decoration-thickness: from-font;
+  }
   .underline-offset-2 {
     text-underline-offset: 2px;
+  }
+  .underline-offset-4 {
+    text-underline-offset: 4px;
+  }
+  .antialiased {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+  .subpixel-antialiased {
+    -webkit-font-smoothing: auto;
+    -moz-osx-font-smoothing: auto;
+  }
+  .placeholder-\[\#fbf0df\]\/40 {
+    &::placeholder {
+      color: color-mix(in oklab, #fbf0df 40%, transparent);
+    }
+  }
+  .accent-auto {
+    accent-color: auto;
+  }
+  .scheme-dark {
+    color-scheme: dark;
+  }
+  .scheme-light {
+    color-scheme: light;
+  }
+  .scheme-light-dark {
+    color-scheme: light dark;
+  }
+  .scheme-normal {
+    color-scheme: normal;
+  }
+  .scheme-only-dark {
+    color-scheme: only dark;
+  }
+  .scheme-only-light {
+    color-scheme: only light;
   }
   .opacity-0 {
     opacity: 0%;
@@ -3184,6 +4564,12 @@
   .opacity-100 {
     opacity: 100%;
   }
+  .mix-blend-plus-darker {
+    mix-blend-mode: plus-darker;
+  }
+  .mix-blend-plus-lighter {
+    mix-blend-mode: plus-lighter;
+  }
   .shadow {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -3196,8 +4582,16 @@
     --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 2px 4px -2px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
+  .shadow-sm {
+    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
   .shadow-xl {
     --tw-shadow: 0 20px 25px -5px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 8px 10px -6px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-xs {
+    --tw-shadow: 0 1px 2px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.05));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
   .shadow\/elevation {
@@ -3220,11 +4614,29 @@
     --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
+  .inset-ring {
+    --tw-inset-ring-shadow: inset 0 0 0 1px var(--tw-inset-ring-color, currentcolor);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-initial {
+    --tw-shadow-color: initial;
+  }
   .ring-primary {
     --tw-ring-color: var(--color-primary);
   }
   .ring-surface-alt {
     --tw-ring-color: var(--color-surface-alt);
+  }
+  .inset-shadow-initial {
+    --tw-inset-shadow-color: initial;
+  }
+  .outline-hidden {
+    --tw-outline-style: none;
+    outline-style: none;
+    @media (forced-colors: active) {
+      outline: 2px solid transparent;
+      outline-offset: 2px;
+    }
   }
   .outline {
     outline-style: var(--tw-outline-style);
@@ -3244,12 +4656,25 @@
     --tw-blur: blur(8px);
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
+  .drop-shadow {
+    --tw-drop-shadow-size: drop-shadow(0 1px 2px var(--tw-drop-shadow-color, rgb(0 0 0 / 0.1))) drop-shadow(0 1px 1px var(--tw-drop-shadow-color, rgb(0 0 0 / 0.06)));
+    --tw-drop-shadow: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow( 0 1px 1px rgb(0 0 0 / 0.06));
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .drop-shadow-none {
+    --tw-drop-shadow:  ;
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
   .grayscale {
     --tw-grayscale: grayscale(100%);
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
   .invert {
     --tw-invert: invert(100%);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+  }
+  .sepia {
+    --tw-sepia: sepia(100%);
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
   .filter {
@@ -3265,12 +4690,32 @@
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
+  .backdrop-grayscale {
+    --tw-backdrop-grayscale: grayscale(100%);
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .backdrop-invert {
+    --tw-backdrop-invert: invert(100%);
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .backdrop-sepia {
+    --tw-backdrop-sepia: sepia(100%);
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
   .backdrop-filter {
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
   .transition {
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, content-visibility, overlay, pointer-events;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-\[color\,box-shadow\] {
+    transition-property: color,box-shadow;
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
   }
@@ -3294,11 +4739,21 @@
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
   }
+  .transition-discrete {
+    transition-behavior: allow-discrete;
+  }
+  .transition-normal {
+    transition-behavior: normal;
+  }
   .delay-100 {
     transition-delay: 100ms;
   }
   .delay-200 {
     transition-delay: 200ms;
+  }
+  .duration-100 {
+    --tw-duration: 100ms;
+    transition-duration: 100ms;
   }
   .duration-150 {
     --tw-duration: 150ms;
@@ -3332,6 +4787,77 @@
     --tw-ease: var(--ease-out);
     transition-timing-function: var(--ease-out);
   }
+  .will-change-auto {
+    will-change: auto;
+  }
+  .will-change-contents {
+    will-change: contents;
+  }
+  .will-change-scroll {
+    will-change: scroll-position;
+  }
+  .will-change-transform {
+    will-change: transform;
+  }
+  .contain-inline-size {
+    --tw-contain-size: inline-size;
+    contain: var(--tw-contain-size,) var(--tw-contain-layout,) var(--tw-contain-paint,) var(--tw-contain-style,);
+  }
+  .contain-layout {
+    --tw-contain-layout: layout;
+    contain: var(--tw-contain-size,) var(--tw-contain-layout,) var(--tw-contain-paint,) var(--tw-contain-style,);
+  }
+  .contain-paint {
+    --tw-contain-paint: paint;
+    contain: var(--tw-contain-size,) var(--tw-contain-layout,) var(--tw-contain-paint,) var(--tw-contain-style,);
+  }
+  .contain-size {
+    --tw-contain-size: size;
+    contain: var(--tw-contain-size,) var(--tw-contain-layout,) var(--tw-contain-paint,) var(--tw-contain-style,);
+  }
+  .contain-style {
+    --tw-contain-style: style;
+    contain: var(--tw-contain-size,) var(--tw-contain-layout,) var(--tw-contain-paint,) var(--tw-contain-style,);
+  }
+  .contain-content {
+    contain: content;
+  }
+  .contain-none {
+    contain: none;
+  }
+  .contain-strict {
+    contain: strict;
+  }
+  .content-none {
+    --tw-content: none;
+    content: none;
+  }
+  .forced-color-adjust-auto {
+    forced-color-adjust: auto;
+  }
+  .forced-color-adjust-none {
+    forced-color-adjust: none;
+  }
+  .outline-dashed {
+    --tw-outline-style: dashed;
+    outline-style: dashed;
+  }
+  .outline-dotted {
+    --tw-outline-style: dotted;
+    outline-style: dotted;
+  }
+  .outline-double {
+    --tw-outline-style: double;
+    outline-style: double;
+  }
+  .outline-none {
+    --tw-outline-style: none;
+    outline-style: none;
+  }
+  .outline-solid {
+    --tw-outline-style: solid;
+    outline-style: solid;
+  }
   .select-all {
     -webkit-user-select: all;
     user-select: all;
@@ -3339,6 +4865,92 @@
   .select-none {
     -webkit-user-select: none;
     user-select: none;
+  }
+  .backface-hidden {
+    backface-visibility: hidden;
+  }
+  .backface-visible {
+    backface-visibility: visible;
+  }
+  .block-auto {
+    block-size: auto;
+  }
+  .block-lh {
+    block-size: 1lh;
+  }
+  .block-screen {
+    block-size: 100vh;
+  }
+  .divide-x-reverse {
+    :where(& > :not(:last-child)) {
+      --tw-divide-x-reverse: 1;
+    }
+  }
+  .duration-initial {
+    --tw-duration: initial;
+  }
+  .inline-auto {
+    inline-size: auto;
+  }
+  .inline-screen {
+    inline-size: 100vw;
+  }
+  .max-block-lh {
+    max-block-size: 1lh;
+  }
+  .max-block-none {
+    max-block-size: none;
+  }
+  .max-block-screen {
+    max-block-size: 100vh;
+  }
+  .max-inline-none {
+    max-inline-size: none;
+  }
+  .max-inline-screen {
+    max-inline-size: 100vw;
+  }
+  .min-block-auto {
+    min-block-size: auto;
+  }
+  .min-block-lh {
+    min-block-size: 1lh;
+  }
+  .min-block-screen {
+    min-block-size: 100vh;
+  }
+  .min-inline-auto {
+    min-inline-size: auto;
+  }
+  .min-inline-screen {
+    min-inline-size: 100vw;
+  }
+  .ring-inset {
+    --tw-ring-inset: inset;
+  }
+  .text-shadow-initial {
+    --tw-text-shadow-color: initial;
+  }
+  .transform-3d {
+    transform-style: preserve-3d;
+  }
+  .transform-border {
+    transform-box: border-box;
+  }
+  .transform-content {
+    transform-box: content-box;
+  }
+  .transform-fill {
+    transform-box: fill-box;
+  }
+  .transform-flat {
+    transform-style: flat;
+  }
+  .transform-stroke {
+    transform-box: stroke-box;
+  }
+  .transform-view {
+    transform-box: view-box;
   }
   .group-focus-within\:underline {
     &:is(:where(.group):focus-within *) {
@@ -3372,6 +4984,16 @@
   .group-focus-visible\:opacity-100 {
     &:is(:where(.group):focus-visible *) {
       opacity: 100%;
+    }
+  }
+  .group-data-\[disabled\=true\]\:pointer-events-none {
+    &:is(:where(.group)[data-disabled="true"] *) {
+      pointer-events: none;
+    }
+  }
+  .group-data-\[disabled\=true\]\:opacity-50 {
+    &:is(:where(.group)[data-disabled="true"] *) {
+      opacity: 50%;
     }
   }
   .peer-checked\:visible {
@@ -3529,6 +5151,11 @@
       cursor: not-allowed;
     }
   }
+  .peer-disabled\:opacity-50 {
+    &:is(:where(.peer):disabled ~ *) {
+      opacity: 50%;
+    }
+  }
   .peer-disabled\:opacity-70 {
     &:is(:where(.peer):disabled ~ *) {
       opacity: 70%;
@@ -3564,6 +5191,47 @@
     }
     &::-webkit-details-marker {
       color: var(--color-primary);
+    }
+  }
+  .selection\:bg-primary {
+    & *::selection {
+      background-color: var(--color-primary);
+    }
+    &::selection {
+      background-color: var(--color-primary);
+    }
+  }
+  .file\:inline-flex {
+    &::file-selector-button {
+      display: inline-flex;
+    }
+  }
+  .file\:h-7 {
+    &::file-selector-button {
+      height: calc(var(--spacing) * 7);
+    }
+  }
+  .file\:border-0 {
+    &::file-selector-button {
+      border-style: var(--tw-border-style);
+      border-width: 0px;
+    }
+  }
+  .file\:bg-transparent {
+    &::file-selector-button {
+      background-color: transparent;
+    }
+  }
+  .file\:text-sm {
+    &::file-selector-button {
+      font-size: var(--text-sm);
+      line-height: var(--tw-leading, var(--text-sm--line-height));
+    }
+  }
+  .file\:font-medium {
+    &::file-selector-button {
+      --tw-font-weight: var(--font-weight-medium);
+      font-weight: var(--font-weight-medium);
     }
   }
   .placeholder\:text-on-surface-muted {
@@ -3946,6 +5614,19 @@
       }
     }
   }
+  .focus-within\:border-\[\#f3d5a3\] {
+    &:focus-within {
+      border-color: #f3d5a3;
+    }
+  }
+  .hover\:-translate-y-px {
+    &:hover {
+      @media (hover: hover) {
+        --tw-translate-y: -1px;
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
+    }
+  }
   .hover\:scale-110 {
     &:hover {
       @media (hover: hover) {
@@ -4013,6 +5694,13 @@
       }
     }
   }
+  .hover\:bg-\[\#f3d5a3\] {
+    &:hover {
+      @media (hover: hover) {
+        background-color: #f3d5a3;
+      }
+    }
+  }
   .hover\:bg-danger\/5 {
     &:hover {
       @media (hover: hover) {
@@ -4059,6 +5747,26 @@
         background-color: color-mix(in srgb, oklch(62.7% 0.265 303.9) 10%, transparent);
         @supports (color: color-mix(in lab, red, red)) {
           background-color: color-mix(in oklab, var(--color-primary) 10%, transparent);
+        }
+      }
+    }
+  }
+  .hover\:bg-primary\/90 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: color-mix(in srgb, oklch(62.7% 0.265 303.9) 90%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-primary) 90%, transparent);
+        }
+      }
+    }
+  }
+  .hover\:bg-secondary\/80 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: color-mix(in srgb, oklch(68.5% 0.169 237.323) 80%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-secondary) 80%, transparent);
         }
       }
     }
@@ -4239,6 +5947,24 @@
       }
     }
   }
+  .hover\:drop-shadow-\[0_0_2em_\#61dafbaa\] {
+    &:hover {
+      @media (hover: hover) {
+        --tw-drop-shadow-size: drop-shadow(0 0 2em var(--tw-drop-shadow-color, #61dafbaa));
+        --tw-drop-shadow: var(--tw-drop-shadow-size);
+        filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+      }
+    }
+  }
+  .hover\:drop-shadow-\[0_0_2em_\#646cffaa\] {
+    &:hover {
+      @media (hover: hover) {
+        --tw-drop-shadow-size: drop-shadow(0 0 2em var(--tw-drop-shadow-color, #646cffaa));
+        --tw-drop-shadow: var(--tw-drop-shadow-size);
+        filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
+      }
+    }
+  }
   .focus\:not-sr-only {
     &:focus {
       position: static;
@@ -4274,6 +6000,11 @@
       scale: var(--tw-scale-x) var(--tw-scale-y);
     }
   }
+  .focus\:border-\[\#f3d5a3\] {
+    &:focus {
+      border-color: #f3d5a3;
+    }
+  }
   .focus\:bg-primary {
     &:focus {
       background-color: var(--color-primary);
@@ -4292,6 +6023,11 @@
   .focus\:text-on-primary {
     &:focus {
       color: var(--color-on-primary);
+    }
+  }
+  .focus\:text-white {
+    &:focus {
+      color: var(--color-white);
     }
   }
   .focus\:underline {
@@ -4446,6 +6182,12 @@
       opacity: 80%;
     }
   }
+  .focus-visible\:ring-\[3px\] {
+    &:focus-visible {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
   .focus-visible\:outline-hidden {
     &:focus-visible {
       --tw-outline-style: none;
@@ -4547,6 +6289,11 @@
   .active\:outline-offset-0 {
     &:active {
       outline-offset: 0px;
+    }
+  }
+  .disabled\:pointer-events-none {
+    &:disabled {
+      pointer-events: none;
     }
   }
   .disabled\:cursor-not-allowed {
@@ -4651,6 +6398,101 @@
   .has-disabled\:opacity-75 {
     &:has(*:disabled) {
       opacity: 75%;
+    }
+  }
+  .has-data-\[slot\=card-action\]\:grid-cols-\[1fr_auto\] {
+    &:has(*[data-slot="card-action"]) {
+      grid-template-columns: 1fr auto;
+    }
+  }
+  .has-\[\>svg\]\:px-2\.5 {
+    &:has(>svg) {
+      padding-inline: calc(var(--spacing) * 2.5);
+    }
+  }
+  .has-\[\>svg\]\:px-3 {
+    &:has(>svg) {
+      padding-inline: calc(var(--spacing) * 3);
+    }
+  }
+  .has-\[\>svg\]\:px-4 {
+    &:has(>svg) {
+      padding-inline: calc(var(--spacing) * 4);
+    }
+  }
+  .data-\[disabled\]\:pointer-events-none {
+    &[data-disabled] {
+      pointer-events: none;
+    }
+  }
+  .data-\[disabled\]\:opacity-50 {
+    &[data-disabled] {
+      opacity: 50%;
+    }
+  }
+  .data-\[side\=bottom\]\:translate-y-1 {
+    &[data-side="bottom"] {
+      --tw-translate-y: calc(var(--spacing) * 1);
+      translate: var(--tw-translate-x) var(--tw-translate-y);
+    }
+  }
+  .data-\[side\=left\]\:-translate-x-1 {
+    &[data-side="left"] {
+      --tw-translate-x: calc(var(--spacing) * -1);
+      translate: var(--tw-translate-x) var(--tw-translate-y);
+    }
+  }
+  .data-\[side\=right\]\:translate-x-1 {
+    &[data-side="right"] {
+      --tw-translate-x: calc(var(--spacing) * 1);
+      translate: var(--tw-translate-x) var(--tw-translate-y);
+    }
+  }
+  .data-\[side\=top\]\:-translate-y-1 {
+    &[data-side="top"] {
+      --tw-translate-y: calc(var(--spacing) * -1);
+      translate: var(--tw-translate-x) var(--tw-translate-y);
+    }
+  }
+  .data-\[size\=default\]\:h-9 {
+    &[data-size="default"] {
+      height: calc(var(--spacing) * 9);
+    }
+  }
+  .data-\[size\=sm\]\:h-8 {
+    &[data-size="sm"] {
+      height: calc(var(--spacing) * 8);
+    }
+  }
+  .\*\:data-\[slot\=select-value\]\:line-clamp-1 {
+    :is(& > *) {
+      &[data-slot="select-value"] {
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 1;
+      }
+    }
+  }
+  .\*\:data-\[slot\=select-value\]\:flex {
+    :is(& > *) {
+      &[data-slot="select-value"] {
+        display: flex;
+      }
+    }
+  }
+  .\*\:data-\[slot\=select-value\]\:items-center {
+    :is(& > *) {
+      &[data-slot="select-value"] {
+        align-items: center;
+      }
+    }
+  }
+  .\*\:data-\[slot\=select-value\]\:gap-2 {
+    :is(& > *) {
+      &[data-slot="select-value"] {
+        gap: calc(var(--spacing) * 2);
+      }
     }
   }
   .supports-\[backdrop-filter\]\:bg-surface\/60 {
@@ -4919,6 +6761,12 @@
     @media (width >= 48rem) {
       font-size: var(--text-5xl);
       line-height: var(--tw-leading, var(--text-5xl--line-height));
+    }
+  }
+  .md\:text-sm {
+    @media (width >= 48rem) {
+      font-size: var(--text-sm);
+      line-height: var(--tw-leading, var(--text-sm--line-height));
     }
   }
   .lg\:static {
@@ -6347,6 +8195,59 @@
       }
     }
   }
+  .\[\&_svg\]\:pointer-events-none {
+    & svg {
+      pointer-events: none;
+    }
+  }
+  .\[\&_svg\]\:shrink-0 {
+    & svg {
+      flex-shrink: 0;
+    }
+  }
+  .\[\&_svg\:not\(\[class\*\=\'size-\'\]\)\]\:size-4 {
+    & svg:not([class*='size-']) {
+      width: calc(var(--spacing) * 4);
+      height: calc(var(--spacing) * 4);
+    }
+  }
+  .\[\.border-b\]\:pb-6 {
+    &:is(.border-b) {
+      padding-bottom: calc(var(--spacing) * 6);
+    }
+  }
+  .\[\.border-t\]\:pt-6 {
+    &:is(.border-t) {
+      padding-top: calc(var(--spacing) * 6);
+    }
+  }
+  .\*\:\[span\]\:last\:flex {
+    :is(& > *) {
+      &:is(span) {
+        &:last-child {
+          display: flex;
+        }
+      }
+    }
+  }
+  .\*\:\[span\]\:last\:items-center {
+    :is(& > *) {
+      &:is(span) {
+        &:last-child {
+          align-items: center;
+        }
+      }
+    }
+  }
+  .\*\:\[span\]\:last\:gap-2 {
+    :is(& > *) {
+      &:is(span) {
+        &:last-child {
+          gap: calc(var(--spacing) * 2);
+        }
+      }
+    }
+  }
 }
 @layer base {
   [data-theme=arctic] {
@@ -7067,7 +8968,29 @@
   syntax: "*";
   inherits: false;
 }
+@property --tw-pan-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-pan-y {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-pinch-zoom {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-scroll-snap-strictness {
+  syntax: "*";
+  inherits: false;
+  initial-value: proximity;
+}
 @property --tw-space-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-space-x-reverse {
   syntax: "*";
   inherits: false;
   initial-value: 0;
@@ -7328,6 +9251,31 @@
   syntax: "*";
   inherits: false;
 }
+@property --tw-contain-size {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-contain-layout {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-contain-paint {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-contain-style {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-text-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-text-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
 @property --tw-content {
   syntax: "*";
   initial-value: "";
@@ -7342,6 +9290,11 @@
   75%, 100% {
     transform: scale(2);
     opacity: 0;
+  }
+}
+@keyframes pulse {
+  50% {
+    opacity: 0.5;
   }
 }
 @keyframes bounce {
@@ -7370,7 +9323,12 @@
       --tw-rotate-z: initial;
       --tw-skew-x: initial;
       --tw-skew-y: initial;
+      --tw-pan-x: initial;
+      --tw-pan-y: initial;
+      --tw-pinch-zoom: initial;
+      --tw-scroll-snap-strictness: proximity;
       --tw-space-y-reverse: 0;
+      --tw-space-x-reverse: 0;
       --tw-divide-x-reverse: 0;
       --tw-border-style: solid;
       --tw-divide-y-reverse: 0;
@@ -7430,6 +9388,12 @@
       --tw-backdrop-sepia: initial;
       --tw-duration: initial;
       --tw-ease: initial;
+      --tw-contain-size: initial;
+      --tw-contain-layout: initial;
+      --tw-contain-paint: initial;
+      --tw-contain-style: initial;
+      --tw-text-shadow-color: initial;
+      --tw-text-shadow-alpha: 100%;
       --tw-content: "";
     }
   }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -2783,9 +2783,6 @@
   .py-16 {
     padding-block: calc(var(--spacing) * 16);
   }
-  .pt-0 {
-    padding-top: calc(var(--spacing) * 0);
-  }
   .pt-1 {
     padding-top: calc(var(--spacing) * 1);
   }

--- a/internal/pages/demo/components/alert.templ
+++ b/internal/pages/demo/components/alert.templ
@@ -10,42 +10,77 @@ templ AlertDemoPage() {
 	@demo.Layout("Alert", "alert", alertDemoContent())
 }
 
-// alertDemoContent renders the actual content inside the layout
+// alertDemoContent renders the demo. Each alert variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/alert).
+// Wrapped in #alert-fragment.
 templ alertDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Alert",
-			Description:   "Alerts display important messages to the user. They come in four color variants (info, success, warning, danger) and support dismiss functionality, action links, action buttons, and list content.",
-		},
-		alertDemoPreview(),
-		`// Default Alert (all 4 variants)
-@alert.Alert(alert.Config{
+	<div id="alert-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Alert",
+				Description: "Inline messages in four semantic colors (info, success, warning, danger). Supports dismiss, action links, action buttons, and list content.",
+			},
+			alertDefaultPreview(),
+			`@alert.Alert(alert.Config{
     Title:       "Update Available",
     Description: "A new version is available.",
     Variant:     alert.Info,
-})
+})`,
+		)
 
-// Dismissible Alert (with transition)
-@alert.Alert(alert.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Dismissible",
+				Description: "Dismissible: true adds a close button that fades the alert out via an Alpine transition.",
+			},
+			alertDismissiblePreview(),
+			`@alert.Alert(alert.Config{
     Title:       "Successfully Subscribed",
     Description: "Welcome aboard!",
     Variant:     alert.Success,
     Dismissible: true,
-})
+})`,
+		)
 
-// Alert with Link
-@alert.Alert(alert.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Link",
+				Description: "Attach a Link config to render a trailing action link.",
+			},
+			alertLinkPreview(),
+			`@alert.Alert(alert.Config{
     Title:       "Update Available",
     Description: "A new version is available.",
     Variant:     alert.Info,
-    Link: &alert.LinkConfig{
-        Text: "Details",
-        Href: "#",
-    },
-})
+    Link: &alert.LinkConfig{Text: "Details", Href: "#"},
+})`,
+		)
 
-// Alert with Action Buttons
-@alert.Alert(alert.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With List",
+				Description: "Pass ListItems to render a bulleted list under the description.",
+			},
+			alertListPreview(),
+			`@alert.Alert(alert.Config{
+    Title:       "Password Requirements",
+    Description: "Make sure your password:",
+    Variant:     alert.Info,
+    ListItems: []string{
+        "has minimum 8 characters",
+        "includes both upper and lower cases",
+        "contains at least one number",
+    },
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Action Buttons",
+				Description: "Attach an Action config for primary + dismiss buttons.",
+			},
+			alertActionPreview(),
+			`@alert.Alert(alert.Config{
     Title:       "Update Available",
     Description: "A new version is available.",
     Variant:     alert.Info,
@@ -54,29 +89,26 @@ templ alertDemoContent() {
         PrimaryOnClick: "alert('Updating...')",
         DismissText:    "Dismiss",
     },
-})
-
-// Alert with List
-@alert.Alert(alert.Config{
-    Title:       "Password Requirements",
-    Description: "Make sure your password:",
-    Variant:     alert.Info,
-    ListItems:   []string{
-        "has minimum 8 characters",
-        "includes both upper and lower cases",
-        "contains at least one number",
-    },
 })`,
-	)
+		)
+	</div>
+	// API reference lives outside #alert-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Title", Type: "string", Default: `""`, Description: "Alert heading."},
+		{Name: "Description", Type: "string", Default: `""`, Description: "Alert body text."},
+		{Name: "Variant", Type: "Variant", Default: "Info", Description: `Color: "info", "success", "warning", "danger".`},
+		{Name: "Dismissible", Type: "bool", Default: "false", Description: "Add a close button with a fade transition."},
+		{Name: "Link", Type: "*LinkConfig", Default: "nil", Description: "Trailing action link (Text + Href)."},
+		{Name: "Action", Type: "*ActionConfig", Default: "nil", Description: "Primary + dismiss action buttons."},
+		{Name: "ListItems", Type: "[]string", Default: "nil", Description: "Bulleted list rendered under the description."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the alert."},
+	})
 }
 
-// alertDemoPreview renders the Goshtoso alert preview
-templ alertDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Default Alerts
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Alert</h4>
-			<div class="space-y-3">
+// alertDefaultPreview renders the four default (non-dismissible) variants.
+templ alertDefaultPreview() {
+	<div id="alert-default" class="w-full max-w-2xl mx-auto">
+		<div class="space-y-3">
 				@alert.Alert(alert.Config{
 					Title:       "Update Available",
 					Description: "A new version is available. Please update to the latest version.",
@@ -99,11 +131,12 @@ templ alertDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Dismissible Alerts
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Dismissible Alert (with Transition)</h4>
-			<div class="space-y-3">
+// alertDismissiblePreview renders the four dismissible variants.
+templ alertDismissiblePreview() {
+	<div id="alert-dismissible" class="w-full max-w-2xl mx-auto">
+		<div class="space-y-3">
 				@alert.Alert(alert.Config{
 					Title:       "Update Available",
 					Description: "A new version is available. Please update to the latest version.",
@@ -130,11 +163,12 @@ templ alertDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Alert with Link
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Alert with Link</h4>
-			<div class="space-y-3">
+// alertLinkPreview renders the four link variants.
+templ alertLinkPreview() {
+	<div id="alert-link" class="w-full max-w-2xl mx-auto">
+		<div class="space-y-3">
 				@alert.Alert(alert.Config{
 					Title:       "Update Available",
 					Description: "A new version is available. Please update to the latest version.",
@@ -173,11 +207,12 @@ templ alertDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Alert with List
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Alert with List</h4>
-			<div class="space-y-3">
+// alertListPreview renders the list-content variants.
+templ alertListPreview() {
+	<div id="alert-list" class="w-full max-w-2xl mx-auto">
+		<div class="space-y-3">
 				@alert.Alert(alert.Config{
 					Title:       "Password is not strong",
 					Description: "The password you entered does not meet the requirements. Make sure your password:",
@@ -200,11 +235,12 @@ templ alertDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Alert with Action Buttons
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Alert with Action Buttons</h4>
-			<div class="space-y-3">
+// alertActionPreview renders the action-button variants.
+templ alertActionPreview() {
+	<div id="alert-action" class="w-full max-w-2xl mx-auto">
+		<div class="space-y-3">
 				@alert.Alert(alert.Config{
 					Title:       "Update Available",
 					Description: "A new version is available. Please update to the latest version.",
@@ -243,5 +279,4 @@ templ alertDemoPreview() {
 				})
 			</div>
 		</div>
-	</div>
 }

--- a/internal/pages/demo/components/alert_templ.go
+++ b/internal/pages/demo/components/alert_templ.go
@@ -43,7 +43,9 @@ func AlertDemoPage() templ.Component {
 	})
 }
 
-// alertDemoContent renders the actual content inside the layout
+// alertDemoContent renders the demo. Each alert variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/alert).
+// Wrapped in #alert-fragment.
 func alertDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,56 +67,68 @@ func alertDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"alert-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Alert",
-				Description: "Alerts display important messages to the user. They come in four color variants (info, success, warning, danger) and support dismiss functionality, action links, action buttons, and list content.",
+				Description: "Inline messages in four semantic colors (info, success, warning, danger). Supports dismiss, action links, action buttons, and list content.",
 			},
-			alertDemoPreview(),
-			`// Default Alert (all 4 variants)
-@alert.Alert(alert.Config{
+			alertDefaultPreview(),
+			`@alert.Alert(alert.Config{
     Title:       "Update Available",
     Description: "A new version is available.",
     Variant:     alert.Info,
-})
-
-// Dismissible Alert (with transition)
-@alert.Alert(alert.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Dismissible",
+				Description: "Dismissible: true adds a close button that fades the alert out via an Alpine transition.",
+			},
+			alertDismissiblePreview(),
+			`@alert.Alert(alert.Config{
     Title:       "Successfully Subscribed",
     Description: "Welcome aboard!",
     Variant:     alert.Success,
     Dismissible: true,
-})
-
-// Alert with Link
-@alert.Alert(alert.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Link",
+				Description: "Attach a Link config to render a trailing action link.",
+			},
+			alertLinkPreview(),
+			`@alert.Alert(alert.Config{
     Title:       "Update Available",
     Description: "A new version is available.",
     Variant:     alert.Info,
-    Link: &alert.LinkConfig{
-        Text: "Details",
-        Href: "#",
-    },
-})
-
-// Alert with Action Buttons
-@alert.Alert(alert.Config{
-    Title:       "Update Available",
-    Description: "A new version is available.",
-    Variant:     alert.Info,
-    Action: &alert.ActionConfig{
-        PrimaryText:    "Update Now",
-        PrimaryOnClick: "alert('Updating...')",
-        DismissText:    "Dismiss",
-    },
-})
-
-// Alert with List
-@alert.Alert(alert.Config{
+    Link: &alert.LinkConfig{Text: "Details", Href: "#"},
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With List",
+				Description: "Pass ListItems to render a bulleted list under the description.",
+			},
+			alertListPreview(),
+			`@alert.Alert(alert.Config{
     Title:       "Password Requirements",
     Description: "Make sure your password:",
     Variant:     alert.Info,
-    ListItems:   []string{
+    ListItems: []string{
         "has minimum 8 characters",
         "includes both upper and lower cases",
         "contains at least one number",
@@ -124,12 +138,49 @@ func alertDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Action Buttons",
+				Description: "Attach an Action config for primary + dismiss buttons.",
+			},
+			alertActionPreview(),
+			`@alert.Alert(alert.Config{
+    Title:       "Update Available",
+    Description: "A new version is available.",
+    Variant:     alert.Info,
+    Action: &alert.ActionConfig{
+        PrimaryText:    "Update Now",
+        PrimaryOnClick: "alert('Updating...')",
+        DismissText:    "Dismiss",
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Title", Type: "string", Default: `""`, Description: "Alert heading."},
+			{Name: "Description", Type: "string", Default: `""`, Description: "Alert body text."},
+			{Name: "Variant", Type: "Variant", Default: "Info", Description: `Color: "info", "success", "warning", "danger".`},
+			{Name: "Dismissible", Type: "bool", Default: "false", Description: "Add a close button with a fade transition."},
+			{Name: "Link", Type: "*LinkConfig", Default: "nil", Description: "Trailing action link (Text + Href)."},
+			{Name: "Action", Type: "*ActionConfig", Default: "nil", Description: "Primary + dismiss action buttons."},
+			{Name: "ListItems", Type: "[]string", Default: "nil", Description: "Bulleted list rendered under the description."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the alert."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// alertDemoPreview renders the Goshtoso alert preview
-func alertDemoPreview() templ.Component {
+// alertDefaultPreview renders the four default (non-dismissible) variants.
+func alertDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -150,7 +201,7 @@ func alertDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Alert</h4><div class=\"space-y-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"alert-default\" class=\"w-full max-w-2xl mx-auto\"><div class=\"space-y-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -186,7 +237,37 @@ func alertDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Dismissible Alert (with Transition)</h4><div class=\"space-y-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// alertDismissiblePreview renders the four dismissible variants.
+func alertDismissiblePreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"alert-dismissible\" class=\"w-full max-w-2xl mx-auto\"><div class=\"space-y-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -226,7 +307,37 @@ func alertDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Alert with Link</h4><div class=\"space-y-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// alertLinkPreview renders the four link variants.
+func alertLinkPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"alert-link\" class=\"w-full max-w-2xl mx-auto\"><div class=\"space-y-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -278,7 +389,37 @@ func alertDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Alert with List</h4><div class=\"space-y-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// alertListPreview renders the list-content variants.
+func alertListPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"alert-list\" class=\"w-full max-w-2xl mx-auto\"><div class=\"space-y-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -308,7 +449,37 @@ func alertDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Alert with Action Buttons</h4><div class=\"space-y-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// alertActionPreview renders the action-button variants.
+func alertActionPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"alert-action\" class=\"w-full max-w-2xl mx-auto\"><div class=\"space-y-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -360,7 +531,7 @@ func alertDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/avatar.templ
+++ b/internal/pages/demo/components/avatar.templ
@@ -45,58 +45,95 @@ document.addEventListener('alpine:init', () => {
 // The x-data wrapper hoists Alpine state above the ComponentDemo macOS-frame
 // so the size selector sits in the page chrome (matching PenguinUI), while
 // every reactive avatar inside the frame still inherits the same scope.
+// The whole demo stays inside one x-data="avatarShowcase" scope so the single
+// size selector (AbovePreview) drives every Reactive avatar across all the
+// per-variant DemoSection boxes in lockstep. Each variant box still carries its
+// e2e data-testid; the API reference sits after #avatar-fragment.
 templ avatarDemoContent() {
 	@avatarShowcaseScript()
 	<div x-data="avatarShowcase">
-		@demo.ComponentDemo(
-			demo.ComponentDemoProps{
-				Title:         "Avatar",
-				Description:   "A visual representation of a user or entity. Supports image, initials, icon placeholder, status indicator, square shape, and now an interactive size selector that drives every avatar on the page in lockstep via Alpine.js (matches PenguinUI's reference UX).",
-				AbovePreview:  avatarSizeSelector(),
-			},
-			avatarDemoPreview(),
-			`// Interactive size selector: the demo page wraps avatars in an Alpine scope
-// that exposes 'avatarSizeClass' + 'avatarStatusSizeClass'. Setting
-// Reactive: true on the avatar Config makes the component read those bindings
-// instead of baking SizeClasses() into the rendered HTML.
-//
-// <div x-data="avatarShowcase">
-//   ... segmented radio group bound to ` + "`selected`" + ` ...
-//   @avatar.Avatar(avatar.Config{Reactive: true, Initials: "JD", ...})
-// </div>
-
-// Image Avatar (reactive — sized by parent Alpine scope)
+		<div id="avatar-fragment">
+			@demo.ComponentDemo(
+				demo.ComponentDemoProps{
+					Title:        "Avatar",
+					Description:  "A visual representation of a user or entity — image, initials, icon placeholder, status indicator, and square shape. The size selector above drives every avatar on the page in lockstep via Alpine.js (Reactive: true).",
+					AbovePreview: avatarSizeSelector(),
+				},
+				avatarImagePreview(),
+				`// Image Avatar (reactive — sized by the shared Alpine scope)
 @avatar.Avatar(avatar.Config{
     Src:      "/assets/images/avatars/avatar-8.webp",
     Alt:      "John Doe",
     Reactive: true,
 })
 
-// Initials Avatar (also reactive)
-@avatar.Avatar(avatar.Config{
-    Initials: "JS",
-    Variant:  avatar.Primary,
-    Reactive: true,
-})
+// Bordered + status variants
+@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-primary", Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusSuccess, Reactive: true})`,
+			)
 
-// With Status Indicator (status dot resizes via avatarStatusSizeClass)
-@avatar.Avatar(avatar.Config{
-    Src:      "/assets/images/avatars/avatar-8.webp",
-    Status:   avatar.StatusSuccess,
-    Reactive: true,
-})
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Initials",
+					Description: "Set Initials and a Variant for a colored monogram fallback.",
+				},
+				avatarInitialsPreview(),
+				`@avatar.Avatar(avatar.Config{Initials: "JD", Variant: avatar.Primary, Reactive: true})`,
+			)
 
-// Size selector — uses the new radio.Segmented variant + Alpine primitives
-@radio.RadioBar() {
-    @radio.Radio(radio.Config{
-        Name: "avatar-size", Value: "md", Label: "md", Segmented: true,
-        Alpine: &radio.AlpineConfig{
-            BindChecked: "selected === 'md'",
-            OnChange:    "selected = 'md'",
-        },
-    })
-}`,
-		)
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Icon Placeholder",
+					Description: "With neither Src nor Initials, the avatar shows a generic user icon in the Variant color.",
+				},
+				avatarIconPreview(),
+				`@avatar.Avatar(avatar.Config{Variant: avatar.Primary, Reactive: true})`,
+			)
+
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Status Indicator",
+					Description: "Set Status: StatusOffline, StatusInfo, StatusSuccess, StatusWarning, or StatusDanger for a corner presence dot.",
+				},
+				avatarStatusPreview(),
+				`@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusSuccess, Reactive: true})`,
+			)
+
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Square Shape",
+					Description: "Shape: avatar.ShapeSquare renders a rounded-square avatar instead of a circle.",
+				},
+				avatarSquarePreview(),
+				`@avatar.Avatar(avatar.Config{Initials: "SQ", Shape: avatar.ShapeSquare, Variant: avatar.Info, Reactive: true})`,
+			)
+
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Fixed Size (image load/error)",
+					Description: "Set an explicit Size (not Reactive) for a fixed avatar. With a Name and no/failed Src, the avatar falls back to initials.",
+				},
+				avatarFixturesPreview(),
+				`@avatar.Avatar(avatar.Config{Src: imgURL, Name: "Load Test", Size: avatar.SizeMD})
+@avatar.Avatar(avatar.Config{Src: "/missing.png", Name: "Error Fallback", Size: avatar.SizeMD})
+@avatar.Avatar(avatar.Config{Name: "Initials Only", Size: avatar.SizeMD, Variant: avatar.Primary})`,
+			)
+		</div>
+		@demo.APIReference([]demo.PropDoc{
+			{Name: "Src", Type: "string", Default: `""`, Description: "Image URL (falls back to initials/icon on error)."},
+			{Name: "Alt", Type: "string", Default: `""`, Description: "Image alt text."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Full name used to derive initials when Src is missing/broken."},
+			{Name: "Initials", Type: "string", Default: `""`, Description: "Explicit initials (overrides Name-derived)."},
+			{Name: "Size", Type: "Size", Default: "SizeMD", Description: `Fixed size: "xs", "sm", "md", "lg", "xl", "2xl" (ignored when Reactive).`},
+			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Color for initials/icon: default, primary, secondary, info, success, warning, danger.`},
+			{Name: "Shape", Type: "Shape", Default: "ShapeCircle", Description: `Shape: "circle" or "square".`},
+			{Name: "Border", Type: "bool", Default: "false", Description: "Add a ring border."},
+			{Name: "BorderColor", Type: "string", Default: `""`, Description: "Tailwind border color class for the ring."},
+			{Name: "Status", Type: "Status", Default: `""`, Description: `Presence dot: "offline", "info", "success", "warning", "danger".`},
+			{Name: "Icon", Type: "templ.Component", Default: "nil", Description: "Custom placeholder icon (overrides the default user icon)."},
+			{Name: "Reactive", Type: "bool", Default: "false", Description: "Read size classes from the parent Alpine scope (avatarSizeClass) instead of Size."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the avatar root."},
+		})
 	</div>
 }
 
@@ -134,121 +171,117 @@ templ sizeOption(value, label string) {
 	})
 }
 
-// avatarDemoPreview renders the Goshtoso avatar preview. Selector lives
-// outside the preview frame (see avatarDemoContent + avatarSizeSelector);
-// this template inherits the avatarShowcase Alpine scope from its parent.
-templ avatarDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto">
-		<div class="space-y-8">
-			// Image Avatars
-			<div>
-				<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Image Avatars</h4>
-				<div class="flex flex-wrap items-center gap-4" data-testid="avatar-section-image">
-					@avatar.Avatar(avatar.Config{
-						Src:      "/assets/images/avatars/avatar-8.webp",
-						Alt:      "User Avatar",
-						Reactive: true,
-					})
-					@avatar.Avatar(avatar.Config{
-						Src:         "/assets/images/avatars/avatar-8.webp",
-						Alt:         "User Avatar with border",
-						Border:      true,
-						BorderColor: "border-primary",
-						Reactive:    true,
-					})
-					@avatar.Avatar(avatar.Config{
-						Src:      "/assets/images/avatars/avatar-8.webp",
-						Alt:      "User with Status",
-						Status:   avatar.StatusSuccess,
-						Reactive: true,
-					})
-					@avatar.Avatar(avatar.Config{
-						Src:      "/assets/images/avatars/avatar-8.webp",
-						Alt:      "User Offline",
-						Status:   avatar.StatusOffline,
-						Reactive: true,
-					})
-				</div>
-			</div>
+// avatarImagePreview renders the reactive image avatars (default ComponentDemo box).
+templ avatarImagePreview() {
+	<div id="avatar-image" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap items-center justify-center gap-4" data-testid="avatar-section-image">
+			@avatar.Avatar(avatar.Config{
+				Src:      "/assets/images/avatars/avatar-8.webp",
+				Alt:      "User Avatar",
+				Reactive: true,
+			})
+			@avatar.Avatar(avatar.Config{
+				Src:         "/assets/images/avatars/avatar-8.webp",
+				Alt:         "User Avatar with border",
+				Border:      true,
+				BorderColor: "border-primary",
+				Reactive:    true,
+			})
+			@avatar.Avatar(avatar.Config{
+				Src:      "/assets/images/avatars/avatar-8.webp",
+				Alt:      "User with Status",
+				Status:   avatar.StatusSuccess,
+				Reactive: true,
+			})
+			@avatar.Avatar(avatar.Config{
+				Src:      "/assets/images/avatars/avatar-8.webp",
+				Alt:      "User Offline",
+				Status:   avatar.StatusOffline,
+				Reactive: true,
+			})
+		</div>
+	</div>
+}
 
-			// Initials Avatars
-			<div>
-				<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Initials Avatars</h4>
-				<div class="flex flex-wrap items-center gap-4" data-testid="avatar-section-initials">
-					@avatar.Avatar(avatar.Config{Initials: "JD", Variant: avatar.Default, Reactive: true})
-					@avatar.Avatar(avatar.Config{Initials: "AB", Variant: avatar.Primary, Reactive: true})
-					@avatar.Avatar(avatar.Config{Initials: "CD", Variant: avatar.Secondary, Reactive: true})
-					@avatar.Avatar(avatar.Config{Initials: "EF", Variant: avatar.Info, Reactive: true})
-					@avatar.Avatar(avatar.Config{Initials: "GH", Variant: avatar.Success, Reactive: true})
-					@avatar.Avatar(avatar.Config{Initials: "IJ", Variant: avatar.Warning, Reactive: true})
-					@avatar.Avatar(avatar.Config{Initials: "KL", Variant: avatar.Danger, Reactive: true})
-				</div>
-			</div>
+// avatarInitialsPreview renders the colored-initials avatars.
+templ avatarInitialsPreview() {
+	<div id="avatar-initials" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap items-center justify-center gap-4" data-testid="avatar-section-initials">
+			@avatar.Avatar(avatar.Config{Initials: "JD", Variant: avatar.Default, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "AB", Variant: avatar.Primary, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "CD", Variant: avatar.Secondary, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "EF", Variant: avatar.Info, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "GH", Variant: avatar.Success, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "IJ", Variant: avatar.Warning, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "KL", Variant: avatar.Danger, Reactive: true})
+		</div>
+	</div>
+}
 
-			// Icon Placeholders
-			<div>
-				<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Icon Placeholders</h4>
-				<div class="flex flex-wrap items-center gap-4">
-					@avatar.Avatar(avatar.Config{Variant: avatar.Default, Reactive: true})
-					@avatar.Avatar(avatar.Config{Variant: avatar.Primary, Reactive: true})
-					@avatar.Avatar(avatar.Config{Variant: avatar.Info, Reactive: true})
-				</div>
-			</div>
+// avatarIconPreview renders the icon-placeholder avatars.
+templ avatarIconPreview() {
+	<div id="avatar-icon" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap items-center justify-center gap-4">
+			@avatar.Avatar(avatar.Config{Variant: avatar.Default, Reactive: true})
+			@avatar.Avatar(avatar.Config{Variant: avatar.Primary, Reactive: true})
+			@avatar.Avatar(avatar.Config{Variant: avatar.Info, Reactive: true})
+		</div>
+	</div>
+}
 
-			// Status Indicators
-			<div>
-				<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Status Indicators</h4>
-				<div class="flex flex-wrap items-center gap-4" data-testid="avatar-section-status">
-					@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Offline", Status: avatar.StatusOffline, Reactive: true})
-					@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Info", Status: avatar.StatusInfo, Reactive: true})
-					@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Online", Status: avatar.StatusSuccess, Reactive: true})
-					@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Away", Status: avatar.StatusWarning, Reactive: true})
-					@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Busy", Status: avatar.StatusDanger, Reactive: true})
-				</div>
-			</div>
+// avatarStatusPreview renders the status-indicator avatars.
+templ avatarStatusPreview() {
+	<div id="avatar-status" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap items-center justify-center gap-4" data-testid="avatar-section-status">
+			@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Offline", Status: avatar.StatusOffline, Reactive: true})
+			@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Info", Status: avatar.StatusInfo, Reactive: true})
+			@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Online", Status: avatar.StatusSuccess, Reactive: true})
+			@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Away", Status: avatar.StatusWarning, Reactive: true})
+			@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Busy", Status: avatar.StatusDanger, Reactive: true})
+		</div>
+	</div>
+}
 
-			// Square Shape
-			<div>
-				<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Square Shape</h4>
-				<div class="flex flex-wrap items-center gap-4" data-testid="avatar-section-square">
-					@avatar.Avatar(avatar.Config{Initials: "SQ", Variant: avatar.Info, Shape: avatar.ShapeSquare, Reactive: true})
-					@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Square", Shape: avatar.ShapeSquare, Reactive: true})
-					@avatar.Avatar(avatar.Config{Initials: "SQ", Variant: avatar.Success, Shape: avatar.ShapeSquare, Status: avatar.StatusSuccess, Reactive: true})
-				</div>
-			</div>
+// avatarSquarePreview renders the square-shape avatars.
+templ avatarSquarePreview() {
+	<div id="avatar-square" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap items-center justify-center gap-4" data-testid="avatar-section-square">
+			@avatar.Avatar(avatar.Config{Initials: "SQ", Variant: avatar.Info, Shape: avatar.ShapeSquare, Reactive: true})
+			@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Square", Shape: avatar.ShapeSquare, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "SQ", Variant: avatar.Success, Shape: avatar.ShapeSquare, Status: avatar.StatusSuccess, Reactive: true})
+		</div>
+	</div>
+}
 
-			// E2E test fixtures — kept at fixed SizeMD so existing tests for image
-			// load/error behavior remain stable. These intentionally do NOT respond
-			// to the size selector.
-			<div data-testid="avatar-e2e-fixtures">
-				<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">E2E Test Fixtures (fixed size)</h4>
-				<div class="flex flex-wrap items-center gap-4">
-					<div data-testid="avatar-test-loaded">
-						@avatar.Avatar(avatar.Config{
-							Src:     "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' fill='%230089d6'/%3E%3Ccircle cx='32' cy='32' r='18' fill='white'/%3E%3C/svg%3E",
-							Alt:     "Loaded",
-							Name:    "Load Test",
-							Size:    avatar.SizeMD,
-							Variant: avatar.Default,
-						})
-					</div>
-					<div data-testid="avatar-test-error">
-						@avatar.Avatar(avatar.Config{
-							Src:     "/assets/images/does-not-exist-404.png",
-							Alt:     "Error",
-							Name:    "Error Fallback",
-							Size:    avatar.SizeMD,
-							Variant: avatar.Default,
-						})
-					</div>
-					<div data-testid="avatar-test-initials">
-						@avatar.Avatar(avatar.Config{
-							Name:    "Initials Only",
-							Size:    avatar.SizeMD,
-							Variant: avatar.Primary,
-						})
-					</div>
-				</div>
+// avatarFixturesPreview renders the fixed-size avatars used by the image
+// load/error e2e tests. These intentionally do NOT respond to the size selector.
+templ avatarFixturesPreview() {
+	<div id="avatar-fixtures" class="w-full max-w-2xl mx-auto" data-testid="avatar-e2e-fixtures">
+		<div class="flex flex-wrap items-center justify-center gap-4">
+			<div data-testid="avatar-test-loaded">
+				@avatar.Avatar(avatar.Config{
+					Src:     "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' fill='%230089d6'/%3E%3Ccircle cx='32' cy='32' r='18' fill='white'/%3E%3C/svg%3E",
+					Alt:     "Loaded",
+					Name:    "Load Test",
+					Size:    avatar.SizeMD,
+					Variant: avatar.Default,
+				})
+			</div>
+			<div data-testid="avatar-test-error">
+				@avatar.Avatar(avatar.Config{
+					Src:     "/assets/images/does-not-exist-404.png",
+					Alt:     "Error",
+					Name:    "Error Fallback",
+					Size:    avatar.SizeMD,
+					Variant: avatar.Default,
+				})
+			</div>
+			<div data-testid="avatar-test-initials">
+				@avatar.Avatar(avatar.Config{
+					Name:    "Initials Only",
+					Size:    avatar.SizeMD,
+					Variant: avatar.Primary,
+				})
 			</div>
 		</div>
 	</div>

--- a/internal/pages/demo/components/avatar_templ.go
+++ b/internal/pages/demo/components/avatar_templ.go
@@ -103,6 +103,10 @@ document.addEventListener('alpine:init', () => {
 // The x-data wrapper hoists Alpine state above the ComponentDemo macOS-frame
 // so the size selector sits in the page chrome (matching PenguinUI), while
 // every reactive avatar inside the frame still inherits the same scope.
+// The whole demo stays inside one x-data="avatarShowcase" scope so the single
+// size selector (AbovePreview) drives every Reactive avatar across all the
+// per-variant DemoSection boxes in lockstep. Each variant box still carries its
+// e2e data-testid; the API reference sits after #avatar-fragment.
 func avatarDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -128,63 +132,111 @@ func avatarDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div x-data=\"avatarShowcase\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div x-data=\"avatarShowcase\"><div id=\"avatar-fragment\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:        "Avatar",
-				Description:  "A visual representation of a user or entity. Supports image, initials, icon placeholder, status indicator, square shape, and now an interactive size selector that drives every avatar on the page in lockstep via Alpine.js (matches PenguinUI's reference UX).",
+				Description:  "A visual representation of a user or entity — image, initials, icon placeholder, status indicator, and square shape. The size selector above drives every avatar on the page in lockstep via Alpine.js (Reactive: true).",
 				AbovePreview: avatarSizeSelector(),
 			},
-			avatarDemoPreview(),
-			`// Interactive size selector: the demo page wraps avatars in an Alpine scope
-// that exposes 'avatarSizeClass' + 'avatarStatusSizeClass'. Setting
-// Reactive: true on the avatar Config makes the component read those bindings
-// instead of baking SizeClasses() into the rendered HTML.
-//
-// <div x-data="avatarShowcase">
-//   ... segmented radio group bound to `+"`selected`"+` ...
-//   @avatar.Avatar(avatar.Config{Reactive: true, Initials: "JD", ...})
-// </div>
-
-// Image Avatar (reactive — sized by parent Alpine scope)
+			avatarImagePreview(),
+			`// Image Avatar (reactive — sized by the shared Alpine scope)
 @avatar.Avatar(avatar.Config{
     Src:      "/assets/images/avatars/avatar-8.webp",
     Alt:      "John Doe",
     Reactive: true,
 })
 
-// Initials Avatar (also reactive)
-@avatar.Avatar(avatar.Config{
-    Initials: "JS",
-    Variant:  avatar.Primary,
-    Reactive: true,
-})
-
-// With Status Indicator (status dot resizes via avatarStatusSizeClass)
-@avatar.Avatar(avatar.Config{
-    Src:      "/assets/images/avatars/avatar-8.webp",
-    Status:   avatar.StatusSuccess,
-    Reactive: true,
-})
-
-// Size selector — uses the new radio.Segmented variant + Alpine primitives
-@radio.RadioBar() {
-    @radio.Radio(radio.Config{
-        Name: "avatar-size", Value: "md", Label: "md", Segmented: true,
-        Alpine: &radio.AlpineConfig{
-            BindChecked: "selected === 'md'",
-            OnChange:    "selected = 'md'",
-        },
-    })
-}`,
+// Bordered + status variants
+@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-primary", Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusSuccess, Reactive: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Initials",
+				Description: "Set Initials and a Variant for a colored monogram fallback.",
+			},
+			avatarInitialsPreview(),
+			`@avatar.Avatar(avatar.Config{Initials: "JD", Variant: avatar.Primary, Reactive: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Icon Placeholder",
+				Description: "With neither Src nor Initials, the avatar shows a generic user icon in the Variant color.",
+			},
+			avatarIconPreview(),
+			`@avatar.Avatar(avatar.Config{Variant: avatar.Primary, Reactive: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Status Indicator",
+				Description: "Set Status: StatusOffline, StatusInfo, StatusSuccess, StatusWarning, or StatusDanger for a corner presence dot.",
+			},
+			avatarStatusPreview(),
+			`@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusSuccess, Reactive: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Square Shape",
+				Description: "Shape: avatar.ShapeSquare renders a rounded-square avatar instead of a circle.",
+			},
+			avatarSquarePreview(),
+			`@avatar.Avatar(avatar.Config{Initials: "SQ", Shape: avatar.ShapeSquare, Variant: avatar.Info, Reactive: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Fixed Size (image load/error)",
+				Description: "Set an explicit Size (not Reactive) for a fixed avatar. With a Name and no/failed Src, the avatar falls back to initials.",
+			},
+			avatarFixturesPreview(),
+			`@avatar.Avatar(avatar.Config{Src: imgURL, Name: "Load Test", Size: avatar.SizeMD})
+@avatar.Avatar(avatar.Config{Src: "/missing.png", Name: "Error Fallback", Size: avatar.SizeMD})
+@avatar.Avatar(avatar.Config{Name: "Initials Only", Size: avatar.SizeMD, Variant: avatar.Primary})`,
 		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Src", Type: "string", Default: `""`, Description: "Image URL (falls back to initials/icon on error)."},
+			{Name: "Alt", Type: "string", Default: `""`, Description: "Image alt text."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Full name used to derive initials when Src is missing/broken."},
+			{Name: "Initials", Type: "string", Default: `""`, Description: "Explicit initials (overrides Name-derived)."},
+			{Name: "Size", Type: "Size", Default: "SizeMD", Description: `Fixed size: "xs", "sm", "md", "lg", "xl", "2xl" (ignored when Reactive).`},
+			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Color for initials/icon: default, primary, secondary, info, success, warning, danger.`},
+			{Name: "Shape", Type: "Shape", Default: "ShapeCircle", Description: `Shape: "circle" or "square".`},
+			{Name: "Border", Type: "bool", Default: "false", Description: "Add a ring border."},
+			{Name: "BorderColor", Type: "string", Default: `""`, Description: "Tailwind border color class for the ring."},
+			{Name: "Status", Type: "Status", Default: `""`, Description: `Presence dot: "offline", "info", "success", "warning", "danger".`},
+			{Name: "Icon", Type: "templ.Component", Default: "nil", Description: "Custom placeholder icon (overrides the default user icon)."},
+			{Name: "Reactive", Type: "bool", Default: "false", Description: "Read size classes from the parent Alpine scope (avatarSizeClass) instead of Size."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the avatar root."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -215,7 +267,7 @@ func avatarSizeSelector() templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"mb-3 flex items-center gap-4\"><label class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Size</label><div data-testid=\"avatar-size-selector\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"mb-3 flex items-center gap-4\"><label class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Size</label><div data-testid=\"avatar-size-selector\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -235,7 +287,7 @@ func avatarSizeSelector() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -243,7 +295,7 @@ func avatarSizeSelector() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -251,7 +303,7 @@ func avatarSizeSelector() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -259,7 +311,7 @@ func avatarSizeSelector() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -267,7 +319,7 @@ func avatarSizeSelector() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -281,7 +333,7 @@ func avatarSizeSelector() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div><span class=\"sr-only\" data-testid=\"avatar-size-selected\" x-text=\"selected\"></span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div><span class=\"sr-only\" data-testid=\"avatar-size-selected\" x-text=\"selected\"></span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -329,10 +381,8 @@ func sizeOption(value, label string) templ.Component {
 	})
 }
 
-// avatarDemoPreview renders the Goshtoso avatar preview. Selector lives
-// outside the preview frame (see avatarDemoContent + avatarSizeSelector);
-// this template inherits the avatarShowcase Alpine scope from its parent.
-func avatarDemoPreview() templ.Component {
+// avatarImagePreview renders the reactive image avatars (default ComponentDemo box).
+func avatarImagePreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -353,7 +403,7 @@ func avatarDemoPreview() templ.Component {
 			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"w-full max-w-4xl mx-auto\"><div class=\"space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Image Avatars</h4><div class=\"flex flex-wrap items-center gap-4\" data-testid=\"avatar-section-image\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"avatar-image\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-image\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -393,7 +443,37 @@ func avatarDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Initials Avatars</h4><div class=\"flex flex-wrap items-center gap-4\" data-testid=\"avatar-section-initials\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// avatarInitialsPreview renders the colored-initials avatars.
+func avatarInitialsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"avatar-initials\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-initials\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -425,7 +505,37 @@ func avatarDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Icon Placeholders</h4><div class=\"flex flex-wrap items-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// avatarIconPreview renders the icon-placeholder avatars.
+func avatarIconPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"avatar-icon\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -441,7 +551,37 @@ func avatarDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Status Indicators</h4><div class=\"flex flex-wrap items-center gap-4\" data-testid=\"avatar-section-status\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// avatarStatusPreview renders the status-indicator avatars.
+func avatarStatusPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"avatar-status\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-status\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -465,7 +605,37 @@ func avatarDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Square Shape</h4><div class=\"flex flex-wrap items-center gap-4\" data-testid=\"avatar-section-square\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// avatarSquarePreview renders the square-shape avatars.
+func avatarSquarePreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div id=\"avatar-square\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-square\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -481,7 +651,38 @@ func avatarDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</div></div><div data-testid=\"avatar-e2e-fixtures\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">E2E Test Fixtures (fixed size)</h4><div class=\"flex flex-wrap items-center gap-4\"><div data-testid=\"avatar-test-loaded\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// avatarFixturesPreview renders the fixed-size avatars used by the image
+// load/error e2e tests. These intentionally do NOT respond to the size selector.
+func avatarFixturesPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div id=\"avatar-fixtures\" class=\"w-full max-w-2xl mx-auto\" data-testid=\"avatar-e2e-fixtures\"><div class=\"flex flex-wrap items-center justify-center gap-4\"><div data-testid=\"avatar-test-loaded\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -495,7 +696,7 @@ func avatarDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div><div data-testid=\"avatar-test-error\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</div><div data-testid=\"avatar-test-error\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -509,7 +710,7 @@ func avatarDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div><div data-testid=\"avatar-test-initials\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div><div data-testid=\"avatar-test-initials\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -521,7 +722,7 @@ func avatarDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div></div></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/badge.templ
+++ b/internal/pages/demo/components/badge.templ
@@ -10,191 +10,204 @@ templ BadgeDemoPage() {
 	@demo.Layout("Badge", "badge", badgeDemoContent())
 }
 
-// badgeDemoContent renders the actual content inside the layout
+// badgeDemoContent renders the demo. Each badge variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/badge).
+// Wrapped in #badge-fragment.
 templ badgeDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Badge",
-			Description:   "A badge is a small label that displays additional information, status, or counts. Used for notifications, status indicators, and categorization.",
-		},
-		badgeDemoPreview(),
-		`// Simple Badge
-@badge.Badge(badge.Config{
-    Text:    "New",
-    Variant: badge.Primary,
-})
+	<div id="badge-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Badge",
+				Description: "A small label for status, counts, or categorization. Solid and soft styles, semantic colors, icons, indicators, notification counts, and animating dots.",
+			},
+			badgeSolidPreview(),
+			`@badge.Badge(badge.Config{Text: "Default", Variant: badge.Default})
+@badge.Badge(badge.Config{Text: "Primary", Variant: badge.Primary})
+@badge.Badge(badge.Config{Text: "Success", Variant: badge.Success})
+@badge.Badge(badge.Config{Text: "Danger", Variant: badge.Danger})`,
+		)
 
-// Soft Style Badge
-@badge.Badge(badge.Config{
-    Text:    "Active",
-    Variant: badge.Success,
-    Style:   badge.StyleSoft,
-})
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Soft Style",
+				Description: "Style: badge.StyleSoft swaps the solid fill for a subtle tinted background with a border.",
+			},
+			badgeSoftPreview(),
+			`@badge.Badge(badge.Config{Text: "Active", Variant: badge.Success, Style: badge.StyleSoft})`,
+		)
 
-// Badge with Icon
-@badge.Badge(badge.Config{
-    Text:    "Verified",
-    Variant: badge.Info,
-    Icon:    checkIcon,
-})
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Icons",
+				Description: "Pass any templ.Component as Icon to render it before the text.",
+			},
+			badgeIconsPreview(),
+			`@badge.Badge(badge.Config{Text: "Verified", Variant: badge.Info, Icon: checkIcon()})`,
+		)
 
-// Badge with Indicator
-@badge.Badge(badge.Config{
-    Text:      "Live",
-    Variant:   badge.Danger,
-    Indicator: true,
-})
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Indicators",
+				Description: "Indicator: true prepends a small status dot tinted to the variant.",
+			},
+			badgeIndicatorPreview(),
+			`@badge.Badge(badge.Config{Text: "Live", Variant: badge.Danger, Indicator: true})`,
+		)
 
-// Notification Badge on Button
-<button class="relative" aria-label="notifications">
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Notification Badges",
+				Description: "badge.NotificationBadge(n) renders a count bubble and badge.NotificationDot() a bare dot — position them on a relative parent (e.g. an icon button).",
+			},
+			badgeNotificationPreview(),
+			`<button class="relative" aria-label="notifications">
     @icons.Bell()
     @badge.NotificationBadge(5)
 </button>
-
-// Notification Dot
-<button class="relative" aria-label="messages">
-    @icons.Message()
+<button class="relative" aria-label="alerts">
+    @icons.Bell()
     @badge.NotificationDot()
-</button>
+</button>`,
+		)
 
-// Animating Notification Dot
-@badge.AnimatingDot(badge.Danger)`,
-	)
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Animating Dots",
+				Description: "badge.AnimatingDot(variant) renders a pulsing presence dot.",
+			},
+			badgeAnimatingPreview(),
+			`@badge.AnimatingDot(badge.Danger)`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Sizes",
+				Description: "Three sizes via Size: badge.SizeSM, badge.SizeMD (default), badge.SizeLG.",
+			},
+			badgeSizesPreview(),
+			`@badge.Badge(badge.Config{Text: "Small", Variant: badge.Primary, Size: badge.SizeSM})
+@badge.Badge(badge.Config{Text: "Large", Variant: badge.Primary, Size: badge.SizeLG})`,
+		)
+	</div>
+	// API reference lives outside #badge-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Text", Type: "string", Default: `""`, Description: "Badge label text."},
+		{Name: "Variant", Type: "Variant", Default: "Default", Description: `Color: "default", "inverse", "primary", "secondary", "info", "success", "warning", "danger".`},
+		{Name: "Style", Type: "Style", Default: "StyleSolid", Description: `Fill style: "solid" or "soft".`},
+		{Name: "Size", Type: "Size", Default: "SizeMD", Description: `Size: "sm", "md", "lg".`},
+		{Name: "Icon", Type: "templ.Component", Default: "nil", Description: "Optional leading icon component."},
+		{Name: "Indicator", Type: "bool", Default: "false", Description: "Prepend a small status dot."},
+		{Name: "IndicatorColor", Type: "string", Default: `""`, Description: "Override the indicator dot color."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the badge."},
+	})
 }
 
-// badgeDemoPreview renders the Goshtoso badge preview
-templ badgeDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Solid Badges (All Variants)
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Solid Badges</h4>
-			<div class="flex flex-wrap gap-2">
-				@badge.Badge(badge.Config{Text: "Default", Variant: badge.Default})
-				@badge.Badge(badge.Config{Text: "Primary", Variant: badge.Primary})
-				@badge.Badge(badge.Config{Text: "Secondary", Variant: badge.Secondary})
-				@badge.Badge(badge.Config{Text: "Info", Variant: badge.Info})
-				@badge.Badge(badge.Config{Text: "Success", Variant: badge.Success})
-				@badge.Badge(badge.Config{Text: "Warning", Variant: badge.Warning})
-				@badge.Badge(badge.Config{Text: "Danger", Variant: badge.Danger})
-			</div>
+// badgeSolidPreview renders all solid color variants.
+templ badgeSolidPreview() {
+	<div id="badge-solid" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-2">
+			@badge.Badge(badge.Config{Text: "Default", Variant: badge.Default})
+			@badge.Badge(badge.Config{Text: "Primary", Variant: badge.Primary})
+			@badge.Badge(badge.Config{Text: "Secondary", Variant: badge.Secondary})
+			@badge.Badge(badge.Config{Text: "Info", Variant: badge.Info})
+			@badge.Badge(badge.Config{Text: "Success", Variant: badge.Success})
+			@badge.Badge(badge.Config{Text: "Warning", Variant: badge.Warning})
+			@badge.Badge(badge.Config{Text: "Danger", Variant: badge.Danger})
 		</div>
+	</div>
+}
 
-		// Soft Style Badges
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Soft Style Badges</h4>
-			<div class="flex flex-wrap gap-2">
-				@badge.Badge(badge.Config{Text: "Default", Variant: badge.Default, Style: badge.StyleSoft})
-				@badge.Badge(badge.Config{Text: "Primary", Variant: badge.Primary, Style: badge.StyleSoft})
-				@badge.Badge(badge.Config{Text: "Secondary", Variant: badge.Secondary, Style: badge.StyleSoft})
-				@badge.Badge(badge.Config{Text: "Info", Variant: badge.Info, Style: badge.StyleSoft})
-				@badge.Badge(badge.Config{Text: "Success", Variant: badge.Success, Style: badge.StyleSoft})
-				@badge.Badge(badge.Config{Text: "Warning", Variant: badge.Warning, Style: badge.StyleSoft})
-				@badge.Badge(badge.Config{Text: "Danger", Variant: badge.Danger, Style: badge.StyleSoft})
-			</div>
+// badgeSoftPreview renders all soft-style variants.
+templ badgeSoftPreview() {
+	<div id="badge-soft" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-2">
+			@badge.Badge(badge.Config{Text: "Default", Variant: badge.Default, Style: badge.StyleSoft})
+			@badge.Badge(badge.Config{Text: "Primary", Variant: badge.Primary, Style: badge.StyleSoft})
+			@badge.Badge(badge.Config{Text: "Secondary", Variant: badge.Secondary, Style: badge.StyleSoft})
+			@badge.Badge(badge.Config{Text: "Info", Variant: badge.Info, Style: badge.StyleSoft})
+			@badge.Badge(badge.Config{Text: "Success", Variant: badge.Success, Style: badge.StyleSoft})
+			@badge.Badge(badge.Config{Text: "Warning", Variant: badge.Warning, Style: badge.StyleSoft})
+			@badge.Badge(badge.Config{Text: "Danger", Variant: badge.Danger, Style: badge.StyleSoft})
 		</div>
+	</div>
+}
 
-		// Badges with Icons
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With Icons</h4>
-			<div class="flex flex-wrap gap-2">
-				@badge.Badge(badge.Config{
-					Text:    "Penguin",
-					Variant: badge.Primary,
-					Icon:    penguinIcon(),
-				})
-				@badge.Badge(badge.Config{
-					Text:    "Filter",
-					Variant: badge.Secondary,
-					Icon:    closeIcon(),
-				})
-				@badge.Badge(badge.Config{
-					Text:    "Verified",
-					Variant: badge.Info,
-					Icon:    checkIcon(),
-				})
-				@badge.Badge(badge.Config{
-					Text:    "Active",
-					Variant: badge.Success,
-					Icon:    checkCircleIcon(),
-				})
-				@badge.Badge(badge.Config{
-					Text:    "Warning",
-					Variant: badge.Warning,
-					Icon:    shieldIcon(),
-				})
-				@badge.Badge(badge.Config{
-					Text:    "Error",
-					Variant: badge.Danger,
-					Icon:    alertIcon(),
-				})
-			</div>
+// badgeIconsPreview renders badges with leading icons.
+templ badgeIconsPreview() {
+	<div id="badge-icons" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-2">
+			@badge.Badge(badge.Config{Text: "Penguin", Variant: badge.Primary, Icon: penguinIcon()})
+			@badge.Badge(badge.Config{Text: "Filter", Variant: badge.Secondary, Icon: closeIcon()})
+			@badge.Badge(badge.Config{Text: "Verified", Variant: badge.Info, Icon: checkIcon()})
+			@badge.Badge(badge.Config{Text: "Active", Variant: badge.Success, Icon: checkCircleIcon()})
+			@badge.Badge(badge.Config{Text: "Warning", Variant: badge.Warning, Icon: shieldIcon()})
+			@badge.Badge(badge.Config{Text: "Error", Variant: badge.Danger, Icon: alertIcon()})
 		</div>
+	</div>
+}
 
-		// Badges with Indicator
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With Indicators</h4>
-			<div class="flex flex-wrap gap-2">
-				@badge.Badge(badge.Config{Text: "Default", Variant: badge.Default, Indicator: true})
-				@badge.Badge(badge.Config{Text: "Primary", Variant: badge.Primary, Indicator: true})
-				@badge.Badge(badge.Config{Text: "Info", Variant: badge.Info, Indicator: true})
-				@badge.Badge(badge.Config{Text: "Success", Variant: badge.Success, Indicator: true})
-				@badge.Badge(badge.Config{Text: "Warning", Variant: badge.Warning, Indicator: true})
-				@badge.Badge(badge.Config{Text: "Danger", Variant: badge.Danger, Indicator: true})
-			</div>
+// badgeIndicatorPreview renders badges with status indicators.
+templ badgeIndicatorPreview() {
+	<div id="badge-indicators" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-2">
+			@badge.Badge(badge.Config{Text: "Default", Variant: badge.Default, Indicator: true})
+			@badge.Badge(badge.Config{Text: "Primary", Variant: badge.Primary, Indicator: true})
+			@badge.Badge(badge.Config{Text: "Info", Variant: badge.Info, Indicator: true})
+			@badge.Badge(badge.Config{Text: "Success", Variant: badge.Success, Indicator: true})
+			@badge.Badge(badge.Config{Text: "Warning", Variant: badge.Warning, Indicator: true})
+			@badge.Badge(badge.Config{Text: "Danger", Variant: badge.Danger, Indicator: true})
 		</div>
+	</div>
+}
 
-		// Notification Badges
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Notification Badges</h4>
-			<div class="flex items-center gap-6">
-				// With count
-				<button class="relative w-fit text-on-surface dark:text-on-surface-dark" aria-label="notifications">
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" class="size-8">
-						<path fill-rule="evenodd" d="M5.25 9a6.75 6.75 0 0113.5 0v.75c0 2.123.8 4.057 2.118 5.52a.75.75 0 01-.297 1.206c-1.544.57-3.16.99-4.831 1.243a3.75 3.75 0 11-7.48 0 24.585 24.585 0 01-4.831-1.244.75.75 0 01-.298-1.205A8.217 8.217 0 005.25 9.75V9zm4.502 8.9a2.25 2.25 0 104.496 0 25.057 25.057 0 01-4.496 0z" clip-rule="evenodd"/>
-					</svg>
-					<span class="sr-only">notifications</span>
-					@badge.NotificationBadge(99)
-				</button>
-
-				// With count (low)
-				<button class="relative w-fit text-on-surface dark:text-on-surface-dark" aria-label="messages">
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" class="size-8">
-						<path fill-rule="evenodd" d="M4.848 2.771A49.144 49.144 0 0112 2.25c2.43 0 4.817.178 7.152.52 1.978.292 3.348 2.024 3.348 3.97v6.02c0 1.946-1.37 3.678-3.348 3.97-1.94.284-3.916.455-5.922.505a.39.39 0 00-.266.112L8.78 21.53A.75.75 0 017.5 21v-3.955a48.842 48.842 0 01-2.652-.316c-1.978-.29-3.348-2.024-3.348-3.97V6.741c0-1.946 1.37-3.68 3.348-3.97z" clip-rule="evenodd"/>
-					</svg>
-					@badge.NotificationBadge(5)
-				</button>
-
-				// Just a dot
-				<button class="relative w-fit text-on-surface dark:text-on-surface-dark" aria-label="alerts">
-					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" class="size-8">
-						<path fill-rule="evenodd" d="M10.339 2.53a.75.75 0 011.262 0 8.27 8.27 0 003.37 2.648.75.75 0 01-.383 1.45 6.77 6.77 0 01-2.613-2.122l-.008-.01a.75.75 0 00-1.188 0l-.008.01A6.77 6.77 0 018.41 6.628a.75.75 0 11-.383-1.45 8.27 8.27 0 003.37-2.648zM9.855 8.25a.75.75 0 01.75-.75h3a.75.75 0 010 1.5h-3a.75.75 0 01-.75-.75zM6.75 9.75a.75.75 0 000 1.5h.75v6a.75.75 0 001.5 0v-6h.75a.75.75 0 000-1.5h-3zm6.75 0a.75.75 0 000 1.5h.75v6a.75.75 0 001.5 0v-6h.75a.75.75 0 000-1.5h-3z" clip-rule="evenodd"/>
-					</svg>
-					@badge.NotificationDot()
-				</button>
-			</div>
+// badgeNotificationPreview renders notification count badges and dots.
+templ badgeNotificationPreview() {
+	<div id="badge-notification" class="w-full max-w-2xl mx-auto">
+		<div class="flex items-center gap-6">
+			<button class="relative w-fit text-on-surface dark:text-on-surface-dark" aria-label="notifications">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" class="size-8">
+					<path fill-rule="evenodd" d="M5.25 9a6.75 6.75 0 0113.5 0v.75c0 2.123.8 4.057 2.118 5.52a.75.75 0 01-.297 1.206c-1.544.57-3.16.99-4.831 1.243a3.75 3.75 0 11-7.48 0 24.585 24.585 0 01-4.831-1.244.75.75 0 01-.298-1.205A8.217 8.217 0 005.25 9.75V9zm4.502 8.9a2.25 2.25 0 104.496 0 25.057 25.057 0 01-4.496 0z" clip-rule="evenodd"></path>
+				</svg>
+				<span class="sr-only">notifications</span>
+				@badge.NotificationBadge(99)
+			</button>
+			<button class="relative w-fit text-on-surface dark:text-on-surface-dark" aria-label="messages">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" class="size-8">
+					<path fill-rule="evenodd" d="M4.848 2.771A49.144 49.144 0 0112 2.25c2.43 0 4.817.178 7.152.52 1.978.292 3.348 2.024 3.348 3.97v6.02c0 1.946-1.37 3.678-3.348 3.97-1.94.284-3.916.455-5.922.505a.39.39 0 00-.266.112L8.78 21.53A.75.75 0 017.5 21v-3.955a48.842 48.842 0 01-2.652-.316c-1.978-.29-3.348-2.024-3.348-3.97V6.741c0-1.946 1.37-3.68 3.348-3.97z" clip-rule="evenodd"></path>
+				</svg>
+				@badge.NotificationBadge(5)
+			</button>
+			<button class="relative w-fit text-on-surface dark:text-on-surface-dark" aria-label="alerts">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor" class="size-8">
+					<path fill-rule="evenodd" d="M10.339 2.53a.75.75 0 011.262 0 8.27 8.27 0 003.37 2.648.75.75 0 01-.383 1.45 6.77 6.77 0 01-2.613-2.122l-.008-.01a.75.75 0 00-1.188 0l-.008.01A6.77 6.77 0 018.41 6.628a.75.75 0 11-.383-1.45 8.27 8.27 0 003.37-2.648zM9.855 8.25a.75.75 0 01.75-.75h3a.75.75 0 010 1.5h-3a.75.75 0 01-.75-.75zM6.75 9.75a.75.75 0 000 1.5h.75v6a.75.75 0 001.5 0v-6h.75a.75.75 0 000-1.5h-3zm6.75 0a.75.75 0 000 1.5h.75v6a.75.75 0 001.5 0v-6h.75a.75.75 0 000-1.5h-3z" clip-rule="evenodd"></path>
+				</svg>
+				@badge.NotificationDot()
+			</button>
 		</div>
+	</div>
+}
 
-		// Animating Dots
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Animating Dots</h4>
-			<div class="flex items-center gap-4">
-				@badge.AnimatingDot(badge.Primary)
-				@badge.AnimatingDot(badge.Secondary)
-				@badge.AnimatingDot(badge.Info)
-				@badge.AnimatingDot(badge.Success)
-				@badge.AnimatingDot(badge.Warning)
-				@badge.AnimatingDot(badge.Danger)
-			</div>
+// badgeAnimatingPreview renders the animating presence dots.
+templ badgeAnimatingPreview() {
+	<div id="badge-animating" class="w-full max-w-2xl mx-auto">
+		<div class="flex items-center gap-4">
+			@badge.AnimatingDot(badge.Primary)
+			@badge.AnimatingDot(badge.Secondary)
+			@badge.AnimatingDot(badge.Info)
+			@badge.AnimatingDot(badge.Success)
+			@badge.AnimatingDot(badge.Warning)
+			@badge.AnimatingDot(badge.Danger)
 		</div>
+	</div>
+}
 
-		// Different Sizes
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Sizes</h4>
-			<div class="flex items-center gap-2">
-				@badge.Badge(badge.Config{Text: "Small", Variant: badge.Primary, Size: badge.SizeSM})
-				@badge.Badge(badge.Config{Text: "Medium", Variant: badge.Primary, Size: badge.SizeMD})
-				@badge.Badge(badge.Config{Text: "Large", Variant: badge.Primary, Size: badge.SizeLG})
-			</div>
+// badgeSizesPreview renders the three badge sizes.
+templ badgeSizesPreview() {
+	<div id="badge-sizes" class="w-full max-w-2xl mx-auto">
+		<div class="flex items-center gap-2">
+			@badge.Badge(badge.Config{Text: "Small", Variant: badge.Primary, Size: badge.SizeSM})
+			@badge.Badge(badge.Config{Text: "Medium", Variant: badge.Primary, Size: badge.SizeMD})
+			@badge.Badge(badge.Config{Text: "Large", Variant: badge.Primary, Size: badge.SizeLG})
 		</div>
 	</div>
 }

--- a/internal/pages/demo/components/badge_templ.go
+++ b/internal/pages/demo/components/badge_templ.go
@@ -43,7 +43,9 @@ func BadgeDemoPage() templ.Component {
 	})
 }
 
-// badgeDemoContent renders the actual content inside the layout
+// badgeDemoContent renders the demo. Each badge variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/badge).
+// Wrapped in #badge-fragment.
 func badgeDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,54 +67,112 @@ func badgeDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"badge-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Badge",
-				Description: "A badge is a small label that displays additional information, status, or counts. Used for notifications, status indicators, and categorization.",
+				Description: "A small label for status, counts, or categorization. Solid and soft styles, semantic colors, icons, indicators, notification counts, and animating dots.",
 			},
-			badgeDemoPreview(),
-			`// Simple Badge
-@badge.Badge(badge.Config{
-    Text:    "New",
-    Variant: badge.Primary,
-})
-
-// Soft Style Badge
-@badge.Badge(badge.Config{
-    Text:    "Active",
-    Variant: badge.Success,
-    Style:   badge.StyleSoft,
-})
-
-// Badge with Icon
-@badge.Badge(badge.Config{
-    Text:    "Verified",
-    Variant: badge.Info,
-    Icon:    checkIcon,
-})
-
-// Badge with Indicator
-@badge.Badge(badge.Config{
-    Text:      "Live",
-    Variant:   badge.Danger,
-    Indicator: true,
-})
-
-// Notification Badge on Button
-<button class="relative" aria-label="notifications">
+			badgeSolidPreview(),
+			`@badge.Badge(badge.Config{Text: "Default", Variant: badge.Default})
+@badge.Badge(badge.Config{Text: "Primary", Variant: badge.Primary})
+@badge.Badge(badge.Config{Text: "Success", Variant: badge.Success})
+@badge.Badge(badge.Config{Text: "Danger", Variant: badge.Danger})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Soft Style",
+				Description: "Style: badge.StyleSoft swaps the solid fill for a subtle tinted background with a border.",
+			},
+			badgeSoftPreview(),
+			`@badge.Badge(badge.Config{Text: "Active", Variant: badge.Success, Style: badge.StyleSoft})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Icons",
+				Description: "Pass any templ.Component as Icon to render it before the text.",
+			},
+			badgeIconsPreview(),
+			`@badge.Badge(badge.Config{Text: "Verified", Variant: badge.Info, Icon: checkIcon()})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Indicators",
+				Description: "Indicator: true prepends a small status dot tinted to the variant.",
+			},
+			badgeIndicatorPreview(),
+			`@badge.Badge(badge.Config{Text: "Live", Variant: badge.Danger, Indicator: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Notification Badges",
+				Description: "badge.NotificationBadge(n) renders a count bubble and badge.NotificationDot() a bare dot — position them on a relative parent (e.g. an icon button).",
+			},
+			badgeNotificationPreview(),
+			`<button class="relative" aria-label="notifications">
     @icons.Bell()
     @badge.NotificationBadge(5)
 </button>
-
-// Notification Dot
-<button class="relative" aria-label="messages">
-    @icons.Message()
+<button class="relative" aria-label="alerts">
+    @icons.Bell()
     @badge.NotificationDot()
-</button>
-
-// Animating Notification Dot
-@badge.AnimatingDot(badge.Danger)`,
+</button>`,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Animating Dots",
+				Description: "badge.AnimatingDot(variant) renders a pulsing presence dot.",
+			},
+			badgeAnimatingPreview(),
+			`@badge.AnimatingDot(badge.Danger)`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Sizes",
+				Description: "Three sizes via Size: badge.SizeSM, badge.SizeMD (default), badge.SizeLG.",
+			},
+			badgeSizesPreview(),
+			`@badge.Badge(badge.Config{Text: "Small", Variant: badge.Primary, Size: badge.SizeSM})
+@badge.Badge(badge.Config{Text: "Large", Variant: badge.Primary, Size: badge.SizeLG})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Text", Type: "string", Default: `""`, Description: "Badge label text."},
+			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Color: "default", "inverse", "primary", "secondary", "info", "success", "warning", "danger".`},
+			{Name: "Style", Type: "Style", Default: "StyleSolid", Description: `Fill style: "solid" or "soft".`},
+			{Name: "Size", Type: "Size", Default: "SizeMD", Description: `Size: "sm", "md", "lg".`},
+			{Name: "Icon", Type: "templ.Component", Default: "nil", Description: "Optional leading icon component."},
+			{Name: "Indicator", Type: "bool", Default: "false", Description: "Prepend a small status dot."},
+			{Name: "IndicatorColor", Type: "string", Default: `""`, Description: "Override the indicator dot color."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the badge."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -120,8 +180,8 @@ func badgeDemoContent() templ.Component {
 	})
 }
 
-// badgeDemoPreview renders the Goshtoso badge preview
-func badgeDemoPreview() templ.Component {
+// badgeSolidPreview renders all solid color variants.
+func badgeSolidPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -142,7 +202,7 @@ func badgeDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Solid Badges</h4><div class=\"flex flex-wrap gap-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"badge-solid\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -174,7 +234,37 @@ func badgeDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Soft Style Badges</h4><div class=\"flex flex-wrap gap-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// badgeSoftPreview renders all soft-style variants.
+func badgeSoftPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"badge-soft\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -206,59 +296,95 @@ func badgeDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With Icons</h4><div class=\"flex flex-wrap gap-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = badge.Badge(badge.Config{
-			Text:    "Penguin",
-			Variant: badge.Primary,
-			Icon:    penguinIcon(),
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		return nil
+	})
+}
+
+// badgeIconsPreview renders badges with leading icons.
+func badgeIconsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"badge-icons\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = badge.Badge(badge.Config{
-			Text:    "Filter",
-			Variant: badge.Secondary,
-			Icon:    closeIcon(),
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = badge.Badge(badge.Config{Text: "Penguin", Variant: badge.Primary, Icon: penguinIcon()}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = badge.Badge(badge.Config{
-			Text:    "Verified",
-			Variant: badge.Info,
-			Icon:    checkIcon(),
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = badge.Badge(badge.Config{Text: "Filter", Variant: badge.Secondary, Icon: closeIcon()}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = badge.Badge(badge.Config{
-			Text:    "Active",
-			Variant: badge.Success,
-			Icon:    checkCircleIcon(),
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = badge.Badge(badge.Config{Text: "Verified", Variant: badge.Info, Icon: checkIcon()}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = badge.Badge(badge.Config{
-			Text:    "Warning",
-			Variant: badge.Warning,
-			Icon:    shieldIcon(),
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = badge.Badge(badge.Config{Text: "Active", Variant: badge.Success, Icon: checkCircleIcon()}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = badge.Badge(badge.Config{
-			Text:    "Error",
-			Variant: badge.Danger,
-			Icon:    alertIcon(),
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = badge.Badge(badge.Config{Text: "Warning", Variant: badge.Warning, Icon: shieldIcon()}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With Indicators</h4><div class=\"flex flex-wrap gap-2\">")
+		templ_7745c5c3_Err = badge.Badge(badge.Config{Text: "Error", Variant: badge.Danger, Icon: alertIcon()}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// badgeIndicatorPreview renders badges with status indicators.
+func badgeIndicatorPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"badge-indicators\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -286,7 +412,37 @@ func badgeDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Notification Badges</h4><div class=\"flex items-center gap-6\"><button class=\"relative w-fit text-on-surface dark:text-on-surface-dark\" aria-label=\"notifications\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-8\"><path fill-rule=\"evenodd\" d=\"M5.25 9a6.75 6.75 0 0113.5 0v.75c0 2.123.8 4.057 2.118 5.52a.75.75 0 01-.297 1.206c-1.544.57-3.16.99-4.831 1.243a3.75 3.75 0 11-7.48 0 24.585 24.585 0 01-4.831-1.244.75.75 0 01-.298-1.205A8.217 8.217 0 005.25 9.75V9zm4.502 8.9a2.25 2.25 0 104.496 0 25.057 25.057 0 01-4.496 0z\" clip-rule=\"evenodd\"></path></svg> <span class=\"sr-only\">notifications</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// badgeNotificationPreview renders notification count badges and dots.
+func badgeNotificationPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"badge-notification\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex items-center gap-6\"><button class=\"relative w-fit text-on-surface dark:text-on-surface-dark\" aria-label=\"notifications\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-8\"><path fill-rule=\"evenodd\" d=\"M5.25 9a6.75 6.75 0 0113.5 0v.75c0 2.123.8 4.057 2.118 5.52a.75.75 0 01-.297 1.206c-1.544.57-3.16.99-4.831 1.243a3.75 3.75 0 11-7.48 0 24.585 24.585 0 01-4.831-1.244.75.75 0 01-.298-1.205A8.217 8.217 0 005.25 9.75V9zm4.502 8.9a2.25 2.25 0 104.496 0 25.057 25.057 0 01-4.496 0z\" clip-rule=\"evenodd\"></path></svg> <span class=\"sr-only\">notifications</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -294,7 +450,7 @@ func badgeDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</button><button class=\"relative w-fit text-on-surface dark:text-on-surface-dark\" aria-label=\"messages\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-8\"><path fill-rule=\"evenodd\" d=\"M4.848 2.771A49.144 49.144 0 0112 2.25c2.43 0 4.817.178 7.152.52 1.978.292 3.348 2.024 3.348 3.97v6.02c0 1.946-1.37 3.678-3.348 3.97-1.94.284-3.916.455-5.922.505a.39.39 0 00-.266.112L8.78 21.53A.75.75 0 017.5 21v-3.955a48.842 48.842 0 01-2.652-.316c-1.978-.29-3.348-2.024-3.348-3.97V6.741c0-1.946 1.37-3.68 3.348-3.97z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</button> <button class=\"relative w-fit text-on-surface dark:text-on-surface-dark\" aria-label=\"messages\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-8\"><path fill-rule=\"evenodd\" d=\"M4.848 2.771A49.144 49.144 0 0112 2.25c2.43 0 4.817.178 7.152.52 1.978.292 3.348 2.024 3.348 3.97v6.02c0 1.946-1.37 3.678-3.348 3.97-1.94.284-3.916.455-5.922.505a.39.39 0 00-.266.112L8.78 21.53A.75.75 0 017.5 21v-3.955a48.842 48.842 0 01-2.652-.316c-1.978-.29-3.348-2.024-3.348-3.97V6.741c0-1.946 1.37-3.68 3.348-3.97z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -302,7 +458,7 @@ func badgeDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</button><button class=\"relative w-fit text-on-surface dark:text-on-surface-dark\" aria-label=\"alerts\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-8\"><path fill-rule=\"evenodd\" d=\"M10.339 2.53a.75.75 0 011.262 0 8.27 8.27 0 003.37 2.648.75.75 0 01-.383 1.45 6.77 6.77 0 01-2.613-2.122l-.008-.01a.75.75 0 00-1.188 0l-.008.01A6.77 6.77 0 018.41 6.628a.75.75 0 11-.383-1.45 8.27 8.27 0 003.37-2.648zM9.855 8.25a.75.75 0 01.75-.75h3a.75.75 0 010 1.5h-3a.75.75 0 01-.75-.75zM6.75 9.75a.75.75 0 000 1.5h.75v6a.75.75 0 001.5 0v-6h.75a.75.75 0 000-1.5h-3zm6.75 0a.75.75 0 000 1.5h.75v6a.75.75 0 001.5 0v-6h.75a.75.75 0 000-1.5h-3z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</button> <button class=\"relative w-fit text-on-surface dark:text-on-surface-dark\" aria-label=\"alerts\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-8\"><path fill-rule=\"evenodd\" d=\"M10.339 2.53a.75.75 0 011.262 0 8.27 8.27 0 003.37 2.648.75.75 0 01-.383 1.45 6.77 6.77 0 01-2.613-2.122l-.008-.01a.75.75 0 00-1.188 0l-.008.01A6.77 6.77 0 018.41 6.628a.75.75 0 11-.383-1.45 8.27 8.27 0 003.37-2.648zM9.855 8.25a.75.75 0 01.75-.75h3a.75.75 0 010 1.5h-3a.75.75 0 01-.75-.75zM6.75 9.75a.75.75 0 000 1.5h.75v6a.75.75 0 001.5 0v-6h.75a.75.75 0 000-1.5h-3zm6.75 0a.75.75 0 000 1.5h.75v6a.75.75 0 001.5 0v-6h.75a.75.75 0 000-1.5h-3z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -310,7 +466,37 @@ func badgeDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</button></div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Animating Dots</h4><div class=\"flex items-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</button></div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// badgeAnimatingPreview renders the animating presence dots.
+func badgeAnimatingPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"badge-animating\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex items-center gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -338,7 +524,37 @@ func badgeDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Sizes</h4><div class=\"flex items-center gap-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// badgeSizesPreview renders the three badge sizes.
+func badgeSizesPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"badge-sizes\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex items-center gap-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -354,7 +570,7 @@ func badgeDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -379,12 +595,12 @@ func penguinIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var4 == nil {
-			templ_7745c5c3_Var4 = templ.NopComponent
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-3\"><path fill-rule=\"evenodd\" d=\"M11.097 1.515a.75.75 0 01.589.882L10.666 7.5h4.47l1.079-5.397a.75.75 0 111.47.294L16.665 7.5h3.585a.75.75 0 010 1.5h-3.885l-1.2 6h3.585a.75.75 0 010 1.5h-3.885l-1.08 5.397a.75.75 0 11-1.47-.294l1.02-5.103h-4.47l-1.08 5.397a.75.75 0 01-1.47-.294l1.02-5.103H3.75a.75.75 0 110-1.5h3.885l1.2-6H5.25a.75.75 0 010-1.5h3.885l1.08-5.397a.75.75 0 01.882-.588zM10.365 9l-1.2 6h4.47l1.2-6h-4.47z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-3\"><path fill-rule=\"evenodd\" d=\"M11.097 1.515a.75.75 0 01.589.882L10.666 7.5h4.47l1.079-5.397a.75.75 0 111.47.294L16.665 7.5h3.585a.75.75 0 010 1.5h-3.885l-1.2 6h3.585a.75.75 0 010 1.5h-3.885l-1.08 5.397a.75.75 0 11-1.47-.294l1.02-5.103h-4.47l-1.08 5.397a.75.75 0 01-1.47-.294l1.02-5.103H3.75a.75.75 0 110-1.5h3.885l1.2-6H5.25a.75.75 0 010-1.5h3.885l1.08-5.397a.75.75 0 01.882-.588zM10.365 9l-1.2 6h4.47l1.2-6h-4.47z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -408,12 +624,12 @@ func closeIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var5 == nil {
-			templ_7745c5c3_Var5 = templ.NopComponent
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" stroke=\"currentColor\" fill=\"none\" stroke-width=\"1.4\" class=\"size-4\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M6 18L18 6M6 6l12 12\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" stroke=\"currentColor\" fill=\"none\" stroke-width=\"1.4\" class=\"size-4\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M6 18L18 6M6 6l12 12\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -437,12 +653,12 @@ func checkIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M8.603 3.799A4.49 4.49 0 0112 2.25c1.357 0 2.573.6 3.397 1.549a4.49 4.49 0 013.498 1.307 4.491 4.491 0 011.307 3.497A4.49 4.49 0 0121.75 12a4.49 4.49 0 01-1.549 3.397 4.491 4.491 0 01-1.307 3.497 4.491 4.491 0 01-3.497 1.307A4.49 4.49 0 0112 21.75a4.49 4.49 0 01-3.397-1.549 4.49 4.49 0 01-3.498-1.306 4.491 4.491 0 01-1.307-3.498A4.49 4.49 0 012.25 12c0-1.357.6-2.573 1.549-3.397a4.49 4.49 0 011.307-3.497 4.49 4.49 0 013.497-1.307zm7.007 6.387a.75.75 0 10-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.14-.094l3.75-5.25z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M8.603 3.799A4.49 4.49 0 0112 2.25c1.357 0 2.573.6 3.397 1.549a4.49 4.49 0 013.498 1.307 4.491 4.491 0 011.307 3.497A4.49 4.49 0 0121.75 12a4.49 4.49 0 01-1.549 3.397 4.491 4.491 0 01-1.307 3.497 4.491 4.491 0 01-3.497 1.307A4.49 4.49 0 0112 21.75a4.49 4.49 0 01-3.397-1.549 4.49 4.49 0 01-3.498-1.306 4.491 4.491 0 01-1.307-3.498A4.49 4.49 0 012.25 12c0-1.357.6-2.573 1.549-3.397a4.49 4.49 0 011.307-3.497 4.49 4.49 0 013.497-1.307zm7.007 6.387a.75.75 0 10-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.14-.094l3.75-5.25z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -466,12 +682,12 @@ func checkCircleIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm13.36-1.814a.75.75 0 10-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.14-.094l3.75-5.25z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm13.36-1.814a.75.75 0 10-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.14-.094l3.75-5.25z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -495,12 +711,12 @@ func shieldIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M11.484 2.17a.75.75 0 011.032 0 11.209 11.209 0 007.877 3.08.75.75 0 01.722.515 12.74 12.74 0 01.635 3.985c0 5.942-4.064 10.933-9.563 12.348a.749.749 0 01-.374 0C6.314 20.683 2.25 15.692 2.25 9.75c0-1.39.223-2.73.635-3.985a.75.75 0 01.722-.516l.143.001c2.996 0 5.718-1.17 7.734-3.08zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zM12 15a.75.75 0 00-.75.75v.008c0 .414.336.75.75.75h.008a.75.75 0 00.75-.75v-.008a.75.75 0 00-.75-.75H12z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M11.484 2.17a.75.75 0 011.032 0 11.209 11.209 0 007.877 3.08.75.75 0 01.722.515 12.74 12.74 0 01.635 3.985c0 5.942-4.064 10.933-9.563 12.348a.749.749 0 01-.374 0C6.314 20.683 2.25 15.692 2.25 9.75c0-1.39.223-2.73.635-3.985a.75.75 0 01.722-.516l.143.001c2.996 0 5.718-1.17 7.734-3.08zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zM12 15a.75.75 0 00-.75.75v.008c0 .414.336.75.75.75h.008a.75.75 0 00.75-.75v-.008a.75.75 0 00-.75-.75H12z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -524,12 +740,12 @@ func alertIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zm0 8.25a.75.75 0 100-1.5.75.75 0 000 1.5z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003zM12 8.25a.75.75 0 01.75.75v3.75a.75.75 0 01-1.5 0V9a.75.75 0 01.75-.75zm0 8.25a.75.75 0 100-1.5.75.75 0 000 1.5z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/banner.templ
+++ b/internal/pages/demo/components/banner.templ
@@ -10,51 +10,68 @@ templ BannerDemoPage() {
 	@demo.Layout("Banner", "banner", bannerDemoContent())
 }
 
-// bannerDemoContent renders the actual content inside the layout
+// bannerDemoContent renders the demo. Each banner variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/banner). Wrapped in #banner-fragment.
 templ bannerDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Banner",
-			Description:   "A banner displays a prominent message at the top of a page or section. Used for announcements, promotions, alerts, and cookie consent.",
-		},
-		bannerDemoPreview(),
-		`// Simple Banner (Dismissible by default)
-@banner.Banner(banner.Config{
-    Text: "Limited Time Offer! Check out our deals",
-})
+	<div id="banner-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Banner",
+				Description: "A prominent page/section message for announcements, promotions, alerts, and cookie consent. Dismissible by default; supports CTAs, semantic colors, and a cookie-consent mode.",
+			},
+			bannerSimplePreview(),
+			`@banner.Banner(banner.Config{
+    Text: "Limited Time Offer! Explore exclusive deals & savings",
+})`,
+		)
 
-// Persistent Banner (Non-dismissible)
-@banner.Banner(banner.Config{
-    Text:       "Important announcement - cannot be dismissed",
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Persistent (Non-dismissible)",
+				Description: "Persistent: true removes the dismiss control so the message stays put.",
+			},
+			bannerPersistentPreview(),
+			`@banner.Banner(banner.Config{
+    Text:       "This banner cannot be dismissed by users",
     Persistent: true,
-})
+})`,
+		)
 
-// Banner with CTA Button
-@banner.Banner(banner.Config{
-    Text: "Get Fit Anywhere, Anytime",
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With CTA Button",
+				Description: "Attach a CTA config for an inline call-to-action (Href for a link, OnClick for an action).",
+			},
+			bannerCTAPreview(),
+			`@banner.Banner(banner.Config{
+    Text: "Get Fit Anywhere, Anytime 💪",
     CTA: &banner.CTAConfig{
         Text: "Start free trial",
         Href: "/signup",
     },
-})
+})`,
+		)
 
-// Fixed Position Banner (stays at top)
-@banner.Banner(banner.Config{
-    Text: "Important system maintenance scheduled",
-    Position: banner.PositionFixed,
-    Variant:  banner.Warning,
-})
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Color Variants",
+				Description: "Set Variant for semantic coloring: Default, Primary, Info, Success, Warning, Danger.",
+			},
+			bannerVariantsPreview(),
+			`@banner.Banner(banner.Config{Text: "Success! Your changes have been saved", Variant: banner.Success})
+@banner.Banner(banner.Config{Text: "Warning: Please review your settings", Variant: banner.Warning})`,
+		)
 
-// Colored Variants
-@banner.Banner(banner.Config{
-    Text: "Success! Your changes have been saved",
-    Variant: banner.Success,
-})
-
-// Cookie Consent Banner
-@banner.Banner(banner.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Cookie Consent",
+				Description: "CookieBanner: true plus a CookieConfig renders a corner-anchored consent card with accept/reject actions.",
+			},
+			bannerCookiePreview(),
+			`@banner.Banner(banner.Config{
     CookieBanner: true,
-    Text: "We use cookies to improve your experience",
+    Text:         "We use cookies to improve your experience.",
     CookieConfig: &banner.CookieBannerConfig{
         Title:        "Cookie Settings",
         AcceptText:   "Accept All",
@@ -63,75 +80,72 @@ templ bannerDemoContent() {
         RejectAction: "show = false",
     },
 })`,
-	)
+		)
+	</div>
+	// API reference lives outside #banner-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Text", Type: "string", Default: `""`, Description: "Banner message text."},
+		{Name: "Variant", Type: "Variant", Default: "Default", Description: `Color: "default", "primary", "info", "success", "warning", "danger".`},
+		{Name: "Position", Type: "Position", Default: "PositionRelative", Description: `Layout: "relative" (inline) or "fixed" (pinned to top).`},
+		{Name: "Persistent", Type: "bool", Default: "false", Description: "Remove the dismiss control."},
+		{Name: "DismissAction", Type: "string", Default: `""`, Description: "Extra Alpine expression run when dismissed."},
+		{Name: "CTA", Type: "*CTAConfig", Default: "nil", Description: "Inline call-to-action (Text + Href or OnClick)."},
+		{Name: "CookieBanner", Type: "bool", Default: "false", Description: "Render as a corner cookie-consent card."},
+		{Name: "CookieConfig", Type: "*CookieBannerConfig", Default: "nil", Description: "Cookie card content + accept/reject actions."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the banner."},
+	})
 }
 
-// bannerDemoPreview renders the Goshtoso banner preview
-templ bannerDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Simple Banner (Dismissible by default)
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Simple Banner (Dismissible by Default)</h4>
-			@banner.Banner(banner.Config{
-				Text: "Limited Time Offer! Explore exclusive deals & savings",
-			})
-		</div>
+// bannerSimplePreview renders the default dismissible banner.
+templ bannerSimplePreview() {
+	<div id="banner-simple" class="w-full max-w-2xl mx-auto">
+		@banner.Banner(banner.Config{
+			Text: "Limited Time Offer! Explore exclusive deals & savings",
+		})
+	</div>
+}
 
-		// Persistent Banner (Non-dismissible)
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Persistent Banner (Non-dismissible)</h4>
-			@banner.Banner(banner.Config{
-				Text:       "This banner cannot be dismissed by users",
-				Persistent: true,
-			})
-		</div>
+// bannerPersistentPreview renders the non-dismissible banner.
+templ bannerPersistentPreview() {
+	<div id="banner-persistent" class="w-full max-w-2xl mx-auto">
+		@banner.Banner(banner.Config{
+			Text:       "This banner cannot be dismissed by users",
+			Persistent: true,
+		})
+	</div>
+}
 
-		// Banner with CTA
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With CTA Button</h4>
-			@banner.Banner(banner.Config{
-				Text: "Get Fit Anywhere, Anytime 💪",
-				CTA: &banner.CTAConfig{
-					Text:    "Start free trial",
-					OnClick: "alert('Starting free trial...')",
-				},
-			})
-		</div>
+// bannerCTAPreview renders a banner with a CTA button.
+templ bannerCTAPreview() {
+	<div id="banner-cta" class="w-full max-w-2xl mx-auto">
+		@banner.Banner(banner.Config{
+			Text: "Get Fit Anywhere, Anytime 💪",
+			CTA: &banner.CTAConfig{
+				Text:    "Start free trial",
+				OnClick: "alert('Starting free trial...')",
+			},
+		})
+	</div>
+}
 
-		// Color Variants
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Color Variants</h4>
-			<div class="space-y-2">
-				@banner.Banner(banner.Config{
-					Text:    "Default variant banner",
-					Variant: banner.Default,
-				})
-				@banner.Banner(banner.Config{
-					Text:    "Primary variant for promotions",
-					Variant: banner.Primary,
-				})
-				@banner.Banner(banner.Config{
-					Text:    "Info variant for general information",
-					Variant: banner.Info,
-				})
-				@banner.Banner(banner.Config{
-					Text:    "Success! Operation completed successfully",
-					Variant: banner.Success,
-				})
-				@banner.Banner(banner.Config{
-					Text:    "Warning: Please review your settings",
-					Variant: banner.Warning,
-				})
-				@banner.Banner(banner.Config{
-					Text:    "Error: Something went wrong",
-					Variant: banner.Danger,
-				})
-			</div>
+// bannerVariantsPreview renders the semantic color variants.
+templ bannerVariantsPreview() {
+	<div id="banner-variants" class="w-full max-w-2xl mx-auto">
+		<div class="space-y-2">
+			@banner.Banner(banner.Config{Text: "Default variant banner", Variant: banner.Default})
+			@banner.Banner(banner.Config{Text: "Primary variant for promotions", Variant: banner.Primary})
+			@banner.Banner(banner.Config{Text: "Info variant for general information", Variant: banner.Info})
+			@banner.Banner(banner.Config{Text: "Success! Operation completed successfully", Variant: banner.Success})
+			@banner.Banner(banner.Config{Text: "Warning: Please review your settings", Variant: banner.Warning})
+			@banner.Banner(banner.Config{Text: "Error: Something went wrong", Variant: banner.Danger})
 		</div>
+	</div>
+}
 
-		// Cookie Consent Banner
+// bannerCookiePreview renders the cookie-consent banner inside a framed stage.
+templ bannerCookiePreview() {
+	<div id="banner-cookie" class="w-full max-w-2xl mx-auto">
 		<div class="relative h-48 overflow-hidden border border-outline dark:border-outline-dark rounded-radius">
-			<h4 class="absolute top-4 left-4 text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong z-10">Cookie Consent Banner (Bottom Right)</h4>
 			<div class="absolute inset-0 bg-surface dark:bg-surface-dark">
 				@banner.Banner(banner.Config{
 					CookieBanner: true,

--- a/internal/pages/demo/components/banner_templ.go
+++ b/internal/pages/demo/components/banner_templ.go
@@ -43,7 +43,9 @@ func BannerDemoPage() templ.Component {
 	})
 }
 
-// bannerDemoContent renders the actual content inside the layout
+// bannerDemoContent renders the demo. Each banner variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/banner). Wrapped in #banner-fragment.
 func bannerDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,49 +67,75 @@ func bannerDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"banner-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Banner",
-				Description: "A banner displays a prominent message at the top of a page or section. Used for announcements, promotions, alerts, and cookie consent.",
+				Description: "A prominent page/section message for announcements, promotions, alerts, and cookie consent. Dismissible by default; supports CTAs, semantic colors, and a cookie-consent mode.",
 			},
-			bannerDemoPreview(),
-			`// Simple Banner (Dismissible by default)
-@banner.Banner(banner.Config{
-    Text: "Limited Time Offer! Check out our deals",
-})
-
-// Persistent Banner (Non-dismissible)
-@banner.Banner(banner.Config{
-    Text:       "Important announcement - cannot be dismissed",
+			bannerSimplePreview(),
+			`@banner.Banner(banner.Config{
+    Text: "Limited Time Offer! Explore exclusive deals & savings",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Persistent (Non-dismissible)",
+				Description: "Persistent: true removes the dismiss control so the message stays put.",
+			},
+			bannerPersistentPreview(),
+			`@banner.Banner(banner.Config{
+    Text:       "This banner cannot be dismissed by users",
     Persistent: true,
-})
-
-// Banner with CTA Button
-@banner.Banner(banner.Config{
-    Text: "Get Fit Anywhere, Anytime",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With CTA Button",
+				Description: "Attach a CTA config for an inline call-to-action (Href for a link, OnClick for an action).",
+			},
+			bannerCTAPreview(),
+			`@banner.Banner(banner.Config{
+    Text: "Get Fit Anywhere, Anytime 💪",
     CTA: &banner.CTAConfig{
         Text: "Start free trial",
         Href: "/signup",
     },
-})
-
-// Fixed Position Banner (stays at top)
-@banner.Banner(banner.Config{
-    Text: "Important system maintenance scheduled",
-    Position: banner.PositionFixed,
-    Variant:  banner.Warning,
-})
-
-// Colored Variants
-@banner.Banner(banner.Config{
-    Text: "Success! Your changes have been saved",
-    Variant: banner.Success,
-})
-
-// Cookie Consent Banner
-@banner.Banner(banner.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Color Variants",
+				Description: "Set Variant for semantic coloring: Default, Primary, Info, Success, Warning, Danger.",
+			},
+			bannerVariantsPreview(),
+			`@banner.Banner(banner.Config{Text: "Success! Your changes have been saved", Variant: banner.Success})
+@banner.Banner(banner.Config{Text: "Warning: Please review your settings", Variant: banner.Warning})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Cookie Consent",
+				Description: "CookieBanner: true plus a CookieConfig renders a corner-anchored consent card with accept/reject actions.",
+			},
+			bannerCookiePreview(),
+			`@banner.Banner(banner.Config{
     CookieBanner: true,
-    Text: "We use cookies to improve your experience",
+    Text:         "We use cookies to improve your experience.",
     CookieConfig: &banner.CookieBannerConfig{
         Title:        "Cookie Settings",
         AcceptText:   "Accept All",
@@ -120,12 +148,30 @@ func bannerDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Text", Type: "string", Default: `""`, Description: "Banner message text."},
+			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Color: "default", "primary", "info", "success", "warning", "danger".`},
+			{Name: "Position", Type: "Position", Default: "PositionRelative", Description: `Layout: "relative" (inline) or "fixed" (pinned to top).`},
+			{Name: "Persistent", Type: "bool", Default: "false", Description: "Remove the dismiss control."},
+			{Name: "DismissAction", Type: "string", Default: `""`, Description: "Extra Alpine expression run when dismissed."},
+			{Name: "CTA", Type: "*CTAConfig", Default: "nil", Description: "Inline call-to-action (Text + Href or OnClick)."},
+			{Name: "CookieBanner", Type: "bool", Default: "false", Description: "Render as a corner cookie-consent card."},
+			{Name: "CookieConfig", Type: "*CookieBannerConfig", Default: "nil", Description: "Cookie card content + accept/reject actions."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the banner."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// bannerDemoPreview renders the Goshtoso banner preview
-func bannerDemoPreview() templ.Component {
+// bannerSimplePreview renders the default dismissible banner.
+func bannerSimplePreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -146,7 +192,7 @@ func bannerDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Simple Banner (Dismissible by Default)</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"banner-simple\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -156,7 +202,37 @@ func bannerDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Persistent Banner (Non-dismissible)</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// bannerPersistentPreview renders the non-dismissible banner.
+func bannerPersistentPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"banner-persistent\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -167,7 +243,37 @@ func bannerDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With CTA Button</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// bannerCTAPreview renders a banner with a CTA button.
+func bannerCTAPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"banner-cta\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -181,53 +287,95 @@ func bannerDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Color Variants</h4><div class=\"space-y-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = banner.Banner(banner.Config{
-			Text:    "Default variant banner",
-			Variant: banner.Default,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		return nil
+	})
+}
+
+// bannerVariantsPreview renders the semantic color variants.
+func bannerVariantsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"banner-variants\" class=\"w-full max-w-2xl mx-auto\"><div class=\"space-y-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = banner.Banner(banner.Config{
-			Text:    "Primary variant for promotions",
-			Variant: banner.Primary,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = banner.Banner(banner.Config{Text: "Default variant banner", Variant: banner.Default}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = banner.Banner(banner.Config{
-			Text:    "Info variant for general information",
-			Variant: banner.Info,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = banner.Banner(banner.Config{Text: "Primary variant for promotions", Variant: banner.Primary}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = banner.Banner(banner.Config{
-			Text:    "Success! Operation completed successfully",
-			Variant: banner.Success,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = banner.Banner(banner.Config{Text: "Info variant for general information", Variant: banner.Info}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = banner.Banner(banner.Config{
-			Text:    "Warning: Please review your settings",
-			Variant: banner.Warning,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = banner.Banner(banner.Config{Text: "Success! Operation completed successfully", Variant: banner.Success}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = banner.Banner(banner.Config{
-			Text:    "Error: Something went wrong",
-			Variant: banner.Danger,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = banner.Banner(banner.Config{Text: "Warning: Please review your settings", Variant: banner.Warning}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div><div class=\"relative h-48 overflow-hidden border border-outline dark:border-outline-dark rounded-radius\"><h4 class=\"absolute top-4 left-4 text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong z-10\">Cookie Consent Banner (Bottom Right)</h4><div class=\"absolute inset-0 bg-surface dark:bg-surface-dark\">")
+		templ_7745c5c3_Err = banner.Banner(banner.Config{Text: "Error: Something went wrong", Variant: banner.Danger}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// bannerCookiePreview renders the cookie-consent banner inside a framed stage.
+func bannerCookiePreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"banner-cookie\" class=\"w-full max-w-2xl mx-auto\"><div class=\"relative h-48 overflow-hidden border border-outline dark:border-outline-dark rounded-radius\"><div class=\"absolute inset-0 bg-surface dark:bg-surface-dark\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -245,7 +393,7 @@ func bannerDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/breadcrumbs.templ
+++ b/internal/pages/demo/components/breadcrumbs.templ
@@ -10,101 +10,107 @@ templ BreadcrumbsDemoPage() {
 	@demo.Layout("Breadcrumbs", "breadcrumbs", breadcrumbsDemoContent())
 }
 
+// breadcrumbsDemoContent renders the demo. Each separator/icon variant lives in
+// its own preview frame followed by its own code block (mirrors
+// penguinui.com/components/breadcrumbs). Wrapped in #breadcrumbs-fragment.
 templ breadcrumbsDemoContent() {
-	<div class="space-y-12">
-		<div>
-			<h1 class="text-3xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong">Breadcrumbs</h1>
-			<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted">Tailwind CSS Breadcrumb Navigation</p>
-			<p class="mt-2 text-on-surface dark:text-on-surface-dark">Breadcrumbs show the user's current location in a site hierarchy. They support chevron and slash separators, optional icons, and custom attributes on links.</p>
-		</div>
+	<div id="breadcrumbs-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Breadcrumbs",
+				Description: "Show the user's location in a site hierarchy. Chevron or slash separators, optional item icons with tooltips, and custom link attributes.",
+			},
+			breadcrumbsChevronPreview(),
+			`@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
+    Items: []breadcrumbs.Item{
+        {Label: "Home", Href: "#"},
+        {Label: "Components", Href: "#"},
+    },
+    Current: "Breadcrumb",
+})`,
+		)
 
-		@chevronBreadcrumbDemo()
-		@slashBreadcrumbDemo()
-		@iconBreadcrumbDemo()
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Slash Separator",
+				Description: "Separator: breadcrumbs.Slash renders a minimal \"/\" between items.",
+			},
+			breadcrumbsSlashPreview(),
+			`@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
+    Items:     items,
+    Current:   "Breadcrumb",
+    Separator: breadcrumbs.Slash,
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Icon",
+				Description: "Give an Item an Icon (and Tooltip) — e.g. a home glyph for the root crumb.",
+			},
+			breadcrumbsIconPreview(),
+			`@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
+    Items: []breadcrumbs.Item{
+        {Label: "", Href: "#", Icon: homeIcon(), Tooltip: "Home"},
+        {Label: "Components", Href: "#"},
+    },
+    Current: "Breadcrumb",
+})`,
+		)
+	</div>
+	// API reference lives outside #breadcrumbs-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Items", Type: "[]Item", Default: "nil", Description: "The crumbs before the current page. Item: Label, Href, optional Icon, Tooltip, LinkAttrs."},
+		{Name: "Current", Type: "string", Default: `""`, Description: "Label of the current (non-link) page, rendered last."},
+		{Name: "Separator", Type: "SeparatorStyle", Default: "Chevron", Description: `Separator between items: "chevron" or "slash".`},
+		{Name: "NavAttrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the <nav> element."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
+	})
+}
+
+// breadcrumbsChevronPreview renders the default chevron-separator breadcrumb.
+templ breadcrumbsChevronPreview() {
+	<div id="breadcrumbs-chevron" class="w-full">
+		@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
+			Items: []breadcrumbs.Item{
+				{Label: "Home", Href: "#"},
+				{Label: "Components", Href: "#"},
+			},
+			Current: "Breadcrumb",
+		})
 	</div>
 }
 
-// --- Variant 1: Chevron Separator ---
-
-templ chevronBreadcrumbDemo() {
-	<div class="not-prose">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2">Chevron Separator</h3>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Default breadcrumb with chevron separators between items.</p>
-		<div class="border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
-			<div class="flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark">
-				<span class="size-3 rounded-full bg-red-400"></span>
-				<span class="size-3 rounded-full bg-yellow-400"></span>
-				<span class="size-3 rounded-full bg-green-400"></span>
-				<span class="ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted">Preview</span>
-			</div>
-			<div class="p-6 bg-surface dark:bg-surface-dark">
-				@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
-					Items: []breadcrumbs.Item{
-						{Label: "Home", Href: "#"},
-						{Label: "Components", Href: "#"},
-					},
-					Current: "Breadcrumb",
-				})
-			</div>
-		</div>
+// breadcrumbsSlashPreview renders the slash-separator breadcrumb.
+templ breadcrumbsSlashPreview() {
+	<div id="breadcrumbs-slash" class="w-full">
+		@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
+			Items: []breadcrumbs.Item{
+				{Label: "Home", Href: "#"},
+				{Label: "Components", Href: "#"},
+			},
+			Current:   "Breadcrumb",
+			Separator: breadcrumbs.Slash,
+		})
 	</div>
 }
 
-// --- Variant 2: Slash Separator ---
-
-templ slashBreadcrumbDemo() {
-	<div class="not-prose">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2">Slash Separator</h3>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Breadcrumb with slash separators for a minimal look.</p>
-		<div class="border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
-			<div class="flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark">
-				<span class="size-3 rounded-full bg-red-400"></span>
-				<span class="size-3 rounded-full bg-yellow-400"></span>
-				<span class="size-3 rounded-full bg-green-400"></span>
-				<span class="ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted">Preview</span>
-			</div>
-			<div class="p-6 bg-surface dark:bg-surface-dark">
-				@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
-					Items: []breadcrumbs.Item{
-						{Label: "Home", Href: "#"},
-						{Label: "Components", Href: "#"},
-					},
-					Current:   "Breadcrumb",
-					Separator: breadcrumbs.Slash,
-				})
-			</div>
-		</div>
+// breadcrumbsIconPreview renders a breadcrumb with a home icon on the root item.
+templ breadcrumbsIconPreview() {
+	<div id="breadcrumbs-icon" class="w-full">
+		@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
+			Items: []breadcrumbs.Item{
+				{Label: "", Href: "#", Icon: breadcrumbHomeIcon(), Tooltip: "Home"},
+				{Label: "Components", Href: "#"},
+			},
+			Current: "Breadcrumb",
+		})
 	</div>
 }
 
-// --- Variant 3: With Icon ---
-
+// breadcrumbHomeIcon renders a home glyph for the root breadcrumb item.
 templ breadcrumbHomeIcon() {
 	<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true" class="size-4">
 		<path fill-rule="evenodd" clip-rule="evenodd" d="M9.293 2.293a1 1 0 0 1 1.414 0l7 7A1 1 0 0 1 17 11h-1v6a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6H3a1 1 0 0 1-.707-1.707l7-7Z"></path>
 	</svg>
-}
-
-templ iconBreadcrumbDemo() {
-	<div class="not-prose">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2">With Icon</h3>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Breadcrumb items can include icons for better visual context.</p>
-		<div class="border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
-			<div class="flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark">
-				<span class="size-3 rounded-full bg-red-400"></span>
-				<span class="size-3 rounded-full bg-yellow-400"></span>
-				<span class="size-3 rounded-full bg-green-400"></span>
-				<span class="ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted">Preview</span>
-			</div>
-			<div class="p-6 bg-surface dark:bg-surface-dark">
-				@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
-					Items: []breadcrumbs.Item{
-						{Label: "", Href: "#", Icon: breadcrumbHomeIcon(), Tooltip: "Home"},
-						{Label: "Components", Href: "#"},
-					},
-					Current: "Breadcrumb",
-				})
-			</div>
-		</div>
-	</div>
 }

--- a/internal/pages/demo/components/breadcrumbs_templ.go
+++ b/internal/pages/demo/components/breadcrumbs_templ.go
@@ -43,6 +43,9 @@ func BreadcrumbsDemoPage() templ.Component {
 	})
 }
 
+// breadcrumbsDemoContent renders the demo. Each separator/icon variant lives in
+// its own preview frame followed by its own code block (mirrors
+// penguinui.com/components/breadcrumbs). Wrapped in #breadcrumbs-fragment.
 func breadcrumbsDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -64,19 +67,56 @@ func breadcrumbsDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-12\"><div><h1 class=\"text-3xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">Breadcrumbs</h1><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Tailwind CSS Breadcrumb Navigation</p><p class=\"mt-2 text-on-surface dark:text-on-surface-dark\">Breadcrumbs show the user's current location in a site hierarchy. They support chevron and slash separators, optional icons, and custom attributes on links.</p></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"breadcrumbs-fragment\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = chevronBreadcrumbDemo().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Breadcrumbs",
+				Description: "Show the user's location in a site hierarchy. Chevron or slash separators, optional item icons with tooltips, and custom link attributes.",
+			},
+			breadcrumbsChevronPreview(),
+			`@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
+    Items: []breadcrumbs.Item{
+        {Label: "Home", Href: "#"},
+        {Label: "Components", Href: "#"},
+    },
+    Current: "Breadcrumb",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = slashBreadcrumbDemo().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Slash Separator",
+				Description: "Separator: breadcrumbs.Slash renders a minimal \"/\" between items.",
+			},
+			breadcrumbsSlashPreview(),
+			`@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
+    Items:     items,
+    Current:   "Breadcrumb",
+    Separator: breadcrumbs.Slash,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = iconBreadcrumbDemo().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Icon",
+				Description: "Give an Item an Icon (and Tooltip) — e.g. a home glyph for the root crumb.",
+			},
+			breadcrumbsIconPreview(),
+			`@breadcrumbs.Breadcrumbs(breadcrumbs.Config{
+    Items: []breadcrumbs.Item{
+        {Label: "", Href: "#", Icon: homeIcon(), Tooltip: "Home"},
+        {Label: "Components", Href: "#"},
+    },
+    Current: "Breadcrumb",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -84,12 +124,22 @@ func breadcrumbsDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Items", Type: "[]Item", Default: "nil", Description: "The crumbs before the current page. Item: Label, Href, optional Icon, Tooltip, LinkAttrs."},
+			{Name: "Current", Type: "string", Default: `""`, Description: "Label of the current (non-link) page, rendered last."},
+			{Name: "Separator", Type: "SeparatorStyle", Default: "Chevron", Description: `Separator between items: "chevron" or "slash".`},
+			{Name: "NavAttrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the <nav> element."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// --- Variant 1: Chevron Separator ---
-func chevronBreadcrumbDemo() templ.Component {
+// breadcrumbsChevronPreview renders the default chevron-separator breadcrumb.
+func breadcrumbsChevronPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -110,7 +160,7 @@ func chevronBreadcrumbDemo() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"not-prose\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">Chevron Separator</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Default breadcrumb with chevron separators between items.</p><div class=\"border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark\"><span class=\"size-3 rounded-full bg-red-400\"></span> <span class=\"size-3 rounded-full bg-yellow-400\"></span> <span class=\"size-3 rounded-full bg-green-400\"></span> <span class=\"ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">Preview</span></div><div class=\"p-6 bg-surface dark:bg-surface-dark\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"breadcrumbs-chevron\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -124,7 +174,7 @@ func chevronBreadcrumbDemo() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -132,8 +182,8 @@ func chevronBreadcrumbDemo() templ.Component {
 	})
 }
 
-// --- Variant 2: Slash Separator ---
-func slashBreadcrumbDemo() templ.Component {
+// breadcrumbsSlashPreview renders the slash-separator breadcrumb.
+func breadcrumbsSlashPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -154,7 +204,7 @@ func slashBreadcrumbDemo() templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"not-prose\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">Slash Separator</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Breadcrumb with slash separators for a minimal look.</p><div class=\"border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark\"><span class=\"size-3 rounded-full bg-red-400\"></span> <span class=\"size-3 rounded-full bg-yellow-400\"></span> <span class=\"size-3 rounded-full bg-green-400\"></span> <span class=\"ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">Preview</span></div><div class=\"p-6 bg-surface dark:bg-surface-dark\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"breadcrumbs-slash\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -169,7 +219,7 @@ func slashBreadcrumbDemo() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -177,8 +227,8 @@ func slashBreadcrumbDemo() templ.Component {
 	})
 }
 
-// --- Variant 3: With Icon ---
-func breadcrumbHomeIcon() templ.Component {
+// breadcrumbsIconPreview renders a breadcrumb with a home icon on the root item.
+func breadcrumbsIconPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -199,7 +249,21 @@ func breadcrumbHomeIcon() templ.Component {
 			templ_7745c5c3_Var5 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"currentColor\" viewBox=\"0 0 20 20\" aria-hidden=\"true\" class=\"size-4\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M9.293 2.293a1 1 0 0 1 1.414 0l7 7A1 1 0 0 1 17 11h-1v6a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6H3a1 1 0 0 1-.707-1.707l7-7Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"breadcrumbs-icon\" class=\"w-full\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = breadcrumbs.Breadcrumbs(breadcrumbs.Config{
+			Items: []breadcrumbs.Item{
+				{Label: "", Href: "#", Icon: breadcrumbHomeIcon(), Tooltip: "Home"},
+				{Label: "Components", Href: "#"},
+			},
+			Current: "Breadcrumb",
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -207,7 +271,8 @@ func breadcrumbHomeIcon() templ.Component {
 	})
 }
 
-func iconBreadcrumbDemo() templ.Component {
+// breadcrumbHomeIcon renders a home glyph for the root breadcrumb item.
+func breadcrumbHomeIcon() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -228,21 +293,7 @@ func iconBreadcrumbDemo() templ.Component {
 			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"not-prose\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">With Icon</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Breadcrumb items can include icons for better visual context.</p><div class=\"border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark\"><span class=\"size-3 rounded-full bg-red-400\"></span> <span class=\"size-3 rounded-full bg-yellow-400\"></span> <span class=\"size-3 rounded-full bg-green-400\"></span> <span class=\"ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">Preview</span></div><div class=\"p-6 bg-surface dark:bg-surface-dark\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = breadcrumbs.Breadcrumbs(breadcrumbs.Config{
-			Items: []breadcrumbs.Item{
-				{Label: "", Href: "#", Icon: breadcrumbHomeIcon(), Tooltip: "Home"},
-				{Label: "Components", Href: "#"},
-			},
-			Current: "Breadcrumb",
-		}).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"currentColor\" viewBox=\"0 0 20 20\" aria-hidden=\"true\" class=\"size-4\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M9.293 2.293a1 1 0 0 1 1.414 0l7 7A1 1 0 0 1 17 11h-1v6a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6H3a1 1 0 0 1-.707-1.707l7-7Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/button.templ
+++ b/internal/pages/demo/components/button.templ
@@ -10,94 +10,86 @@ templ ButtonDemoPage() {
 	@demo.Layout("Buttons", "button", buttonDemoContent())
 }
 
-// buttonDemoContent renders the actual content inside the layout
+// buttonDemoContent renders the demo. Each button variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/button). The docs wrapper is #button-docs-fragment so
+// it doesn't collide with ButtonFragment's #button-fragment variants grid (which
+// the e2e suite and the HTMX fragment endpoint target).
 templ buttonDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Buttons",
-			Description:   "Buttons are a fundamental element of any user interface. Users can use them to trigger actions, such as submitting a form, opening a modal, or navigating to another page.",
-		},
-		buttonDemoPreview(),
-		`// Primary Button
+	<div id="button-docs-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Buttons",
+				Description: "Trigger actions — submit a form, open a modal, navigate. Eight color variants, four sizes, disabled state, and first-class HTMX wiring (GET/POST/DELETE, confirm, loading indicator).",
+			},
+			buttonVariantsPreview(),
+			`@button.Button(button.Config{Variant: button.Primary, Type: "button"}) { Primary }
+@button.Button(button.Config{Variant: button.Secondary, Type: "button"}) { Secondary }
+@button.Button(button.Config{Variant: button.Danger, Type: "button"}) { Danger }
+@button.Button(button.Config{Variant: button.Success, Type: "button"}) { Success }`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Sizes",
+				Description: "Four sizes via Size: SizeSmall, SizeMedium, SizeLarge, SizeXLarge.",
+			},
+			buttonSizesPreview(),
+			`@button.Button(button.Config{Variant: button.Primary, Size: button.SizeSmall, Type: "button"}) { Small }
+@button.Button(button.Config{Variant: button.Primary, Size: button.SizeXLarge, Type: "button"}) { Extra Large }`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks interaction and dims the button.",
+			},
+			buttonDisabledPreview(),
+			`@button.Button(button.Config{Variant: button.Primary, Type: "button", Disabled: true}) { Primary }`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "HTMX Interactions",
+				Description: "Attach an HTMX config to fire a request on click. Supports Get/Post/Delete, a Confirm prompt, a loading Indicator, and LoadingText.",
+			},
+			buttonHTMXPreview(),
+			`@button.Button(button.Config{
+    Variant: button.Primary, Type: "button",
+    HTMX: &button.HTMXConfig{Post: "/api/hello", Target: "#result", Swap: "innerHTML"},
+}) { Send POST }
+
 @button.Button(button.Config{
-    Variant: button.Primary,
-    Type:    "button",
-}) {
-    Primary
+    Variant: button.Danger, Type: "button",
+    HTMX: &button.HTMXConfig{Delete: "/api/item/123", Confirm: "Are you sure?", Target: "#item"},
+}) { Delete }`,
+		)
+	</div>
+	// API reference lives outside #button-docs-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Variant", Type: "Variant", Default: "Primary", Description: `Color: "primary", "secondary", "alternate", "inverse", "info", "danger", "warning", "success".`},
+		{Name: "Size", Type: "Size", Default: "SizeMedium", Description: `Size: "sm", "md", "lg", "xl".`},
+		{Name: "Type", Type: "string", Default: `"button"`, Description: `Native button type: "button", "submit", "reset".`},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
+		{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "HTMX wiring (Get/Post/Put/Delete, Target, Swap, Trigger, Confirm, Indicator)."},
+		{Name: "Alpine", Type: "*AlpineConfig", Default: "nil", Description: "Alpine.js directives for client-side behavior."},
+		{Name: "LoadingText", Type: "string", Default: `""`, Description: "Text shown while an HTMX request is in flight."},
+		{Name: "ID", Type: "string", Default: `""`, Description: "Optional element id."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the button."},
+	})
 }
 
-// Secondary Button  
-@button.Button(button.Config{
-    Variant: button.Secondary,
-    Type:    "button",
-}) {
-    Secondary
+// buttonVariantsPreview renders the eight color variants (the ButtonFragment grid).
+templ buttonVariantsPreview() {
+	<div id="button-variants" class="w-full">
+		@ButtonFragment(false)
+	</div>
 }
 
-// With HTMX - Basic POST
-@button.Button(button.Config{
-    Variant: button.Primary,
-    Type:    "button",
-    HTMX: &button.HTMXConfig{
-        Post:   "/api/action",
-        Target: "#result",
-        Swap:   "innerHTML",
-    },
-}) {
-    Submit
-}
-
-// With HTMX - GET Request
-@button.Button(button.Config{
-    Variant: button.Info,
-    Type:    "button",
-    HTMX: &button.HTMXConfig{
-        Get:     "/api/data",
-        Target:  "#data-container",
-        Trigger: "click",
-    },
-}) {
-    Load Data
-}
-
-// With HTMX - With Loading State
-@button.Button(button.Config{
-    Variant:    button.Secondary,
-    Type:       "button",
-    LoadingText: "Loading...",
-    HTMX: &button.HTMXConfig{
-        Post:      "/api/process",
-        Target:    "#output",
-        Indicator: "#spinner",
-    },
-}) {
-    Process
-}
-
-// With HTMX - Confirm Dialog
-@button.Button(button.Config{
-    Variant: button.Danger,
-    Type:    "button",
-    HTMX: &button.HTMXConfig{
-        Delete:  "/api/item/123",
-        Confirm: "Are you sure you want to delete this?",
-        Target:  "#item-123",
-        Swap:    "outerHTML",
-    },
-}) {
-    Delete
-}`,
-	)
-}
-
-// buttonDemoPreview renders the Goshtoso button preview
-templ buttonDemoPreview() {
-	@ButtonFragment(false)
-
-	<!-- Sizes -->
-	<div class="space-y-3 p-8 pt-0">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">Sizes</h3>
-		<div class="flex flex-wrap items-center gap-4">
+// buttonSizesPreview renders the four button sizes.
+templ buttonSizesPreview() {
+	<div id="button-sizes" class="w-full">
+		<div class="flex flex-wrap items-center justify-center gap-4">
 			@button.Button(button.Config{Variant: button.Primary, Size: button.SizeSmall, Type: "button"}) {
 				Small
 			}
@@ -112,11 +104,12 @@ templ buttonDemoPreview() {
 			}
 		</div>
 	</div>
+}
 
-	<!-- Disabled -->
-	<div class="space-y-3 p-8 pt-0">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">Disabled</h3>
-		<div class="flex flex-wrap items-center gap-4">
+// buttonDisabledPreview renders disabled buttons across variants.
+templ buttonDisabledPreview() {
+	<div id="button-disabled" class="w-full">
+		<div class="flex flex-wrap items-center justify-center gap-4">
 			@button.Button(button.Config{Variant: button.Primary, Type: "button", Disabled: true}) {
 				Primary
 			}
@@ -131,11 +124,12 @@ templ buttonDemoPreview() {
 			}
 		</div>
 	</div>
+}
 
-	<!-- With HTMX -->
-	<div class="space-y-3 p-8 pt-0">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">HTMX Interactions</h3>
-		<div class="flex flex-wrap items-center gap-4">
+// buttonHTMXPreview renders the HTMX-wired buttons with their result targets.
+templ buttonHTMXPreview() {
+	<div id="button-htmx" class="w-full">
+		<div class="flex flex-wrap items-center justify-center gap-4">
 			<div class="flex items-center gap-3">
 				@button.Button(button.Config{
 					Variant: button.Primary,

--- a/internal/pages/demo/components/button_templ.go
+++ b/internal/pages/demo/components/button_templ.go
@@ -43,7 +43,11 @@ func ButtonDemoPage() templ.Component {
 	})
 }
 
-// buttonDemoContent renders the actual content inside the layout
+// buttonDemoContent renders the demo. Each button variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/button). The docs wrapper is #button-docs-fragment so
+// it doesn't collide with ButtonFragment's #button-fragment variants grid (which
+// the e2e suite and the HTMX fragment endpoint target).
 func buttonDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,82 +69,81 @@ func buttonDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"button-docs-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Buttons",
-				Description: "Buttons are a fundamental element of any user interface. Users can use them to trigger actions, such as submitting a form, opening a modal, or navigating to another page.",
+				Description: "Trigger actions — submit a form, open a modal, navigate. Eight color variants, four sizes, disabled state, and first-class HTMX wiring (GET/POST/DELETE, confirm, loading indicator).",
 			},
-			buttonDemoPreview(),
-			`// Primary Button
-@button.Button(button.Config{
-    Variant: button.Primary,
-    Type:    "button",
-}) {
-    Primary
-}
-
-// Secondary Button  
-@button.Button(button.Config{
-    Variant: button.Secondary,
-    Type:    "button",
-}) {
-    Secondary
-}
-
-// With HTMX - Basic POST
-@button.Button(button.Config{
-    Variant: button.Primary,
-    Type:    "button",
-    HTMX: &button.HTMXConfig{
-        Post:   "/api/action",
-        Target: "#result",
-        Swap:   "innerHTML",
-    },
-}) {
-    Submit
-}
-
-// With HTMX - GET Request
-@button.Button(button.Config{
-    Variant: button.Info,
-    Type:    "button",
-    HTMX: &button.HTMXConfig{
-        Get:     "/api/data",
-        Target:  "#data-container",
-        Trigger: "click",
-    },
-}) {
-    Load Data
-}
-
-// With HTMX - With Loading State
-@button.Button(button.Config{
-    Variant:    button.Secondary,
-    Type:       "button",
-    LoadingText: "Loading...",
-    HTMX: &button.HTMXConfig{
-        Post:      "/api/process",
-        Target:    "#output",
-        Indicator: "#spinner",
-    },
-}) {
-    Process
-}
-
-// With HTMX - Confirm Dialog
-@button.Button(button.Config{
-    Variant: button.Danger,
-    Type:    "button",
-    HTMX: &button.HTMXConfig{
-        Delete:  "/api/item/123",
-        Confirm: "Are you sure you want to delete this?",
-        Target:  "#item-123",
-        Swap:    "outerHTML",
-    },
-}) {
-    Delete
-}`,
+			buttonVariantsPreview(),
+			`@button.Button(button.Config{Variant: button.Primary, Type: "button"}) { Primary }
+@button.Button(button.Config{Variant: button.Secondary, Type: "button"}) { Secondary }
+@button.Button(button.Config{Variant: button.Danger, Type: "button"}) { Danger }
+@button.Button(button.Config{Variant: button.Success, Type: "button"}) { Success }`,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Sizes",
+				Description: "Four sizes via Size: SizeSmall, SizeMedium, SizeLarge, SizeXLarge.",
+			},
+			buttonSizesPreview(),
+			`@button.Button(button.Config{Variant: button.Primary, Size: button.SizeSmall, Type: "button"}) { Small }
+@button.Button(button.Config{Variant: button.Primary, Size: button.SizeXLarge, Type: "button"}) { Extra Large }`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks interaction and dims the button.",
+			},
+			buttonDisabledPreview(),
+			`@button.Button(button.Config{Variant: button.Primary, Type: "button", Disabled: true}) { Primary }`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "HTMX Interactions",
+				Description: "Attach an HTMX config to fire a request on click. Supports Get/Post/Delete, a Confirm prompt, a loading Indicator, and LoadingText.",
+			},
+			buttonHTMXPreview(),
+			`@button.Button(button.Config{
+    Variant: button.Primary, Type: "button",
+    HTMX: &button.HTMXConfig{Post: "/api/hello", Target: "#result", Swap: "innerHTML"},
+}) { Send POST }
+
+@button.Button(button.Config{
+    Variant: button.Danger, Type: "button",
+    HTMX: &button.HTMXConfig{Delete: "/api/item/123", Confirm: "Are you sure?", Target: "#item"},
+}) { Delete }`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Variant", Type: "Variant", Default: "Primary", Description: `Color: "primary", "secondary", "alternate", "inverse", "info", "danger", "warning", "success".`},
+			{Name: "Size", Type: "Size", Default: "SizeMedium", Description: `Size: "sm", "md", "lg", "xl".`},
+			{Name: "Type", Type: "string", Default: `"button"`, Description: `Native button type: "button", "submit", "reset".`},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
+			{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "HTMX wiring (Get/Post/Put/Delete, Target, Swap, Trigger, Confirm, Indicator)."},
+			{Name: "Alpine", Type: "*AlpineConfig", Default: "nil", Description: "Alpine.js directives for client-side behavior."},
+			{Name: "LoadingText", Type: "string", Default: `""`, Description: "Text shown while an HTMX request is in flight."},
+			{Name: "ID", Type: "string", Default: `""`, Description: "Optional element id."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the button."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -148,8 +151,8 @@ func buttonDemoContent() templ.Component {
 	})
 }
 
-// buttonDemoPreview renders the Goshtoso button preview
-func buttonDemoPreview() templ.Component {
+// buttonVariantsPreview renders the eight color variants (the ButtonFragment grid).
+func buttonVariantsPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -170,33 +173,45 @@ func buttonDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"button-variants\" class=\"w-full\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = ButtonFragment(false).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<!-- Sizes --><div class=\"space-y-3 p-8 pt-0\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Sizes</h3><div class=\"flex flex-wrap items-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var4 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-			if !templ_7745c5c3_IsBuffer {
-				defer func() {
-					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-					if templ_7745c5c3_Err == nil {
-						templ_7745c5c3_Err = templ_7745c5c3_BufErr
-					}
-				}()
-			}
-			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "Small")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			return nil
-		})
-		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Primary, Size: button.SizeSmall, Type: "button"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
+		return nil
+	})
+}
+
+// buttonSizesPreview renders the four button sizes.
+func buttonSizesPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"button-sizes\" class=\"w-full\"><div class=\"flex flex-wrap items-center justify-center gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -212,13 +227,13 @@ func buttonDemoPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "Medium")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "Small")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Primary, Size: button.SizeMedium, Type: "button"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var5), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Primary, Size: button.SizeSmall, Type: "button"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var5), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -234,13 +249,13 @@ func buttonDemoPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "Large")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "Medium")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Primary, Size: button.SizeLarge, Type: "button"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var6), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Primary, Size: button.SizeMedium, Type: "button"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var6), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -256,17 +271,13 @@ func buttonDemoPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "Extra Large")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "Large")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Primary, Size: button.SizeXLarge, Type: "button"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div><!-- Disabled --><div class=\"space-y-3 p-8 pt-0\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Disabled</h3><div class=\"flex flex-wrap items-center gap-4\">")
+		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Primary, Size: button.SizeLarge, Type: "button"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -282,35 +293,47 @@ func buttonDemoPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "Primary")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "Extra Large")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Primary, Type: "button", Disabled: true}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var8), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Primary, Size: button.SizeXLarge, Type: "button"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var8), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var9 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-			if !templ_7745c5c3_IsBuffer {
-				defer func() {
-					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-					if templ_7745c5c3_Err == nil {
-						templ_7745c5c3_Err = templ_7745c5c3_BufErr
-					}
-				}()
-			}
-			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "Secondary")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			return nil
-		})
-		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Secondary, Type: "button", Disabled: true}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var9), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// buttonDisabledPreview renders disabled buttons across variants.
+func buttonDisabledPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"button-disabled\" class=\"w-full\"><div class=\"flex flex-wrap items-center justify-center gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -326,13 +349,13 @@ func buttonDemoPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "Danger")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "Primary")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Danger, Type: "button", Disabled: true}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Primary, Type: "button", Disabled: true}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -348,17 +371,13 @@ func buttonDemoPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "Success")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "Secondary")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Success, Type: "button", Disabled: true}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div></div><!-- With HTMX --><div class=\"space-y-3 p-8 pt-0\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">HTMX Interactions</h3><div class=\"flex flex-wrap items-center gap-4\"><div class=\"flex items-center gap-3\">")
+		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Secondary, Type: "button", Disabled: true}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -374,25 +393,13 @@ func buttonDemoPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "Send POST")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "Danger")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = button.Button(button.Config{
-			Variant: button.Primary,
-			Type:    "button",
-			HTMX: &button.HTMXConfig{
-				Post:   "/api/hello",
-				Target: "#htmx-result-1",
-				Swap:   "innerHTML",
-			},
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<span id=\"htmx-result-1\" class=\"text-sm text-on-surface dark:text-on-surface-dark\"><em class=\"text-on-surface-muted dark:text-on-surface-dark-muted\">Click to load...</em></span></div><div class=\"flex items-center gap-3\">")
+		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Danger, Type: "button", Disabled: true}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -408,7 +415,97 @@ func buttonDemoPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "Send GET")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "Success")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = button.Button(button.Config{Variant: button.Success, Type: "button", Disabled: true}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var13), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// buttonHTMXPreview renders the HTMX-wired buttons with their result targets.
+func buttonHTMXPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"button-htmx\" class=\"w-full\"><div class=\"flex flex-wrap items-center justify-center gap-4\"><div class=\"flex items-center gap-3\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var15 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "Send POST")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = button.Button(button.Config{
+			Variant: button.Primary,
+			Type:    "button",
+			HTMX: &button.HTMXConfig{
+				Post:   "/api/hello",
+				Target: "#htmx-result-1",
+				Swap:   "innerHTML",
+			},
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<span id=\"htmx-result-1\" class=\"text-sm text-on-surface dark:text-on-surface-dark\"><em class=\"text-on-surface-muted dark:text-on-surface-dark-muted\">Click to load...</em></span></div><div class=\"flex items-center gap-3\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var16 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "Send GET")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -422,15 +519,15 @@ func buttonDemoPreview() templ.Component {
 				Target: "#htmx-result-2",
 				Swap:   "innerHTML",
 			},
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var13), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var16), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<span id=\"htmx-result-2\" class=\"text-sm text-on-surface dark:text-on-surface-dark\"><em class=\"text-on-surface-muted dark:text-on-surface-dark-muted\">Click to load...</em></span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<span id=\"htmx-result-2\" class=\"text-sm text-on-surface dark:text-on-surface-dark\"><em class=\"text-on-surface-muted dark:text-on-surface-dark-muted\">Click to load...</em></span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var14 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var17 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -442,7 +539,7 @@ func buttonDemoPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "Delete (confirm)")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "Delete (confirm)")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -457,11 +554,11 @@ func buttonDemoPreview() templ.Component {
 				Target:  "#htmx-result-3",
 				Swap:    "innerHTML",
 			},
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var17), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<span id=\"htmx-result-3\"></span></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<span id=\"htmx-result-3\"></span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -486,90 +583,12 @@ func ButtonFragment(disabled bool) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var15 == nil {
-			templ_7745c5c3_Var15 = templ.NopComponent
+		templ_7745c5c3_Var18 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var18 == nil {
+			templ_7745c5c3_Var18 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<div class=\"mx-auto grid grid-cols-2 lg:grid-cols-4 gap-8 p-8 place-content-evenly place-items-center\" id=\"button-fragment\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Var16 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-			if !templ_7745c5c3_IsBuffer {
-				defer func() {
-					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-					if templ_7745c5c3_Err == nil {
-						templ_7745c5c3_Err = templ_7745c5c3_BufErr
-					}
-				}()
-			}
-			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "Primary")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			return nil
-		})
-		templ_7745c5c3_Err = button.Button(button.Config{
-			Variant:  button.Primary,
-			Type:     "button",
-			Disabled: disabled,
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var16), templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Var17 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-			if !templ_7745c5c3_IsBuffer {
-				defer func() {
-					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-					if templ_7745c5c3_Err == nil {
-						templ_7745c5c3_Err = templ_7745c5c3_BufErr
-					}
-				}()
-			}
-			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "Secondary")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			return nil
-		})
-		templ_7745c5c3_Err = button.Button(button.Config{
-			Variant:  button.Secondary,
-			Type:     "button",
-			Disabled: disabled,
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var17), templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-			if !templ_7745c5c3_IsBuffer {
-				defer func() {
-					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-					if templ_7745c5c3_Err == nil {
-						templ_7745c5c3_Err = templ_7745c5c3_BufErr
-					}
-				}()
-			}
-			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "Alternate")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			return nil
-		})
-		templ_7745c5c3_Err = button.Button(button.Config{
-			Variant:  button.Alternate,
-			Type:     "button",
-			Disabled: disabled,
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div class=\"mx-auto grid grid-cols-2 lg:grid-cols-4 gap-8 p-8 place-content-evenly place-items-center\" id=\"button-fragment\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -585,14 +604,14 @@ func ButtonFragment(disabled bool) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "Inverse")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "Primary")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
 		templ_7745c5c3_Err = button.Button(button.Config{
-			Variant:  button.Inverse,
+			Variant:  button.Primary,
 			Type:     "button",
 			Disabled: disabled,
 		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var19), templ_7745c5c3_Buffer)
@@ -611,14 +630,14 @@ func ButtonFragment(disabled bool) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "Info")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "Secondary")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
 		templ_7745c5c3_Err = button.Button(button.Config{
-			Variant:  button.Info,
+			Variant:  button.Secondary,
 			Type:     "button",
 			Disabled: disabled,
 		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
@@ -637,14 +656,14 @@ func ButtonFragment(disabled bool) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "Danger")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "Alternate")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
 		templ_7745c5c3_Err = button.Button(button.Config{
-			Variant:  button.Danger,
+			Variant:  button.Alternate,
 			Type:     "button",
 			Disabled: disabled,
 		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var21), templ_7745c5c3_Buffer)
@@ -663,14 +682,14 @@ func ButtonFragment(disabled bool) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "Warning")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "Inverse")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
 		templ_7745c5c3_Err = button.Button(button.Config{
-			Variant:  button.Warning,
+			Variant:  button.Inverse,
 			Type:     "button",
 			Disabled: disabled,
 		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var22), templ_7745c5c3_Buffer)
@@ -689,7 +708,85 @@ func ButtonFragment(disabled bool) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "Success")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "Info")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = button.Button(button.Config{
+			Variant:  button.Info,
+			Type:     "button",
+			Disabled: disabled,
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var23), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var24 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "Danger")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = button.Button(button.Config{
+			Variant:  button.Danger,
+			Type:     "button",
+			Disabled: disabled,
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var24), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var25 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "Warning")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = button.Button(button.Config{
+			Variant:  button.Warning,
+			Type:     "button",
+			Disabled: disabled,
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var25), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var26 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "Success")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -699,11 +796,11 @@ func ButtonFragment(disabled bool) templ.Component {
 			Variant:  button.Success,
 			Type:     "button",
 			Disabled: disabled,
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var23), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var26), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -728,16 +825,16 @@ func HTMXButtonDemos() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var24 == nil {
-			templ_7745c5c3_Var24 = templ.NopComponent
+		templ_7745c5c3_Var27 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var27 == nil {
+			templ_7745c5c3_Var27 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<div class=\"space-y-6 p-8\"><div class=\"flex items-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div class=\"space-y-6 p-8\"><div class=\"flex items-center gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var25 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var28 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -749,7 +846,7 @@ func HTMXButtonDemos() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "Send POST Request")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "Send POST Request")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -763,15 +860,15 @@ func HTMXButtonDemos() templ.Component {
 				Target: "#htmx-result-1",
 				Swap:   "innerHTML",
 			},
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var25), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var28), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div id=\"htmx-result-1\" class=\"text-sm text-on-surface dark:text-on-surface-dark\"><em>Click button to load content...</em></div></div><div class=\"flex items-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<div id=\"htmx-result-1\" class=\"text-sm text-on-surface dark:text-on-surface-dark\"><em>Click button to load content...</em></div></div><div class=\"flex items-center gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var26 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var29 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -783,7 +880,7 @@ func HTMXButtonDemos() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "Load with Spinner")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "Load with Spinner")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -797,15 +894,15 @@ func HTMXButtonDemos() templ.Component {
 				Target:    "#htmx-result-2",
 				Indicator: "#loading-spinner",
 			},
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var26), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var29), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<div id=\"loading-spinner\" class=\"htmx-indicator\"><svg class=\"animate-spin h-4 w-4 text-primary\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\"><circle class=\"opacity-25\" cx=\"12\" cy=\"12\" r=\"10\" stroke=\"currentColor\" stroke-width=\"4\"></circle> <path class=\"opacity-75\" fill=\"currentColor\" d=\"M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z\"></path></svg></div><div id=\"htmx-result-2\" class=\"text-sm text-on-surface dark:text-on-surface-dark\"><em>Content will appear here...</em></div></div><div class=\"flex items-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<div id=\"loading-spinner\" class=\"htmx-indicator\"><svg class=\"animate-spin h-4 w-4 text-primary\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\"><circle class=\"opacity-25\" cx=\"12\" cy=\"12\" r=\"10\" stroke=\"currentColor\" stroke-width=\"4\"></circle> <path class=\"opacity-75\" fill=\"currentColor\" d=\"M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z\"></path></svg></div><div id=\"htmx-result-2\" class=\"text-sm text-on-surface dark:text-on-surface-dark\"><em>Content will appear here...</em></div></div><div class=\"flex items-center gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var27 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var30 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -817,7 +914,7 @@ func HTMXButtonDemos() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "Delete (with Confirm)")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "Delete (with Confirm)")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -831,11 +928,11 @@ func HTMXButtonDemos() templ.Component {
 				Confirm: "Are you sure you want to proceed?",
 				Target:  "#htmx-result-3",
 			},
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var27), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var30), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div id=\"htmx-result-3\" class=\"text-sm text-on-surface dark:text-on-surface-dark\"></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<div id=\"htmx-result-3\" class=\"text-sm text-on-surface dark:text-on-surface-dark\"></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/card.templ
+++ b/internal/pages/demo/components/card.templ
@@ -11,132 +11,187 @@ templ CardDemoPage() {
 	@demo.Layout("Card", "card", cardDemoContent())
 }
 
-// cardDemoContent renders the actual content inside the layout
+// cardDemoContent renders the demo. Each card recipe lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/card).
 templ cardDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Card",
-			Description:   "A card is a flexible container that groups related content and actions. Used for displaying products, articles, testimonials, and more.",
-		},
-		cardDemoPreview(),
-		`// Simple Card
-@card.Card(card.Config{
-    Image:       "https://example.com/image.jpg",
-    ImageAlt:    "Description",
+	<div id="card-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Card",
+				Description: "A flexible container that groups related content and actions — products, articles, testimonials, pricing, and more.",
+			},
+			cardDefaultPreview(),
+			`@card.Card(card.Config{
+    Image:       "/assets/images/cards/card-img-1.webp",
+    ImageAlt:    "A penguin robot talking with a human",
     Tag:         "Features",
-    Title:       "Card Title",
-    Description: "Card description text...",
-})
-
-// Card with Button
-@card.Card(card.Config{
-    Image:       "https://example.com/image.jpg",
-    Title:       "Mediterranean Escape",
-    Description: "Relax under the sun and savor delicious cuisine",
-    Footer:      bookButton(),
-})
-
-// Horizontal Layout Card
-@card.Card(card.Config{
-    Layout:      card.LayoutHorizontal,
-    Image:       "https://example.com/image.jpg",
-    Title:       "AI-Powered VR Goggles",
-    Description: "Experience the next level of augmented reality",
-})
-
-// E-commerce Product Card
-@card.Card(card.Config{
-    Image:       "product.jpg",
-    Title:       "Product Name",
-    Description: "Product description",
-    Price:       "$99.99",
-    Rating:      4,
-})
-
-// Testimonial Card
-@card.Card(card.Config{
-    Title:       "Testimonial",
-    Description: "Quote text...",
-    Footer:      testimonialFooter(),
-})
-
-// Pricing Card (Primary variant)
-@card.Card(card.Config{
-    Variant:     card.Primary,
-    Title:       "Premium",
-    Description: "Best tools for productivity",
-    Footer:      pricingFooter(),
+    Title:       "Penguai can teach you Javascript",
+    Description: "Learning JavaScript doesn't need to be difficult...",
 })`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Card with Button",
+				Description: "Pass any templ.Component as Footer to add actions below the body.",
+			},
+			cardButtonPreview(),
+			`@card.Card(card.Config{
+    Image:       "/assets/images/cards/card-img-2.webp",
+    Title:       "Mediterranean Escape",
+    Description: "Relax under the sun and savor delicious cuisine.",
+    Footer:      bookNowButton(),
+})
+
+templ bookNowButton() {
+    <div class="mt-2">
+        @button.Button(button.Config{Variant: button.Primary, Type: "button"}) { Book Now }
+    </div>
+}`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Horizontal Layout",
+				Description: "Set Layout: card.LayoutHorizontal to place the image beside the content instead of above it.",
+			},
+			cardHorizontalPreview(),
+			`@card.Card(card.Config{
+    Layout:      card.LayoutHorizontal,
+    Image:       "/assets/images/cards/card-img-4.webp",
+    Tag:         "Artificial Intelligence",
+    Title:       "AI-Powered VR Goggles Redefine Reality",
+    Description: "Experience the next level of augmented reality...",
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Product Card",
+				Description: "An e-commerce recipe: compose a bordered article with card.StarRating, a price, and an Add to Cart button. (Config.Price/Rating are exposed but rendered by the caller, not the base template.)",
+			},
+			cardProductPreview(),
+			`<article class="group flex rounded-radius max-w-sm flex-col overflow-hidden border border-outline bg-surface-alt ...">
+    <div class="h-44 md:h-64 overflow-hidden">
+        <img src="/assets/images/cards/card-img-3.webp" alt="CASIO G-SHOCK GA2100" />
+    </div>
+    <div class="flex flex-col gap-4 p-6">
+        <h3 class="text-lg font-bold">CASIO G-SHOCK GA2100</h3>
+        @card.StarRating(3)
+        <span class="text-xl font-medium">$99.99</span>
+        @button.Button(button.Config{Variant: button.Primary}) { Add to Cart }
+    </div>
+</article>`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Pricing Card",
+				Description: "A pricing recipe using the primary border accent and a full-width CTA. Composed as a custom article.",
+			},
+			cardPricingPreview(),
+			`<article class="group flex rounded-radius max-w-xs flex-col overflow-hidden border-2 border-primary bg-surface-alt p-6 ...">
+    <span class="ml-auto w-fit rounded-radius bg-primary px-2 py-1 text-xs text-on-primary">TOP CHOICE</span>
+    <h3 class="text-xl font-bold">Premium</h3>
+    <span class="mt-8 text-3xl font-medium">$8.99</span>
+    <ul class="mt-4 list-inside list-disc space-y-2 text-sm">...</ul>
+    @button.Button(button.Config{Variant: button.Primary, Class: "w-full"}) { Start your free trial }
+</article>`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Testimonial Card",
+				Description: "A quote recipe pairing a person, role, and card.StarRating in the footer row.",
+			},
+			cardTestimonialPreview(),
+			`<article class="group rounded-radius flex max-w-md flex-col border border-outline bg-surface-alt p-6 ...">
+    <svg class="size-12">...</svg>
+    <p class="mt-2 text-sm">Simply put, this software transformed my workflow!...</p>
+    <div class="flex mt-8 justify-between gap-6">
+        <div class="flex items-center gap-2">
+            <img src="/assets/images/avatars/avatar-1.webp" class="size-10 rounded-full" alt="Bob Johnson" />
+            <div><h3 class="font-bold">Bob Johnson</h3><span class="text-xs">CEO - TechNova</span></div>
+        </div>
+        @card.StarRating(4)
+    </div>
+</article>`,
+		)
+	</div>
+	// API reference lives outside #card-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Image", Type: "string", Default: `""`, Description: "Card image URL (rendered above the body, or beside it in horizontal layout)."},
+		{Name: "ImageAlt", Type: "string", Default: `""`, Description: "Alt text for the image."},
+		{Name: "Tag", Type: "string", Default: `""`, Description: "Optional category/tag shown above the title."},
+		{Name: "Title", Type: "string", Default: `""`, Description: "Card title (also seeds the aria-describedby id)."},
+		{Name: "Description", Type: "string", Default: `""`, Description: "Body text."},
+		{Name: "Footer", Type: "templ.Component", Default: "nil", Description: "Optional footer content (buttons, links, ratings) rendered below the body."},
+		{Name: "Variant", Type: "Variant", Default: "Default", Description: `Style: "default" or "primary" (adds a 2px primary border accent).`},
+		{Name: "Layout", Type: "Layout", Default: "LayoutVertical", Description: `Layout: "vertical" (image top) or "horizontal" (image beside content).`},
+		{Name: "Price", Type: "string", Default: `""`, Description: "Exposed for ecommerce recipes; render via a custom Footer (base template does not emit it)."},
+		{Name: "Rating", Type: "int", Default: "0", Description: "Exposed for ecommerce recipes; render with card.StarRating in a Footer."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes appended to the article container."},
+	})
 }
 
-// cardDemoPreview renders the Goshtoso card preview
-templ cardDemoPreview() {
-	<div class="w-full max-w-5xl mx-auto space-y-12">
-		// Default Card
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Card</h4>
-			<div class="flex flex-wrap gap-6">
-				@card.Card(card.Config{
-					Image:       "/assets/images/cards/card-img-1.webp",
-					ImageAlt:    "A penguin robot talking with a human",
-					Tag:         "Features",
-					Title:       "Penguai can teach you Javascript",
-					Description: "Learning JavaScript doesn't need to be difficult. Our penguin AI robot can learn how much you know and will go at your speed.",
-				})
-			</div>
-		</div>
+// cardDefaultPreview renders the simple default card.
+templ cardDefaultPreview() {
+	<div id="card-default" class="w-full max-w-sm mx-auto">
+		@card.Card(card.Config{
+			Image:       "/assets/images/cards/card-img-1.webp",
+			ImageAlt:    "A penguin robot talking with a human",
+			Tag:         "Features",
+			Title:       "Penguai can teach you Javascript",
+			Description: "Learning JavaScript doesn't need to be difficult. Our penguin AI robot can learn how much you know and will go at your speed.",
+		})
+	</div>
+}
 
-		// Card with Button
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Card with Button</h4>
-			<div class="flex flex-wrap gap-6">
-				@card.Card(card.Config{
-					Image:       "/assets/images/cards/card-img-2.webp",
-					ImageAlt:    "Mediterranean coastal village",
-					Title:       "Mediterranean Escape",
-					Description: "Relax under the sun, savor delicious cuisine, and create memories that last a lifetime. Book your getaway now.",
-					Footer:      bookNowButton(),
-				})
-			</div>
-		</div>
+// cardButtonPreview renders a card with a footer button.
+templ cardButtonPreview() {
+	<div id="card-button" class="w-full max-w-sm mx-auto">
+		@card.Card(card.Config{
+			Image:       "/assets/images/cards/card-img-2.webp",
+			ImageAlt:    "Mediterranean coastal village",
+			Title:       "Mediterranean Escape",
+			Description: "Relax under the sun, savor delicious cuisine, and create memories that last a lifetime. Book your getaway now.",
+			Footer:      bookNowButton(),
+		})
+	</div>
+}
 
-		// Horizontal Layout
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Horizontal Layout</h4>
-			@card.Card(card.Config{
-				Layout:      card.LayoutHorizontal,
-				Image:       "/assets/images/cards/card-img-4.webp",
-				ImageAlt:    "Man wearing VR goggles",
-				Tag:         "Artificial Intelligence",
-				Title:       "AI-Powered VR Goggles Redefine Reality",
-				Description: "Experience the next level of augmented reality with smart goggles integrating cutting-edge AI for seamless interaction with the world around you.",
-			})
-		</div>
+// cardHorizontalPreview renders the horizontal-layout card.
+templ cardHorizontalPreview() {
+	<div id="card-horizontal" class="w-full max-w-2xl mx-auto">
+		@card.Card(card.Config{
+			Layout:      card.LayoutHorizontal,
+			Image:       "/assets/images/cards/card-img-4.webp",
+			ImageAlt:    "Man wearing VR goggles",
+			Tag:         "Artificial Intelligence",
+			Title:       "AI-Powered VR Goggles Redefine Reality",
+			Description: "Experience the next level of augmented reality with smart goggles integrating cutting-edge AI for seamless interaction with the world around you.",
+		})
+	</div>
+}
 
-		// E-commerce Product Card
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Product Card</h4>
-			<div class="flex flex-wrap gap-6">
-				@ecommerceProductCard()
-			</div>
-		</div>
+// cardProductPreview renders the e-commerce product card recipe.
+templ cardProductPreview() {
+	<div id="card-product" class="w-full max-w-sm mx-auto">
+		@ecommerceProductCard()
+	</div>
+}
 
-		// Pricing Card
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Pricing Card</h4>
-			<div class="flex flex-wrap gap-6">
-				@pricingCard()
-			</div>
-		</div>
+// cardPricingPreview renders the pricing card recipe.
+templ cardPricingPreview() {
+	<div id="card-pricing" class="w-full max-w-xs mx-auto">
+		@pricingCard()
+	</div>
+}
 
-		// Testimonial Card
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Testimonial Card</h4>
-			<div class="flex flex-wrap gap-6">
-				@testimonialCard()
-			</div>
-		</div>
+// cardTestimonialPreview renders the testimonial card recipe.
+templ cardTestimonialPreview() {
+	<div id="card-testimonial" class="w-full max-w-md mx-auto">
+		@testimonialCard()
 	</div>
 }
 
@@ -156,7 +211,7 @@ templ bookNowButton() {
 templ ecommerceProductCard() {
 	<article class="group flex rounded-radius max-w-sm flex-col overflow-hidden border border-outline bg-surface-alt text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark">
 		<div class="h-44 md:h-64 overflow-hidden">
-			<img src="/assets/images/cards/card-img-3.webp" class="object-cover transition duration-700 ease-out group-hover:scale-105" alt="CASIO G-SHOCK GA2100" />
+			<img src="/assets/images/cards/card-img-3.webp" class="object-cover transition duration-700 ease-out group-hover:scale-105" alt="CASIO G-SHOCK GA2100"/>
 		</div>
 		<div class="flex flex-col gap-4 p-6">
 			<div class="flex flex-col md:flex-row gap-4 md:gap-12 justify-between">
@@ -210,14 +265,14 @@ templ pricingCard() {
 templ testimonialCard() {
 	<article class="group rounded-radius flex max-w-md flex-col border border-outline bg-surface-alt p-6 text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark">
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-12 text-on-surface-strong dark:text-on-surface-dark-strong group-hover:scale-105 transition duration-500 ease-out" aria-hidden="true">
-			<path d="M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z" />
+			<path d="M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z"></path>
 		</svg>
 		<p class="mt-2 text-pretty text-sm">
 			Simply put, this software transformed my workflow! Its intuitive interface and powerful features make tasks a breeze. A game-changer for productivity!
 		</p>
 		<div class="flex flex-col-reverse md:flex-row md:items-center mt-8 justify-between gap-6">
 			<div class="flex items-center gap-2">
-				<img src="/assets/images/avatars/avatar-1.webp" class="size-10 rounded-full object-cover" alt="Bob Johnson" />
+				<img src="/assets/images/avatars/avatar-1.webp" class="size-10 rounded-full object-cover" alt="Bob Johnson"/>
 				<div class="flex flex-col gap-1">
 					<h3 class="font-bold leading-4 text-on-surface-strong dark:text-on-surface-dark-strong">Bob Johnson</h3>
 					<span class="text-xs">CEO - TechNova</span>

--- a/internal/pages/demo/components/card_templ.go
+++ b/internal/pages/demo/components/card_templ.go
@@ -44,7 +44,8 @@ func CardDemoPage() templ.Component {
 	})
 }
 
-// cardDemoContent renders the actual content inside the layout
+// cardDemoContent renders the demo. Each card recipe lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/card).
 func cardDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -66,61 +67,142 @@ func cardDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"card-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Card",
-				Description: "A card is a flexible container that groups related content and actions. Used for displaying products, articles, testimonials, and more.",
+				Description: "A flexible container that groups related content and actions — products, articles, testimonials, pricing, and more.",
 			},
-			cardDemoPreview(),
-			`// Simple Card
-@card.Card(card.Config{
-    Image:       "https://example.com/image.jpg",
-    ImageAlt:    "Description",
+			cardDefaultPreview(),
+			`@card.Card(card.Config{
+    Image:       "/assets/images/cards/card-img-1.webp",
+    ImageAlt:    "A penguin robot talking with a human",
     Tag:         "Features",
-    Title:       "Card Title",
-    Description: "Card description text...",
-})
-
-// Card with Button
-@card.Card(card.Config{
-    Image:       "https://example.com/image.jpg",
-    Title:       "Mediterranean Escape",
-    Description: "Relax under the sun and savor delicious cuisine",
-    Footer:      bookButton(),
-})
-
-// Horizontal Layout Card
-@card.Card(card.Config{
-    Layout:      card.LayoutHorizontal,
-    Image:       "https://example.com/image.jpg",
-    Title:       "AI-Powered VR Goggles",
-    Description: "Experience the next level of augmented reality",
-})
-
-// E-commerce Product Card
-@card.Card(card.Config{
-    Image:       "product.jpg",
-    Title:       "Product Name",
-    Description: "Product description",
-    Price:       "$99.99",
-    Rating:      4,
-})
-
-// Testimonial Card
-@card.Card(card.Config{
-    Title:       "Testimonial",
-    Description: "Quote text...",
-    Footer:      testimonialFooter(),
-})
-
-// Pricing Card (Primary variant)
-@card.Card(card.Config{
-    Variant:     card.Primary,
-    Title:       "Premium",
-    Description: "Best tools for productivity",
-    Footer:      pricingFooter(),
+    Title:       "Penguai can teach you Javascript",
+    Description: "Learning JavaScript doesn't need to be difficult...",
 })`,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Card with Button",
+				Description: "Pass any templ.Component as Footer to add actions below the body.",
+			},
+			cardButtonPreview(),
+			`@card.Card(card.Config{
+    Image:       "/assets/images/cards/card-img-2.webp",
+    Title:       "Mediterranean Escape",
+    Description: "Relax under the sun and savor delicious cuisine.",
+    Footer:      bookNowButton(),
+})
+
+templ bookNowButton() {
+    <div class="mt-2">
+        @button.Button(button.Config{Variant: button.Primary, Type: "button"}) { Book Now }
+    </div>
+}`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Horizontal Layout",
+				Description: "Set Layout: card.LayoutHorizontal to place the image beside the content instead of above it.",
+			},
+			cardHorizontalPreview(),
+			`@card.Card(card.Config{
+    Layout:      card.LayoutHorizontal,
+    Image:       "/assets/images/cards/card-img-4.webp",
+    Tag:         "Artificial Intelligence",
+    Title:       "AI-Powered VR Goggles Redefine Reality",
+    Description: "Experience the next level of augmented reality...",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Product Card",
+				Description: "An e-commerce recipe: compose a bordered article with card.StarRating, a price, and an Add to Cart button. (Config.Price/Rating are exposed but rendered by the caller, not the base template.)",
+			},
+			cardProductPreview(),
+			`<article class="group flex rounded-radius max-w-sm flex-col overflow-hidden border border-outline bg-surface-alt ...">
+    <div class="h-44 md:h-64 overflow-hidden">
+        <img src="/assets/images/cards/card-img-3.webp" alt="CASIO G-SHOCK GA2100" />
+    </div>
+    <div class="flex flex-col gap-4 p-6">
+        <h3 class="text-lg font-bold">CASIO G-SHOCK GA2100</h3>
+        @card.StarRating(3)
+        <span class="text-xl font-medium">$99.99</span>
+        @button.Button(button.Config{Variant: button.Primary}) { Add to Cart }
+    </div>
+</article>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Pricing Card",
+				Description: "A pricing recipe using the primary border accent and a full-width CTA. Composed as a custom article.",
+			},
+			cardPricingPreview(),
+			`<article class="group flex rounded-radius max-w-xs flex-col overflow-hidden border-2 border-primary bg-surface-alt p-6 ...">
+    <span class="ml-auto w-fit rounded-radius bg-primary px-2 py-1 text-xs text-on-primary">TOP CHOICE</span>
+    <h3 class="text-xl font-bold">Premium</h3>
+    <span class="mt-8 text-3xl font-medium">$8.99</span>
+    <ul class="mt-4 list-inside list-disc space-y-2 text-sm">...</ul>
+    @button.Button(button.Config{Variant: button.Primary, Class: "w-full"}) { Start your free trial }
+</article>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Testimonial Card",
+				Description: "A quote recipe pairing a person, role, and card.StarRating in the footer row.",
+			},
+			cardTestimonialPreview(),
+			`<article class="group rounded-radius flex max-w-md flex-col border border-outline bg-surface-alt p-6 ...">
+    <svg class="size-12">...</svg>
+    <p class="mt-2 text-sm">Simply put, this software transformed my workflow!...</p>
+    <div class="flex mt-8 justify-between gap-6">
+        <div class="flex items-center gap-2">
+            <img src="/assets/images/avatars/avatar-1.webp" class="size-10 rounded-full" alt="Bob Johnson" />
+            <div><h3 class="font-bold">Bob Johnson</h3><span class="text-xs">CEO - TechNova</span></div>
+        </div>
+        @card.StarRating(4)
+    </div>
+</article>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Image", Type: "string", Default: `""`, Description: "Card image URL (rendered above the body, or beside it in horizontal layout)."},
+			{Name: "ImageAlt", Type: "string", Default: `""`, Description: "Alt text for the image."},
+			{Name: "Tag", Type: "string", Default: `""`, Description: "Optional category/tag shown above the title."},
+			{Name: "Title", Type: "string", Default: `""`, Description: "Card title (also seeds the aria-describedby id)."},
+			{Name: "Description", Type: "string", Default: `""`, Description: "Body text."},
+			{Name: "Footer", Type: "templ.Component", Default: "nil", Description: "Optional footer content (buttons, links, ratings) rendered below the body."},
+			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Style: "default" or "primary" (adds a 2px primary border accent).`},
+			{Name: "Layout", Type: "Layout", Default: "LayoutVertical", Description: `Layout: "vertical" (image top) or "horizontal" (image beside content).`},
+			{Name: "Price", Type: "string", Default: `""`, Description: "Exposed for ecommerce recipes; render via a custom Footer (base template does not emit it)."},
+			{Name: "Rating", Type: "int", Default: "0", Description: "Exposed for ecommerce recipes; render with card.StarRating in a Footer."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes appended to the article container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -128,8 +210,8 @@ func cardDemoContent() templ.Component {
 	})
 }
 
-// cardDemoPreview renders the Goshtoso card preview
-func cardDemoPreview() templ.Component {
+// cardDefaultPreview renders the simple default card.
+func cardDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -150,7 +232,7 @@ func cardDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-5xl mx-auto space-y-12\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Card</h4><div class=\"flex flex-wrap gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"card-default\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -164,7 +246,37 @@ func cardDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Card with Button</h4><div class=\"flex flex-wrap gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// cardButtonPreview renders a card with a footer button.
+func cardButtonPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"card-button\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -178,7 +290,37 @@ func cardDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Horizontal Layout</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// cardHorizontalPreview renders the horizontal-layout card.
+func cardHorizontalPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"card-horizontal\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -193,7 +335,37 @@ func cardDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Product Card</h4><div class=\"flex flex-wrap gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// cardProductPreview renders the e-commerce product card recipe.
+func cardProductPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"card-product\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -201,7 +373,37 @@ func cardDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Pricing Card</h4><div class=\"flex flex-wrap gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// cardPricingPreview renders the pricing card recipe.
+func cardPricingPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"card-pricing\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -209,7 +411,37 @@ func cardDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Testimonial Card</h4><div class=\"flex flex-wrap gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// cardTestimonialPreview renders the testimonial card recipe.
+func cardTestimonialPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"card-testimonial\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -217,7 +449,7 @@ func cardDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -242,16 +474,16 @@ func bookNowButton() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var4 == nil {
-			templ_7745c5c3_Var4 = templ.NopComponent
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"mt-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div class=\"mt-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var5 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var10 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -263,7 +495,7 @@ func bookNowButton() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "Book Now")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "Book Now")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -272,11 +504,11 @@ func bookNowButton() templ.Component {
 		templ_7745c5c3_Err = button.Button(button.Config{
 			Variant: button.Primary,
 			Type:    "button",
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var5), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -301,12 +533,12 @@ func ecommerceProductCard() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<article class=\"group flex rounded-radius max-w-sm flex-col overflow-hidden border border-outline bg-surface-alt text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><div class=\"h-44 md:h-64 overflow-hidden\"><img src=\"/assets/images/cards/card-img-3.webp\" class=\"object-cover transition duration-700 ease-out group-hover:scale-105\" alt=\"CASIO G-SHOCK GA2100\"></div><div class=\"flex flex-col gap-4 p-6\"><div class=\"flex flex-col md:flex-row gap-4 md:gap-12 justify-between\"><div class=\"flex flex-col\"><h3 class=\"text-lg lg:text-xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">CASIO G-SHOCK GA2100</h3>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<article class=\"group flex rounded-radius max-w-sm flex-col overflow-hidden border border-outline bg-surface-alt text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><div class=\"h-44 md:h-64 overflow-hidden\"><img src=\"/assets/images/cards/card-img-3.webp\" class=\"object-cover transition duration-700 ease-out group-hover:scale-105\" alt=\"CASIO G-SHOCK GA2100\"></div><div class=\"flex flex-col gap-4 p-6\"><div class=\"flex flex-col md:flex-row gap-4 md:gap-12 justify-between\"><div class=\"flex flex-col\"><h3 class=\"text-lg lg:text-xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">CASIO G-SHOCK GA2100</h3>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -314,11 +546,11 @@ func ecommerceProductCard() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div><span class=\"text-xl font-medium\">$99.99</span></div><p class=\"mb-2 text-pretty text-sm\">The Casio G-Shock GA2100 is simply designed for easy timekeeping, featuring a sleek profile and clear display.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div><span class=\"text-xl font-medium\">$99.99</span></div><p class=\"mb-2 text-pretty text-sm\">The Casio G-Shock GA2100 is simply designed for easy timekeeping, featuring a sleek profile and clear display.</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var12 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -330,7 +562,7 @@ func ecommerceProductCard() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "Add to Cart")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "Add to Cart")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -339,11 +571,11 @@ func ecommerceProductCard() templ.Component {
 		templ_7745c5c3_Err = button.Button(button.Config{
 			Variant: button.Primary,
 			Type:    "button",
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div></article>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</div></article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -368,16 +600,16 @@ func pricingCard() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<article class=\"group flex rounded-radius w-full max-w-xs flex-col overflow-hidden border-2 border-primary bg-surface-alt p-6 text-on-surface dark:border-primary-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><span class=\"ml-auto w-fit rounded-radius bg-primary px-2 py-1 text-xs font-medium text-on-primary dark:bg-primary-dark dark:text-on-primary-dark\">TOP CHOICE</span><h3 class=\"text-xl text-balance md:text-2xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">Premium</h3><p class=\"mt-2 text-pretty text-xs font-medium\">Best tools for productivity</p><span class=\"mt-8 text-balance text-3xl md:text-4xl font-medium text-on-surface dark:text-on-surface-dark\">$8.99</span> <span class=\"mt-2 text-pretty text-xs font-medium\">Per month</span><h4 class=\"mt-12 font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Features</h4><ul class=\"mt-4 list-inside list-disc space-y-2 text-sm font-medium marker:text-lg marker:text-primary dark:marker:text-primary-dark\"><li>Unlimited access to all courses</li><li>Personalized learning plan</li><li>Offline viewing</li><li>No ads</li><li>High quality video</li><li>Cancel anytime</li></ul><div class=\"mt-12\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<article class=\"group flex rounded-radius w-full max-w-xs flex-col overflow-hidden border-2 border-primary bg-surface-alt p-6 text-on-surface dark:border-primary-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><span class=\"ml-auto w-fit rounded-radius bg-primary px-2 py-1 text-xs font-medium text-on-primary dark:bg-primary-dark dark:text-on-primary-dark\">TOP CHOICE</span><h3 class=\"text-xl text-balance md:text-2xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">Premium</h3><p class=\"mt-2 text-pretty text-xs font-medium\">Best tools for productivity</p><span class=\"mt-8 text-balance text-3xl md:text-4xl font-medium text-on-surface dark:text-on-surface-dark\">$8.99</span> <span class=\"mt-2 text-pretty text-xs font-medium\">Per month</span><h4 class=\"mt-12 font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Features</h4><ul class=\"mt-4 list-inside list-disc space-y-2 text-sm font-medium marker:text-lg marker:text-primary dark:marker:text-primary-dark\"><li>Unlimited access to all courses</li><li>Personalized learning plan</li><li>Offline viewing</li><li>No ads</li><li>High quality video</li><li>Cancel anytime</li></ul><div class=\"mt-12\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var9 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var14 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -389,7 +621,7 @@ func pricingCard() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "Start your free trial")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "Start your free trial")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -399,11 +631,11 @@ func pricingCard() templ.Component {
 			Variant: button.Primary,
 			Type:    "button",
 			Class:   "w-full",
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var9), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div></article>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div></article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -428,12 +660,12 @@ func testimonialCard() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var10 == nil {
-			templ_7745c5c3_Var10 = templ.NopComponent
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<article class=\"group rounded-radius flex max-w-md flex-col border border-outline bg-surface-alt p-6 text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 16 16\" fill=\"currentColor\" class=\"size-12 text-on-surface-strong dark:text-on-surface-dark-strong group-hover:scale-105 transition duration-500 ease-out\" aria-hidden=\"true\"><path d=\"M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z\"></path></svg><p class=\"mt-2 text-pretty text-sm\">Simply put, this software transformed my workflow! Its intuitive interface and powerful features make tasks a breeze. A game-changer for productivity!</p><div class=\"flex flex-col-reverse md:flex-row md:items-center mt-8 justify-between gap-6\"><div class=\"flex items-center gap-2\"><img src=\"/assets/images/avatars/avatar-1.webp\" class=\"size-10 rounded-full object-cover\" alt=\"Bob Johnson\"><div class=\"flex flex-col gap-1\"><h3 class=\"font-bold leading-4 text-on-surface-strong dark:text-on-surface-dark-strong\">Bob Johnson</h3><span class=\"text-xs\">CEO - TechNova</span></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<article class=\"group rounded-radius flex max-w-md flex-col border border-outline bg-surface-alt p-6 text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 16 16\" fill=\"currentColor\" class=\"size-12 text-on-surface-strong dark:text-on-surface-dark-strong group-hover:scale-105 transition duration-500 ease-out\" aria-hidden=\"true\"><path d=\"M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z\"></path></svg><p class=\"mt-2 text-pretty text-sm\">Simply put, this software transformed my workflow! Its intuitive interface and powerful features make tasks a breeze. A game-changer for productivity!</p><div class=\"flex flex-col-reverse md:flex-row md:items-center mt-8 justify-between gap-6\"><div class=\"flex items-center gap-2\"><img src=\"/assets/images/avatars/avatar-1.webp\" class=\"size-10 rounded-full object-cover\" alt=\"Bob Johnson\"><div class=\"flex flex-col gap-1\"><h3 class=\"font-bold leading-4 text-on-surface-strong dark:text-on-surface-dark-strong\">Bob Johnson</h3><span class=\"text-xs\">CEO - TechNova</span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -441,7 +673,7 @@ func testimonialCard() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div></article>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</div></article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/carousel.templ
+++ b/internal/pages/demo/components/carousel.templ
@@ -10,148 +10,213 @@ templ CarouselDemoPage() {
 	@demo.Layout("Carousel", "carousel", carouselDemoContent())
 }
 
-// carouselDemoContent renders all carousel variant demos
+// carouselDemoContent renders the demo. Each carousel variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/carousel). Wrapped in #carousel-fragment.
 templ carouselDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Carousel",
-			Description:   "A carousel component for cycling through slides with images, text overlays, autoplay, touch support, and HTMX dynamic loading.",
-		},
-		carouselDemoPreview(),
-		carouselDemoCode,
-	)
-}
-
-var carouselDemoCode = `// Default Carousel
-@carousel.Carousel(carousel.Config{
+	<div id="carousel-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Carousel",
+				Description: "Cycle through slides with images, text overlays, CTAs, autoplay, touch/swipe, fixed aspect ratios, card framing, and HTMX dynamic loading.",
+			},
+			carouselDefaultPreview(),
+			`@carousel.Carousel(carousel.Config{
     Slides: []carousel.Slide{
-        {ImgSrc: "img1.webp", ImgAlt: "Slide 1"},
-        {ImgSrc: "img2.webp", ImgAlt: "Slide 2"},
+        {ImgSrc: "slide-1.webp", ImgAlt: "Slide 1"},
+        {ImgSrc: "slide-2.webp", ImgAlt: "Slide 2"},
     },
-})
+})`,
+		)
 
-// With Text Overlay
-@carousel.Carousel(carousel.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Text Overlay",
+				Description: "Variant: carousel.WithText adds a gradient title + description overlay per slide.",
+			},
+			carouselTextPreview(),
+			`@carousel.Carousel(carousel.Config{
     Variant: carousel.WithText,
     Slides: []carousel.Slide{
-        {ImgSrc: "img1.webp", ImgAlt: "...", Title: "Hello", Description: "World"},
+        {ImgSrc: "slide-1.webp", ImgAlt: "...", Title: "Front end developers", Description: "The architects of the digital world."},
     },
-})
+})`,
+		)
 
-// With CTA Button
-@carousel.Carousel(carousel.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With CTA Button",
+				Description: "Variant: carousel.WithCTA adds a call-to-action button using each slide's CTAUrl + CTAText.",
+			},
+			carouselCTAPreview(),
+			`@carousel.Carousel(carousel.Config{
     Variant: carousel.WithCTA,
     Slides: []carousel.Slide{
-        {ImgSrc: "img1.webp", ImgAlt: "...", Title: "Title", Description: "Desc", CTAUrl: "/link", CTAText: "Learn More"},
+        {ImgSrc: "slide-1.webp", ImgAlt: "...", Title: "Build faster", Description: "Pre-built UI components.", CTAUrl: "#", CTAText: "Get Started"},
     },
-})
+})`,
+		)
 
-// With Autoplay
-@carousel.Carousel(carousel.Config{
-    Autoplay: &carousel.AutoplayConfig{Interval: 4000},
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Autoplay",
+				Description: "Pass an Autoplay config to advance slides automatically every Interval milliseconds.",
+			},
+			carouselAutoplayPreview(),
+			`@carousel.Carousel(carousel.Config{
     Variant:  carousel.WithText,
+    Autoplay: &carousel.AutoplayConfig{Interval: 4000},
     Slides:   slides,
-})
+})`,
+		)
 
-// Fixed Aspect Ratio (3:1)
-@carousel.Carousel(carousel.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Fixed Aspect Ratio (3:1)",
+				Description: "Set AspectRatio (e.g. \"3/1\") to lock the frame's proportions.",
+			},
+			carouselAspectPreview(),
+			`@carousel.Carousel(carousel.Config{
     AspectRatio: "3/1",
     Slides:      slides,
-})
+})`,
+		)
 
-// With Touch / Swipe
-@carousel.Carousel(carousel.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Touch / Swipe",
+				Description: "Touch: true enables left/right swipe gestures on touch devices.",
+			},
+			carouselTouchPreview(),
+			`@carousel.Carousel(carousel.Config{
     Touch:  true,
     Slides: slides,
-})
+})`,
+		)
 
-// On Card
-@carousel.Carousel(carousel.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "On Card",
+				Description: "Variant: carousel.OnCard frames the carousel in an article card with product info below.",
+			},
+			carouselCardPreview(),
+			`@carousel.Carousel(carousel.Config{
     Variant: carousel.OnCard,
     Slides: []carousel.Slide{
-        {ImgSrc: "img.webp", ImgAlt: "...", Title: "Product", Description: "$29.99"},
+        {ImgSrc: "slide-1.webp", ImgAlt: "...", Title: "Abstract Blue Series", Description: "Limited edition print. $49.99"},
     },
-})
+})`,
+		)
 
-// HTMX Dynamic Loading
-@carousel.Carousel(carousel.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "HTMX Dynamic Loading",
+				Description: "Provide an HTMX config and the slides are fetched from the server on page load.",
+			},
+			carouselHTMXPreview(),
+			`@carousel.Carousel(carousel.Config{
     HTMX: &carousel.HTMXConfig{Get: "/api/components/carousel/slides"},
-})`
+})`,
+		)
+	</div>
+	// API reference lives outside #carousel-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Slides", Type: "[]Slide", Default: "nil", Description: "Slide data (ImgSrc, ImgAlt, Title, Description, CTAUrl, CTAText)."},
+		{Name: "Variant", Type: "Variant", Default: "Default", Description: `Style: "default", "with-text", "with-cta", "on-card".`},
+		{Name: "Autoplay", Type: "*AutoplayConfig", Default: "nil", Description: "Auto-advance config (Interval in ms)."},
+		{Name: "Touch", Type: "bool", Default: "false", Description: "Enable left/right swipe gestures."},
+		{Name: "AspectRatio", Type: "string", Default: `""`, Description: `Lock the frame ratio (e.g. "3/1", "16/9").`},
+		{Name: "Height", Type: "string", Default: `""`, Description: "Explicit height override (when AspectRatio is unset)."},
+		{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "Fetch slides from the server (Get URL)."},
+		{Name: "ID", Type: "string", Default: "auto", Description: "Container id used for Alpine state scoping; auto-generated when empty."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the carousel container."},
+	})
+}
 
-templ carouselDemoPreview() {
-	<div class="space-y-12">
-		<!-- Default -->
-		<div>
-			<h4 class="mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">Default</h4>
-			@carousel.Carousel(carousel.Config{
-				Slides: defaultSlides(),
-			})
-		</div>
+// carouselDefaultPreview renders the image-only default carousel.
+templ carouselDefaultPreview() {
+	<div id="carousel-default" class="w-full max-w-2xl mx-auto">
+		@carousel.Carousel(carousel.Config{
+			ID:     "carousel-default-c",
+			Slides: defaultSlides(),
+		})
+	</div>
+}
 
-		<!-- With Text -->
-		<div>
-			<h4 class="mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">With Text Overlay</h4>
-			@carousel.Carousel(carousel.Config{
-				Variant: carousel.WithText,
-				Slides:  textSlides(),
-			})
-		</div>
+// carouselTextPreview renders the text-overlay variant.
+templ carouselTextPreview() {
+	<div id="carousel-text" class="w-full max-w-2xl mx-auto">
+		@carousel.Carousel(carousel.Config{
+			ID:      "carousel-text-c",
+			Variant: carousel.WithText,
+			Slides:  textSlides(),
+		})
+	</div>
+}
 
-		<!-- With CTA -->
-		<div>
-			<h4 class="mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">With CTA Button</h4>
-			@carousel.Carousel(carousel.Config{
-				Variant: carousel.WithCTA,
-				Slides:  ctaSlides(),
-			})
-		</div>
+// carouselCTAPreview renders the CTA-button variant.
+templ carouselCTAPreview() {
+	<div id="carousel-cta" class="w-full max-w-2xl mx-auto">
+		@carousel.Carousel(carousel.Config{
+			ID:      "carousel-cta-c",
+			Variant: carousel.WithCTA,
+			Slides:  ctaSlides(),
+		})
+	</div>
+}
 
-		<!-- With Autoplay -->
-		<div>
-			<h4 class="mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">With Autoplay</h4>
-			@carousel.Carousel(carousel.Config{
-				Variant:  carousel.WithText,
-				Autoplay: &carousel.AutoplayConfig{Interval: 4000},
-				Slides:   textSlides(),
-			})
-		</div>
+// carouselAutoplayPreview renders the autoplay variant.
+templ carouselAutoplayPreview() {
+	<div id="carousel-autoplay" class="w-full max-w-2xl mx-auto">
+		@carousel.Carousel(carousel.Config{
+			ID:       "carousel-autoplay-c",
+			Variant:  carousel.WithText,
+			Autoplay: &carousel.AutoplayConfig{Interval: 4000},
+			Slides:   textSlides(),
+		})
+	</div>
+}
 
-		<!-- Fixed Aspect Ratio -->
-		<div>
-			<h4 class="mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">Fixed Aspect Ratio (3:1)</h4>
-			@carousel.Carousel(carousel.Config{
-				AspectRatio: "3/1",
-				Slides:      defaultSlides(),
-			})
-		</div>
+// carouselAspectPreview renders the fixed-aspect-ratio variant.
+templ carouselAspectPreview() {
+	<div id="carousel-aspect" class="w-full max-w-2xl mx-auto">
+		@carousel.Carousel(carousel.Config{
+			ID:          "carousel-aspect-c",
+			AspectRatio: "3/1",
+			Slides:      defaultSlides(),
+		})
+	</div>
+}
 
-		<!-- With Touch -->
-		<div>
-			<h4 class="mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">With Touch / Swipe</h4>
-			<p class="mb-2 text-sm text-on-surface-muted dark:text-on-surface-dark-muted">Swipe left or right on touch devices</p>
-			@carousel.Carousel(carousel.Config{
-				Touch:  true,
-				Slides: defaultSlides(),
-			})
-		</div>
+// carouselTouchPreview renders the touch/swipe variant.
+templ carouselTouchPreview() {
+	<div id="carousel-touch" class="w-full max-w-2xl mx-auto">
+		@carousel.Carousel(carousel.Config{
+			ID:     "carousel-touch-c",
+			Touch:  true,
+			Slides: defaultSlides(),
+		})
+	</div>
+}
 
-		<!-- On Card -->
-		<div>
-			<h4 class="mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">On Card</h4>
-			@carousel.Carousel(carousel.Config{
-				Variant: carousel.OnCard,
-				Slides:  cardSlides(),
-			})
-		</div>
+// carouselCardPreview renders the on-card variant.
+templ carouselCardPreview() {
+	<div id="carousel-card" class="w-full max-w-2xl mx-auto">
+		@carousel.Carousel(carousel.Config{
+			ID:      "carousel-card-c",
+			Variant: carousel.OnCard,
+			Slides:  cardSlides(),
+		})
+	</div>
+}
 
-		<!-- HTMX Dynamic -->
-		<div>
-			<h4 class="mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">HTMX Dynamic Loading</h4>
-			<p class="mb-2 text-sm text-on-surface-muted dark:text-on-surface-dark-muted">Slides fetched from the server via HTMX on page load</p>
-			@carousel.Carousel(carousel.Config{
-				HTMX: &carousel.HTMXConfig{Get: "/api/components/carousel/slides"},
-			})
-		</div>
+// carouselHTMXPreview renders the HTMX dynamic-loading variant.
+templ carouselHTMXPreview() {
+	<div id="carousel-htmx" class="w-full max-w-2xl mx-auto">
+		@carousel.Carousel(carousel.Config{
+			ID:   "carousel-htmx-c",
+			HTMX: &carousel.HTMXConfig{Get: "/api/components/carousel/slides"},
+		})
 	</div>
 }
 

--- a/internal/pages/demo/components/carousel_templ.go
+++ b/internal/pages/demo/components/carousel_templ.go
@@ -43,7 +43,9 @@ func CarouselDemoPage() templ.Component {
 	})
 }
 
-// carouselDemoContent renders all carousel variant demos
+// carouselDemoContent renders the demo. Each carousel variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/carousel). Wrapped in #carousel-fragment.
 func carouselDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,14 +67,145 @@ func carouselDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"carousel-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Carousel",
-				Description: "A carousel component for cycling through slides with images, text overlays, autoplay, touch support, and HTMX dynamic loading.",
+				Description: "Cycle through slides with images, text overlays, CTAs, autoplay, touch/swipe, fixed aspect ratios, card framing, and HTMX dynamic loading.",
 			},
-			carouselDemoPreview(),
-			carouselDemoCode,
+			carouselDefaultPreview(),
+			`@carousel.Carousel(carousel.Config{
+    Slides: []carousel.Slide{
+        {ImgSrc: "slide-1.webp", ImgAlt: "Slide 1"},
+        {ImgSrc: "slide-2.webp", ImgAlt: "Slide 2"},
+    },
+})`,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Text Overlay",
+				Description: "Variant: carousel.WithText adds a gradient title + description overlay per slide.",
+			},
+			carouselTextPreview(),
+			`@carousel.Carousel(carousel.Config{
+    Variant: carousel.WithText,
+    Slides: []carousel.Slide{
+        {ImgSrc: "slide-1.webp", ImgAlt: "...", Title: "Front end developers", Description: "The architects of the digital world."},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With CTA Button",
+				Description: "Variant: carousel.WithCTA adds a call-to-action button using each slide's CTAUrl + CTAText.",
+			},
+			carouselCTAPreview(),
+			`@carousel.Carousel(carousel.Config{
+    Variant: carousel.WithCTA,
+    Slides: []carousel.Slide{
+        {ImgSrc: "slide-1.webp", ImgAlt: "...", Title: "Build faster", Description: "Pre-built UI components.", CTAUrl: "#", CTAText: "Get Started"},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Autoplay",
+				Description: "Pass an Autoplay config to advance slides automatically every Interval milliseconds.",
+			},
+			carouselAutoplayPreview(),
+			`@carousel.Carousel(carousel.Config{
+    Variant:  carousel.WithText,
+    Autoplay: &carousel.AutoplayConfig{Interval: 4000},
+    Slides:   slides,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Fixed Aspect Ratio (3:1)",
+				Description: "Set AspectRatio (e.g. \"3/1\") to lock the frame's proportions.",
+			},
+			carouselAspectPreview(),
+			`@carousel.Carousel(carousel.Config{
+    AspectRatio: "3/1",
+    Slides:      slides,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Touch / Swipe",
+				Description: "Touch: true enables left/right swipe gestures on touch devices.",
+			},
+			carouselTouchPreview(),
+			`@carousel.Carousel(carousel.Config{
+    Touch:  true,
+    Slides: slides,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "On Card",
+				Description: "Variant: carousel.OnCard frames the carousel in an article card with product info below.",
+			},
+			carouselCardPreview(),
+			`@carousel.Carousel(carousel.Config{
+    Variant: carousel.OnCard,
+    Slides: []carousel.Slide{
+        {ImgSrc: "slide-1.webp", ImgAlt: "...", Title: "Abstract Blue Series", Description: "Limited edition print. $49.99"},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "HTMX Dynamic Loading",
+				Description: "Provide an HTMX config and the slides are fetched from the server on page load.",
+			},
+			carouselHTMXPreview(),
+			`@carousel.Carousel(carousel.Config{
+    HTMX: &carousel.HTMXConfig{Get: "/api/components/carousel/slides"},
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Slides", Type: "[]Slide", Default: "nil", Description: "Slide data (ImgSrc, ImgAlt, Title, Description, CTAUrl, CTAText)."},
+			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Style: "default", "with-text", "with-cta", "on-card".`},
+			{Name: "Autoplay", Type: "*AutoplayConfig", Default: "nil", Description: "Auto-advance config (Interval in ms)."},
+			{Name: "Touch", Type: "bool", Default: "false", Description: "Enable left/right swipe gestures."},
+			{Name: "AspectRatio", Type: "string", Default: `""`, Description: `Lock the frame ratio (e.g. "3/1", "16/9").`},
+			{Name: "Height", Type: "string", Default: `""`, Description: "Explicit height override (when AspectRatio is unset)."},
+			{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "Fetch slides from the server (Get URL)."},
+			{Name: "ID", Type: "string", Default: "auto", Description: "Container id used for Alpine state scoping; auto-generated when empty."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the carousel container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -80,63 +213,8 @@ func carouselDemoContent() templ.Component {
 	})
 }
 
-var carouselDemoCode = `// Default Carousel
-@carousel.Carousel(carousel.Config{
-    Slides: []carousel.Slide{
-        {ImgSrc: "img1.webp", ImgAlt: "Slide 1"},
-        {ImgSrc: "img2.webp", ImgAlt: "Slide 2"},
-    },
-})
-
-// With Text Overlay
-@carousel.Carousel(carousel.Config{
-    Variant: carousel.WithText,
-    Slides: []carousel.Slide{
-        {ImgSrc: "img1.webp", ImgAlt: "...", Title: "Hello", Description: "World"},
-    },
-})
-
-// With CTA Button
-@carousel.Carousel(carousel.Config{
-    Variant: carousel.WithCTA,
-    Slides: []carousel.Slide{
-        {ImgSrc: "img1.webp", ImgAlt: "...", Title: "Title", Description: "Desc", CTAUrl: "/link", CTAText: "Learn More"},
-    },
-})
-
-// With Autoplay
-@carousel.Carousel(carousel.Config{
-    Autoplay: &carousel.AutoplayConfig{Interval: 4000},
-    Variant:  carousel.WithText,
-    Slides:   slides,
-})
-
-// Fixed Aspect Ratio (3:1)
-@carousel.Carousel(carousel.Config{
-    AspectRatio: "3/1",
-    Slides:      slides,
-})
-
-// With Touch / Swipe
-@carousel.Carousel(carousel.Config{
-    Touch:  true,
-    Slides: slides,
-})
-
-// On Card
-@carousel.Carousel(carousel.Config{
-    Variant: carousel.OnCard,
-    Slides: []carousel.Slide{
-        {ImgSrc: "img.webp", ImgAlt: "...", Title: "Product", Description: "$29.99"},
-    },
-})
-
-// HTMX Dynamic Loading
-@carousel.Carousel(carousel.Config{
-    HTMX: &carousel.HTMXConfig{Get: "/api/components/carousel/slides"},
-})`
-
-func carouselDemoPreview() templ.Component {
+// carouselDefaultPreview renders the image-only default carousel.
+func carouselDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -157,43 +235,137 @@ func carouselDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-12\"><!-- Default --><div><h4 class=\"mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Default</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"carousel-default\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = carousel.Carousel(carousel.Config{
+			ID:     "carousel-default-c",
 			Slides: defaultSlides(),
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><!-- With Text --><div><h4 class=\"mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">With Text Overlay</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// carouselTextPreview renders the text-overlay variant.
+func carouselTextPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"carousel-text\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = carousel.Carousel(carousel.Config{
+			ID:      "carousel-text-c",
 			Variant: carousel.WithText,
 			Slides:  textSlides(),
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><!-- With CTA --><div><h4 class=\"mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">With CTA Button</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// carouselCTAPreview renders the CTA-button variant.
+func carouselCTAPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"carousel-cta\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = carousel.Carousel(carousel.Config{
+			ID:      "carousel-cta-c",
 			Variant: carousel.WithCTA,
 			Slides:  ctaSlides(),
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><!-- With Autoplay --><div><h4 class=\"mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">With Autoplay</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// carouselAutoplayPreview renders the autoplay variant.
+func carouselAutoplayPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"carousel-autoplay\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = carousel.Carousel(carousel.Config{
+			ID:       "carousel-autoplay-c",
 			Variant:  carousel.WithText,
 			Autoplay: &carousel.AutoplayConfig{Interval: 4000},
 			Slides:   textSlides(),
@@ -201,50 +373,174 @@ func carouselDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div><!-- Fixed Aspect Ratio --><div><h4 class=\"mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Fixed Aspect Ratio (3:1)</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// carouselAspectPreview renders the fixed-aspect-ratio variant.
+func carouselAspectPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"carousel-aspect\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = carousel.Carousel(carousel.Config{
+			ID:          "carousel-aspect-c",
 			AspectRatio: "3/1",
 			Slides:      defaultSlides(),
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div><!-- With Touch --><div><h4 class=\"mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">With Touch / Swipe</h4><p class=\"mb-2 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Swipe left or right on touch devices</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// carouselTouchPreview renders the touch/swipe variant.
+func carouselTouchPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"carousel-touch\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = carousel.Carousel(carousel.Config{
+			ID:     "carousel-touch-c",
 			Touch:  true,
 			Slides: defaultSlides(),
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div><!-- On Card --><div><h4 class=\"mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">On Card</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// carouselCardPreview renders the on-card variant.
+func carouselCardPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"carousel-card\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = carousel.Carousel(carousel.Config{
+			ID:      "carousel-card-c",
 			Variant: carousel.OnCard,
 			Slides:  cardSlides(),
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div><!-- HTMX Dynamic --><div><h4 class=\"mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">HTMX Dynamic Loading</h4><p class=\"mb-2 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Slides fetched from the server via HTMX on page load</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// carouselHTMXPreview renders the HTMX dynamic-loading variant.
+func carouselHTMXPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"carousel-htmx\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = carousel.Carousel(carousel.Config{
+			ID:   "carousel-htmx-c",
 			HTMX: &carousel.HTMXConfig{Get: "/api/components/carousel/slides"},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/checkbox.templ
+++ b/internal/pages/demo/components/checkbox.templ
@@ -10,48 +10,87 @@ templ CheckboxDemoPage() {
 	@demo.Layout("Checkbox", "checkbox", checkboxDemoContent())
 }
 
-// checkboxDemoContent renders the actual content inside the layout
+// checkboxDemoContent renders the demo. Each checkbox variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/checkbox). Wrapped in #checkbox-fragment.
 templ checkboxDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Checkbox",
-			Description:   "A checkbox allows users to select one or more options from a set. Supports color variants, custom icons, animations, descriptions, containers, and groups.",
-		},
-		checkboxDemoPreview(),
-		`// Default Checkbox
-@checkbox.Checkbox(checkbox.Config{
+	<div id="checkbox-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Checkbox",
+				Description: "Select one or more options. Supports color variants, custom icons, animations, descriptions, a bordered container, groups, and disabled states.",
+			},
+			checkboxDefaultPreview(),
+			`@checkbox.Checkbox(checkbox.Config{
     ID:      "notifications",
     Label:   "Notifications",
     Checked: true,
-})
+})`,
+		)
 
-// Color Variant
-@checkbox.Checkbox(checkbox.Config{
-    ID:      "success",
-    Label:   "Success",
-    Variant: checkbox.Success,
-    Checked: true,
-})
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Color Variants",
+				Description: "Set Variant: Primary, Secondary, Info, Success, Warning, or Danger.",
+			},
+			checkboxColorsPreview(),
+			`@checkbox.Checkbox(checkbox.Config{ID: "success", Label: "Success", Variant: checkbox.Success, Checked: true})`,
+		)
 
-// With Description
-@checkbox.Checkbox(checkbox.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Custom Icons",
+				Description: "Swap the check glyph with Icon: checkbox.IconXmark, IconMinus, or IconPlus.",
+			},
+			checkboxIconsPreview(),
+			`@checkbox.Checkbox(checkbox.Config{ID: "iconPlus", Label: "Plus", Icon: checkbox.IconPlus, Checked: true})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Animations",
+				Description: "Set Animation: checkbox.AnimationSlideUp, AnimationScaleUp, or AnimationSlideDown for an animated check transition.",
+			},
+			checkboxAnimationsPreview(),
+			`@checkbox.Checkbox(checkbox.Config{ID: "anim", Label: "Slide Up", Animation: checkbox.AnimationSlideUp, Checked: true})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Description",
+				Description: "Add Description (and DescriptionID for aria-describedby) for helper text under the label.",
+			},
+			checkboxDescriptionPreview(),
+			`@checkbox.Checkbox(checkbox.Config{
     ID:            "email",
     Label:         "Email Updates",
     Description:   "You only gonna get good news, promise.",
     DescriptionID: "emailDesc",
     Checked:       true,
-})
+})`,
+		)
 
-// With Container
-@checkbox.Checkbox(checkbox.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Container",
+				Description: "Container: true wraps the checkbox and label in a bordered, justify-between container.",
+			},
+			checkboxContainerPreview(),
+			`@checkbox.Checkbox(checkbox.Config{
     ID:        "containerCheck",
     Label:     "Notifications",
     Container: true,
     Checked:   true,
-})
+})`,
+		)
 
-// Checkbox Group
-@checkbox.CheckboxGroup(checkbox.GroupConfig{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Checkbox Group",
+				Description: "checkbox.CheckboxGroup renders a titled set of related checkboxes.",
+			},
+			checkboxGroupPreview(),
+			`@checkbox.CheckboxGroup(checkbox.GroupConfig{
     Title: "Notifications",
     Items: []checkbox.Config{
         {ID: "email", Label: "Email notifications", Value: "email", Checked: true},
@@ -59,32 +98,56 @@ templ checkboxDemoContent() {
         {ID: "sms", Label: "SMS alerts", Value: "sms", Checked: true},
     },
 })`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks interaction in both the checked and unchecked states.",
+			},
+			checkboxDisabledPreview(),
+			`@checkbox.Checkbox(checkbox.Config{ID: "off", Label: "Disabled unchecked", Disabled: true})
+@checkbox.Checkbox(checkbox.Config{ID: "on", Label: "Disabled checked", Disabled: true, Checked: true})`,
+		)
+	</div>
+	// API reference lives outside #checkbox-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the input (and label's for target)."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+		{Name: "Value", Type: "string", Default: `""`, Description: "Form field value when checked."},
+		{Name: "Label", Type: "string", Default: `""`, Description: "Label text beside the box."},
+		{Name: "Checked", Type: "bool", Default: "false", Description: "Initial checked state."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
+		{Name: "Variant", Type: "Variant", Default: "Primary", Description: `Color: "primary", "secondary", "info", "success", "warning", "danger".`},
+		{Name: "Icon", Type: "Icon", Default: "IconCheck", Description: `Check glyph: "check", "xmark", "minus", "plus".`},
+		{Name: "Animation", Type: "Animation", Default: "AnimationNone", Description: `Check transition: "", "slide-up", "scale-up", "slide-down".`},
+		{Name: "Description", Type: "string", Default: `""`, Description: "Helper text below the label."},
+		{Name: "DescriptionID", Type: "string", Default: `""`, Description: "ID of the description for aria-describedby."},
+		{Name: "Container", Type: "bool", Default: "false", Description: "Wrap in a bordered container."},
+	})
 }
 
-// checkboxDemoPreview renders the Goshtoso checkbox preview
-templ checkboxDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Default Checkbox
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Checkbox</h4>
-			<div class="flex flex-wrap gap-4">
-				@checkbox.Checkbox(checkbox.Config{
-					ID:      "defaultChecked",
-					Label:   "Notifications",
-					Checked: true,
-				})
-				@checkbox.Checkbox(checkbox.Config{
-					ID:    "defaultUnchecked",
-					Label: "Unchecked",
-				})
-			</div>
+// checkboxDefaultPreview renders the default checked/unchecked pair.
+templ checkboxDefaultPreview() {
+	<div id="checkbox-default" class="w-full max-w-md mx-auto">
+		<div class="flex flex-wrap gap-4">
+			@checkbox.Checkbox(checkbox.Config{
+				ID:      "defaultChecked",
+				Label:   "Notifications",
+				Checked: true,
+			})
+			@checkbox.Checkbox(checkbox.Config{
+				ID:    "defaultUnchecked",
+				Label: "Unchecked",
+			})
 		</div>
+	</div>
+}
 
-		// Color Variants
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Color Variants</h4>
-			<div class="flex flex-wrap gap-4">
+// checkboxColorsPreview renders the six color variants.
+templ checkboxColorsPreview() {
+	<div id="checkbox-colors" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-4">
 				@checkbox.Checkbox(checkbox.Config{
 					ID:      "variantPrimary",
 					Label:   "Primary",
@@ -123,11 +186,12 @@ templ checkboxDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Custom Icons
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Custom Icons</h4>
-			<div class="flex flex-wrap gap-4">
+// checkboxIconsPreview renders the custom-icon variants.
+templ checkboxIconsPreview() {
+	<div id="checkbox-icons" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-4">
 				@checkbox.Checkbox(checkbox.Config{
 					ID:      "iconXmark",
 					Label:   "Xmark",
@@ -148,11 +212,12 @@ templ checkboxDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Animations
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Animations</h4>
-			<div class="flex flex-wrap gap-4">
+// checkboxAnimationsPreview renders the animation variants.
+templ checkboxAnimationsPreview() {
+	<div id="checkbox-animations" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-4">
 				@checkbox.Checkbox(checkbox.Config{
 					ID:        "animSlideUp",
 					Label:     "Slide Up",
@@ -173,34 +238,37 @@ templ checkboxDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// With Description
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With Description</h4>
-			@checkbox.Checkbox(checkbox.Config{
-				ID:            "descriptionCheckbox",
+// checkboxDescriptionPreview renders a checkbox with a description.
+templ checkboxDescriptionPreview() {
+	<div id="checkbox-description" class="w-full max-w-md mx-auto">
+		@checkbox.Checkbox(checkbox.Config{
+			ID:            "descriptionCheckbox",
 				Label:         "Email Updates",
 				Description:   "You only gonna get good news, promise.",
 				DescriptionID: "checkboxDescription",
 				Checked:       true,
 			})
 		</div>
+}
 
-		// With Container
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With Container</h4>
-			@checkbox.Checkbox(checkbox.Config{
-				ID:        "containerCheckbox",
+// checkboxContainerPreview renders the container-style checkbox.
+templ checkboxContainerPreview() {
+	<div id="checkbox-container" class="w-full max-w-md mx-auto">
+		@checkbox.Checkbox(checkbox.Config{
+			ID:        "containerCheckbox",
 				Label:     "Notifications",
 				Container: true,
 				Checked:   true,
 			})
 		</div>
+}
 
-		// Checkbox Group
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Checkbox Group</h4>
-			@checkbox.CheckboxGroup(checkbox.GroupConfig{
+// checkboxGroupPreview renders a titled checkbox group.
+templ checkboxGroupPreview() {
+	<div id="checkbox-group" class="w-full max-w-md mx-auto">
+		@checkbox.CheckboxGroup(checkbox.GroupConfig{
 				Title: "Notifications",
 				Items: []checkbox.Config{
 					{ID: "groupEmail", Label: "Email notifications", Value: "Email notifications", Checked: true},
@@ -209,11 +277,12 @@ templ checkboxDemoPreview() {
 				},
 			})
 		</div>
+}
 
-		// Disabled State
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Disabled</h4>
-			<div class="flex flex-wrap gap-4">
+// checkboxDisabledPreview renders the disabled states.
+templ checkboxDisabledPreview() {
+	<div id="checkbox-disabled" class="w-full max-w-md mx-auto">
+		<div class="flex flex-wrap gap-4">
 				@checkbox.Checkbox(checkbox.Config{
 					ID:       "disabledUnchecked",
 					Label:    "Disabled unchecked",
@@ -227,5 +296,4 @@ templ checkboxDemoPreview() {
 				})
 			</div>
 		</div>
-	</div>
 }

--- a/internal/pages/demo/components/checkbox_templ.go
+++ b/internal/pages/demo/components/checkbox_templ.go
@@ -43,7 +43,9 @@ func CheckboxDemoPage() templ.Component {
 	})
 }
 
-// checkboxDemoContent renders the actual content inside the layout
+// checkboxDemoContent renders the demo. Each checkbox variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/checkbox). Wrapped in #checkbox-fragment.
 func checkboxDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,46 +67,98 @@ func checkboxDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"checkbox-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Checkbox",
-				Description: "A checkbox allows users to select one or more options from a set. Supports color variants, custom icons, animations, descriptions, containers, and groups.",
+				Description: "Select one or more options. Supports color variants, custom icons, animations, descriptions, a bordered container, groups, and disabled states.",
 			},
-			checkboxDemoPreview(),
-			`// Default Checkbox
-@checkbox.Checkbox(checkbox.Config{
+			checkboxDefaultPreview(),
+			`@checkbox.Checkbox(checkbox.Config{
     ID:      "notifications",
     Label:   "Notifications",
     Checked: true,
-})
-
-// Color Variant
-@checkbox.Checkbox(checkbox.Config{
-    ID:      "success",
-    Label:   "Success",
-    Variant: checkbox.Success,
-    Checked: true,
-})
-
-// With Description
-@checkbox.Checkbox(checkbox.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Color Variants",
+				Description: "Set Variant: Primary, Secondary, Info, Success, Warning, or Danger.",
+			},
+			checkboxColorsPreview(),
+			`@checkbox.Checkbox(checkbox.Config{ID: "success", Label: "Success", Variant: checkbox.Success, Checked: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Custom Icons",
+				Description: "Swap the check glyph with Icon: checkbox.IconXmark, IconMinus, or IconPlus.",
+			},
+			checkboxIconsPreview(),
+			`@checkbox.Checkbox(checkbox.Config{ID: "iconPlus", Label: "Plus", Icon: checkbox.IconPlus, Checked: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Animations",
+				Description: "Set Animation: checkbox.AnimationSlideUp, AnimationScaleUp, or AnimationSlideDown for an animated check transition.",
+			},
+			checkboxAnimationsPreview(),
+			`@checkbox.Checkbox(checkbox.Config{ID: "anim", Label: "Slide Up", Animation: checkbox.AnimationSlideUp, Checked: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Description",
+				Description: "Add Description (and DescriptionID for aria-describedby) for helper text under the label.",
+			},
+			checkboxDescriptionPreview(),
+			`@checkbox.Checkbox(checkbox.Config{
     ID:            "email",
     Label:         "Email Updates",
     Description:   "You only gonna get good news, promise.",
     DescriptionID: "emailDesc",
     Checked:       true,
-})
-
-// With Container
-@checkbox.Checkbox(checkbox.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Container",
+				Description: "Container: true wraps the checkbox and label in a bordered, justify-between container.",
+			},
+			checkboxContainerPreview(),
+			`@checkbox.Checkbox(checkbox.Config{
     ID:        "containerCheck",
     Label:     "Notifications",
     Container: true,
     Checked:   true,
-})
-
-// Checkbox Group
-@checkbox.CheckboxGroup(checkbox.GroupConfig{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Checkbox Group",
+				Description: "checkbox.CheckboxGroup renders a titled set of related checkboxes.",
+			},
+			checkboxGroupPreview(),
+			`@checkbox.CheckboxGroup(checkbox.GroupConfig{
     Title: "Notifications",
     Items: []checkbox.Config{
         {ID: "email", Label: "Email notifications", Value: "email", Checked: true},
@@ -116,12 +170,45 @@ func checkboxDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks interaction in both the checked and unchecked states.",
+			},
+			checkboxDisabledPreview(),
+			`@checkbox.Checkbox(checkbox.Config{ID: "off", Label: "Disabled unchecked", Disabled: true})
+@checkbox.Checkbox(checkbox.Config{ID: "on", Label: "Disabled checked", Disabled: true, Checked: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the input (and label's for target)."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+			{Name: "Value", Type: "string", Default: `""`, Description: "Form field value when checked."},
+			{Name: "Label", Type: "string", Default: `""`, Description: "Label text beside the box."},
+			{Name: "Checked", Type: "bool", Default: "false", Description: "Initial checked state."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
+			{Name: "Variant", Type: "Variant", Default: "Primary", Description: `Color: "primary", "secondary", "info", "success", "warning", "danger".`},
+			{Name: "Icon", Type: "Icon", Default: "IconCheck", Description: `Check glyph: "check", "xmark", "minus", "plus".`},
+			{Name: "Animation", Type: "Animation", Default: "AnimationNone", Description: `Check transition: "", "slide-up", "scale-up", "slide-down".`},
+			{Name: "Description", Type: "string", Default: `""`, Description: "Helper text below the label."},
+			{Name: "DescriptionID", Type: "string", Default: `""`, Description: "ID of the description for aria-describedby."},
+			{Name: "Container", Type: "bool", Default: "false", Description: "Wrap in a bordered container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// checkboxDemoPreview renders the Goshtoso checkbox preview
-func checkboxDemoPreview() templ.Component {
+// checkboxDefaultPreview renders the default checked/unchecked pair.
+func checkboxDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -142,7 +229,7 @@ func checkboxDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Checkbox</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"checkbox-default\" class=\"w-full max-w-md mx-auto\"><div class=\"flex flex-wrap gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -161,7 +248,37 @@ func checkboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Color Variants</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// checkboxColorsPreview renders the six color variants.
+func checkboxColorsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"checkbox-colors\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -219,7 +336,37 @@ func checkboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Custom Icons</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// checkboxIconsPreview renders the custom-icon variants.
+func checkboxIconsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"checkbox-icons\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -250,7 +397,37 @@ func checkboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Animations</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// checkboxAnimationsPreview renders the animation variants.
+func checkboxAnimationsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"checkbox-animations\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -281,7 +458,37 @@ func checkboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With Description</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// checkboxDescriptionPreview renders a checkbox with a description.
+func checkboxDescriptionPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"checkbox-description\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -295,7 +502,37 @@ func checkboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With Container</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// checkboxContainerPreview renders the container-style checkbox.
+func checkboxContainerPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"checkbox-container\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -308,7 +545,37 @@ func checkboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Checkbox Group</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// checkboxGroupPreview renders a titled checkbox group.
+func checkboxGroupPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"checkbox-group\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -323,7 +590,37 @@ func checkboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Disabled</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// checkboxDisabledPreview renders the disabled states.
+func checkboxDisabledPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"checkbox-disabled\" class=\"w-full max-w-md mx-auto\"><div class=\"flex flex-wrap gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -344,7 +641,7 @@ func checkboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/combobox.templ
+++ b/internal/pages/demo/components/combobox.templ
@@ -10,73 +10,143 @@ templ ComboboxDemoPage() {
 	@demo.Layout("Combobox", "combobox", comboboxDemoContent())
 }
 
-// comboboxDemoContent renders the actual content inside the layout
+// comboboxDemoContent renders the demo. Each combobox variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/combobox). Wrapped in #combobox-fragment.
 templ comboboxDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Combobox",
-			Description:   "A combobox is an input widget with an associated popup that enables users to select a value from a collection of possible values.",
-		},
-		comboboxDemoPreview(),
-		`// Simple Single-Select
-@combobox.Combobox(combobox.Config{
+	<div id="combobox-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Combobox",
+				Description: "An input with an associated popup for selecting from a set of values. Single or multi-select, optional search, avatars, pre-selected values, clear-all, disabled, and HTMX lazy loading.",
+			},
+			comboboxSinglePreview(),
+			`@combobox.Combobox(combobox.Config{
     ID:          "industry",
     Label:       "Industry",
     Placeholder: "Select an industry",
     Options: []combobox.Option{
         {Value: "tech", Label: "Technology"},
-        {Value: "health", Label: "Healthcare"},
         {Value: "finance", Label: "Finance"},
     },
-})
+})`,
+		)
 
-// Multi-Select with Checkboxes
-@combobox.Combobox(combobox.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Single Select with Search",
+				Description: "EnableSearch: true adds a search box to filter options.",
+			},
+			comboboxSearchPreview(),
+			`@combobox.Combobox(combobox.Config{
+    ID:           "make",
+    Label:        "Make",
+    EnableSearch: true,
+    Options:      makes,
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Multi-Select with Checkboxes",
+				Description: "Mode: combobox.ModeMultiple shows checkboxes and keeps the popup open; EnableClearAll adds a clear-all action.",
+			},
+			comboboxMultiPreview(),
+			`@combobox.Combobox(combobox.Config{
     ID:             "skills",
     Label:          "Skills",
     Mode:           combobox.ModeMultiple,
     EnableClearAll: true,
-    Options: []combobox.Option{
-        {Value: "go", Label: "Go"},
-        {Value: "js", Label: "JavaScript"},
-        {Value: "py", Label: "Python"},
-    },
-})
-
-// With Search
-@combobox.Combobox(combobox.Config{
-    ID:           "country",
-    Label:        "Country",
-    EnableSearch: true,
-    Options:      countries,
-})
-
-// With Images (Avatars)
-@combobox.Combobox(combobox.Config{
-    ID:      "user",
-    Label:   "Share with",
-    Options: users, // Options with Img field
-})
-
-// HTMX Lazy Loading
-@combobox.Combobox(combobox.Config{
-    ID:              "products",
-    Label:           "Product",
-    HXMTEndpoint:    "/api/products",
-    EnableSearch:    true,
-    HTMXSearchParam: "q",
+    Options:        skills,
 })`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Multi-Select with Search",
+				Description: "Combine ModeMultiple with EnableSearch for a searchable multi-select.",
+			},
+			comboboxMultiSearchPreview(),
+			`@combobox.Combobox(combobox.Config{
+    ID:             "languages",
+    Label:          "Languages",
+    Mode:           combobox.ModeMultiple,
+    EnableSearch:   true,
+    EnableClearAll: true,
+    Options:        languages,
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Images",
+				Description: "Give each Option an Img to render an avatar beside its label.",
+			},
+			comboboxImagesPreview(),
+			`@combobox.Combobox(combobox.Config{
+    ID:    "user",
+    Label: "Share with",
+    Options: []combobox.Option{
+        {Value: "aiden", Label: "Aiden Walker", Img: "/avatars/avatar-1.webp"},
+    },
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Pre-selected Values",
+				Description: "Pass Selected to seed the initial selection.",
+			},
+			comboboxPreselectedPreview(),
+			`@combobox.Combobox(combobox.Config{
+    ID:       "preselected",
+    Label:    "Frameworks",
+    Mode:     combobox.ModeMultiple,
+    Selected: []string{"react", "vue"},
+    Options:  frameworks,
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks interaction. (For server-driven options, set HXMTEndpoint + HTMXSearchParam for HTMX lazy loading.)",
+			},
+			comboboxDisabledPreview(),
+			`@combobox.Combobox(combobox.Config{
+    ID:       "disabled",
+    Label:    "Disabled Combobox",
+    Disabled: true,
+    Options:  options,
+})`,
+		)
+	</div>
+	// API reference lives outside #combobox-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id (seeds the trigger id <id>-trigger, label, and listbox)."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Form field name (multi-select submits as name[])."},
+		{Name: "Label", Type: "string", Default: `""`, Description: "Label above the combobox."},
+		{Name: "Placeholder", Type: "string", Default: `""`, Description: "Trigger placeholder when nothing is selected."},
+		{Name: "Options", Type: "[]Option", Default: "nil", Description: "Options (Value, Label, optional Img)."},
+		{Name: "Selected", Type: "[]string", Default: "nil", Description: "Initially selected option values."},
+		{Name: "Mode", Type: "SelectionMode", Default: "single", Description: `Selection: single or combobox.ModeMultiple (checkboxes).`},
+		{Name: "EnableSearch", Type: "bool", Default: "false", Description: "Add a search box to filter options."},
+		{Name: "EnableClearAll", Type: "bool", Default: "false", Description: "Show a clear-all action (multi-select)."},
+		{Name: "State", Type: "State", Default: "StateDefault", Description: "Validation state (default/error/success)."},
+		{Name: "Size", Type: "Size", Default: "md", Description: "Control size."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
+		{Name: "HXMTEndpoint", Type: "string", Default: `""`, Description: "Server URL for HTMX lazy-loaded options."},
+		{Name: "HTMXSearchParam", Type: "string", Default: `""`, Description: "Query param name for the search term sent to HXMTEndpoint."},
+		{Name: "NoResultsText", Type: "string", Default: `""`, Description: "Message shown when search yields no matches."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+	})
 }
 
-// comboboxDemoPreview renders the Goshtoso combobox preview
-templ comboboxDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Simple Single-Select
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Single Select</h4>
-			@combobox.Combobox(combobox.Config{
-				ID:          "industry",
+// comboboxSinglePreview renders the simple single-select combobox.
+templ comboboxSinglePreview() {
+	<div id="combobox-single" class="w-full max-w-xs mx-auto">
+		@combobox.Combobox(combobox.Config{
+			ID:          "industry",
 				Label:       "Industry",
 				Placeholder: "Select an industry",
 				Name:        "industry",
@@ -97,11 +167,13 @@ templ comboboxDemoPreview() {
 			})
 		</div>
 
-		// Single-Select with Search
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Single Select with Search</h4>
-			@combobox.Combobox(combobox.Config{
-				ID:           "make",
+}
+
+// comboboxSearchPreview renders the searchable single-select.
+templ comboboxSearchPreview() {
+	<div id="combobox-search" class="w-full max-w-xs mx-auto">
+		@combobox.Combobox(combobox.Config{
+			ID:           "make",
 				Label:        "Make",
 				Placeholder:  "Select a make",
 				Name:         "make",
@@ -130,11 +202,13 @@ templ comboboxDemoPreview() {
 			})
 		</div>
 
-		// Multi-Select with Checkboxes
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Multi-Select with Checkboxes</h4>
-			@combobox.Combobox(combobox.Config{
-				ID:             "skills",
+}
+
+// comboboxMultiPreview renders the multi-select with checkboxes.
+templ comboboxMultiPreview() {
+	<div id="combobox-multi" class="w-full max-w-xs mx-auto">
+		@combobox.Combobox(combobox.Config{
+			ID:             "skills",
 				Label:          "Skills",
 				Placeholder:    "Select skills",
 				Name:           "skills",
@@ -157,11 +231,13 @@ templ comboboxDemoPreview() {
 			})
 		</div>
 
-		// Multi-Select with Search
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Multi-Select with Search</h4>
-			@combobox.Combobox(combobox.Config{
-				ID:             "languages",
+}
+
+// comboboxMultiSearchPreview renders the searchable multi-select.
+templ comboboxMultiSearchPreview() {
+	<div id="combobox-multi-search" class="w-full max-w-xs mx-auto">
+		@combobox.Combobox(combobox.Config{
+			ID:             "languages",
 				Label:          "Languages",
 				Placeholder:    "Select languages",
 				Name:           "languages",
@@ -185,11 +261,13 @@ templ comboboxDemoPreview() {
 			})
 		</div>
 
-		// With Images (Avatars)
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With Images</h4>
-			@combobox.Combobox(combobox.Config{
-				ID:          "user",
+}
+
+// comboboxImagesPreview renders the combobox with avatar images.
+templ comboboxImagesPreview() {
+	<div id="combobox-images" class="w-full max-w-xs mx-auto">
+		@combobox.Combobox(combobox.Config{
+			ID:          "user",
 				Label:       "Share with",
 				Placeholder: "Select a user",
 				Name:        "user",
@@ -203,11 +281,13 @@ templ comboboxDemoPreview() {
 			})
 		</div>
 
-		// Pre-selected Values
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Pre-selected Values</h4>
-			@combobox.Combobox(combobox.Config{
-				ID:          "preselected",
+}
+
+// comboboxPreselectedPreview renders the combobox with pre-selected values.
+templ comboboxPreselectedPreview() {
+	<div id="combobox-preselected" class="w-full max-w-xs mx-auto">
+		@combobox.Combobox(combobox.Config{
+			ID:          "preselected",
 				Label:       "Frameworks",
 				Placeholder: "Select frameworks",
 				Name:        "frameworks",
@@ -223,11 +303,13 @@ templ comboboxDemoPreview() {
 			})
 		</div>
 
-		// Disabled State
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Disabled State</h4>
-			@combobox.Combobox(combobox.Config{
-				ID:       "disabled",
+}
+
+// comboboxDisabledPreview renders the disabled combobox.
+templ comboboxDisabledPreview() {
+	<div id="combobox-disabled" class="w-full max-w-xs mx-auto">
+		@combobox.Combobox(combobox.Config{
+			ID:       "disabled",
 				Label:    "Disabled Combobox",
 				Name:     "disabled",
 				Disabled: true,
@@ -236,6 +318,5 @@ templ comboboxDemoPreview() {
 					{Value: "b", Label: "Option B"},
 				},
 			})
-		</div>
 	</div>
 }

--- a/internal/pages/demo/components/combobox_new.templ
+++ b/internal/pages/demo/components/combobox_new.templ
@@ -58,20 +58,93 @@ templ ComboboxNewPage() {
 	@demo.Layout("Combobox (HTMX SSR rewrite)", "combobox-new", comboboxNewDemoContent())
 }
 
+// comboboxNewDemoContent renders the v2 (HTMX SSR rewrite) combobox demo. Each
+// mode lives in its own preview frame followed by its own code block (mirrors
+// penguinui.com/components/combobox). Wrapped in #combobox-new-fragment.
 templ comboboxNewDemoContent() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		<h1 class="text-2xl font-semibold">Combobox v2 (client + server modes)</h1>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted">
-			Client-mode comboboxes (industry, skills) toggle entirely in the browser — no HTTP on open/select. Server-mode (users) keeps the HTMX lazy/search path for cases where options can't be pre-rendered.
-		</p>
-		<div class="max-w-xs">
-			@combobox.Combobox(IndustryCfg, combobox.State{Options: IndustryCfg.Source.Static})
-		</div>
-		<div class="max-w-xs">
-			@combobox.Combobox(SkillsCfg, combobox.State{Options: SkillsCfg.Source.Static})
-		</div>
-		<div class="max-w-xs">
-			@combobox.Combobox(UsersCfg, combobox.State{})
-		</div>
+	<div id="combobox-new-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Combobox (v2 — client + server modes)",
+				Description: "The HTMX SSR rewrite. Client-mode comboboxes toggle entirely in the browser (no HTTP on open/select); server-mode keeps an HTMX lazy/search path for options that can't be pre-rendered.",
+			},
+			comboboxNewIndustryPreview(),
+			`// Client mode: options are pre-rendered, toggling happens in the browser.
+var IndustryCfg = combobox.Config{
+    ID: "industry", Name: "industry", Label: "Industry",
+    Mode:   combobox.ModeSingle,
+    Source: combobox.Source{Static: industryOptions},
+}
+@combobox.Combobox(IndustryCfg, combobox.State{Options: IndustryCfg.Source.Static})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Client Multi-Select",
+				Description: "Mode: combobox.ModeMultiple with EnableClearAll — still fully client-side.",
+			},
+			comboboxNewSkillsPreview(),
+			`var SkillsCfg = combobox.Config{
+    ID: "skills", Name: "skills", Mode: combobox.ModeMultiple, EnableClearAll: true,
+    Source: combobox.Source{Static: skillOptions},
+}
+@combobox.Combobox(SkillsCfg, combobox.State{Options: SkillsCfg.Source.Static})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Server Mode (lazy search)",
+				Description: "Set the Toggle/Options/Clear endpoints and a LazyEndpoint Source; the component fetches and searches options over HTMX.",
+			},
+			comboboxNewUsersPreview(),
+			`var UsersCfg = combobox.Config{
+    ID: "users", Name: "users", Mode: combobox.ModeMultiple,
+    EnableSearch: true, EnableClearAll: true,
+    ToggleEndpoint:  "/api/.../toggle",
+    OptionsEndpoint: "/api/.../options",
+    ClearEndpoint:   "/api/.../clear",
+    Source: combobox.Source{LazyEndpoint: "/api/.../options"},
+}
+@combobox.Combobox(UsersCfg, combobox.State{})`,
+		)
+	</div>
+	// API reference lives outside #combobox-new-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id (seeds #<id>-trigger, options, hidden inputs)."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Form field name (multi-select submits repeated hidden inputs)."},
+		{Name: "Label", Type: "string", Default: `""`, Description: "Label above the combobox."},
+		{Name: "Placeholder", Type: "string", Default: `""`, Description: "Trigger placeholder."},
+		{Name: "Mode", Type: "Mode", Default: "ModeSingle", Description: "combobox.ModeSingle or combobox.ModeMultiple."},
+		{Name: "Source", Type: "Source", Default: "{}", Description: "Options source: Static []Option (client mode) or LazyEndpoint (server mode)."},
+		{Name: "EnableSearch", Type: "bool", Default: "false", Description: "Show a search box (server mode queries the endpoint)."},
+		{Name: "EnableClearAll", Type: "bool", Default: "false", Description: "Show a clear-all action."},
+		{Name: "Required", Type: "bool", Default: "false", Description: "Mark the field required."},
+		{Name: "DependsOn", Type: "[]string", Default: "nil", Description: "Other field names that re-trigger this combobox."},
+		{Name: "ToggleEndpoint", Type: "string", Default: `""`, Description: "Server URL for toggling a selection (server mode)."},
+		{Name: "OptionsEndpoint", Type: "string", Default: `""`, Description: "Server URL for fetching/searching options."},
+		{Name: "ClearEndpoint", Type: "string", Default: `""`, Description: "Server URL for clearing the selection."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+	})
+}
+
+// comboboxNewIndustryPreview renders the client-mode single-select.
+templ comboboxNewIndustryPreview() {
+	<div id="combobox-new-industry" class="w-full max-w-xs mx-auto">
+		@combobox.Combobox(IndustryCfg, combobox.State{Options: IndustryCfg.Source.Static})
+	</div>
+}
+
+// comboboxNewSkillsPreview renders the client-mode multi-select.
+templ comboboxNewSkillsPreview() {
+	<div id="combobox-new-skills" class="w-full max-w-xs mx-auto">
+		@combobox.Combobox(SkillsCfg, combobox.State{Options: SkillsCfg.Source.Static})
+	</div>
+}
+
+// comboboxNewUsersPreview renders the server-mode lazy-search multi-select.
+templ comboboxNewUsersPreview() {
+	<div id="combobox-new-users" class="w-full max-w-xs mx-auto">
+		@combobox.Combobox(UsersCfg, combobox.State{})
 	</div>
 }

--- a/internal/pages/demo/components/combobox_new_templ.go
+++ b/internal/pages/demo/components/combobox_new_templ.go
@@ -91,6 +91,9 @@ func ComboboxNewPage() templ.Component {
 	})
 }
 
+// comboboxNewDemoContent renders the v2 (HTMX SSR rewrite) combobox demo. Each
+// mode lives in its own preview frame followed by its own code block (mirrors
+// penguinui.com/components/combobox). Wrapped in #combobox-new-fragment.
 func comboboxNewDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -112,7 +115,112 @@ func comboboxNewDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><h1 class=\"text-2xl font-semibold\">Combobox v2 (client + server modes)</h1><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Client-mode comboboxes (industry, skills) toggle entirely in the browser — no HTTP on open/select. Server-mode (users) keeps the HTMX lazy/search path for cases where options can't be pre-rendered.</p><div class=\"max-w-xs\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"combobox-new-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Combobox (v2 — client + server modes)",
+				Description: "The HTMX SSR rewrite. Client-mode comboboxes toggle entirely in the browser (no HTTP on open/select); server-mode keeps an HTMX lazy/search path for options that can't be pre-rendered.",
+			},
+			comboboxNewIndustryPreview(),
+			`// Client mode: options are pre-rendered, toggling happens in the browser.
+var IndustryCfg = combobox.Config{
+    ID: "industry", Name: "industry", Label: "Industry",
+    Mode:   combobox.ModeSingle,
+    Source: combobox.Source{Static: industryOptions},
+}
+@combobox.Combobox(IndustryCfg, combobox.State{Options: IndustryCfg.Source.Static})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Client Multi-Select",
+				Description: "Mode: combobox.ModeMultiple with EnableClearAll — still fully client-side.",
+			},
+			comboboxNewSkillsPreview(),
+			`var SkillsCfg = combobox.Config{
+    ID: "skills", Name: "skills", Mode: combobox.ModeMultiple, EnableClearAll: true,
+    Source: combobox.Source{Static: skillOptions},
+}
+@combobox.Combobox(SkillsCfg, combobox.State{Options: SkillsCfg.Source.Static})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Server Mode (lazy search)",
+				Description: "Set the Toggle/Options/Clear endpoints and a LazyEndpoint Source; the component fetches and searches options over HTMX.",
+			},
+			comboboxNewUsersPreview(),
+			`var UsersCfg = combobox.Config{
+    ID: "users", Name: "users", Mode: combobox.ModeMultiple,
+    EnableSearch: true, EnableClearAll: true,
+    ToggleEndpoint:  "/api/.../toggle",
+    OptionsEndpoint: "/api/.../options",
+    ClearEndpoint:   "/api/.../clear",
+    Source: combobox.Source{LazyEndpoint: "/api/.../options"},
+}
+@combobox.Combobox(UsersCfg, combobox.State{})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id (seeds #<id>-trigger, options, hidden inputs)."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Form field name (multi-select submits repeated hidden inputs)."},
+			{Name: "Label", Type: "string", Default: `""`, Description: "Label above the combobox."},
+			{Name: "Placeholder", Type: "string", Default: `""`, Description: "Trigger placeholder."},
+			{Name: "Mode", Type: "Mode", Default: "ModeSingle", Description: "combobox.ModeSingle or combobox.ModeMultiple."},
+			{Name: "Source", Type: "Source", Default: "{}", Description: "Options source: Static []Option (client mode) or LazyEndpoint (server mode)."},
+			{Name: "EnableSearch", Type: "bool", Default: "false", Description: "Show a search box (server mode queries the endpoint)."},
+			{Name: "EnableClearAll", Type: "bool", Default: "false", Description: "Show a clear-all action."},
+			{Name: "Required", Type: "bool", Default: "false", Description: "Mark the field required."},
+			{Name: "DependsOn", Type: "[]string", Default: "nil", Description: "Other field names that re-trigger this combobox."},
+			{Name: "ToggleEndpoint", Type: "string", Default: `""`, Description: "Server URL for toggling a selection (server mode)."},
+			{Name: "OptionsEndpoint", Type: "string", Default: `""`, Description: "Server URL for fetching/searching options."},
+			{Name: "ClearEndpoint", Type: "string", Default: `""`, Description: "Server URL for clearing the selection."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// comboboxNewIndustryPreview renders the client-mode single-select.
+func comboboxNewIndustryPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var3 == nil {
+			templ_7745c5c3_Var3 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"combobox-new-industry\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -120,7 +228,37 @@ func comboboxNewDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><div class=\"max-w-xs\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// comboboxNewSkillsPreview renders the client-mode multi-select.
+func comboboxNewSkillsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"combobox-new-skills\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -128,7 +266,37 @@ func comboboxNewDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><div class=\"max-w-xs\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// comboboxNewUsersPreview renders the server-mode lazy-search multi-select.
+func comboboxNewUsersPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"combobox-new-users\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -136,7 +304,7 @@ func comboboxNewDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/combobox_templ.go
+++ b/internal/pages/demo/components/combobox_templ.go
@@ -43,7 +43,9 @@ func ComboboxDemoPage() templ.Component {
 	})
 }
 
-// comboboxDemoContent renders the actual content inside the layout
+// comboboxDemoContent renders the demo. Each combobox variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/combobox). Wrapped in #combobox-fragment.
 func comboboxDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,61 +67,152 @@ func comboboxDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"combobox-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Combobox",
-				Description: "A combobox is an input widget with an associated popup that enables users to select a value from a collection of possible values.",
+				Description: "An input with an associated popup for selecting from a set of values. Single or multi-select, optional search, avatars, pre-selected values, clear-all, disabled, and HTMX lazy loading.",
 			},
-			comboboxDemoPreview(),
-			`// Simple Single-Select
-@combobox.Combobox(combobox.Config{
+			comboboxSinglePreview(),
+			`@combobox.Combobox(combobox.Config{
     ID:          "industry",
     Label:       "Industry",
     Placeholder: "Select an industry",
     Options: []combobox.Option{
         {Value: "tech", Label: "Technology"},
-        {Value: "health", Label: "Healthcare"},
         {Value: "finance", Label: "Finance"},
     },
-})
-
-// Multi-Select with Checkboxes
-@combobox.Combobox(combobox.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Single Select with Search",
+				Description: "EnableSearch: true adds a search box to filter options.",
+			},
+			comboboxSearchPreview(),
+			`@combobox.Combobox(combobox.Config{
+    ID:           "make",
+    Label:        "Make",
+    EnableSearch: true,
+    Options:      makes,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Multi-Select with Checkboxes",
+				Description: "Mode: combobox.ModeMultiple shows checkboxes and keeps the popup open; EnableClearAll adds a clear-all action.",
+			},
+			comboboxMultiPreview(),
+			`@combobox.Combobox(combobox.Config{
     ID:             "skills",
     Label:          "Skills",
     Mode:           combobox.ModeMultiple,
     EnableClearAll: true,
-    Options: []combobox.Option{
-        {Value: "go", Label: "Go"},
-        {Value: "js", Label: "JavaScript"},
-        {Value: "py", Label: "Python"},
-    },
-})
-
-// With Search
-@combobox.Combobox(combobox.Config{
-    ID:           "country",
-    Label:        "Country",
-    EnableSearch: true,
-    Options:      countries,
-})
-
-// With Images (Avatars)
-@combobox.Combobox(combobox.Config{
-    ID:      "user",
-    Label:   "Share with",
-    Options: users, // Options with Img field
-})
-
-// HTMX Lazy Loading
-@combobox.Combobox(combobox.Config{
-    ID:              "products",
-    Label:           "Product",
-    HXMTEndpoint:    "/api/products",
-    EnableSearch:    true,
-    HTMXSearchParam: "q",
+    Options:        skills,
 })`,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Multi-Select with Search",
+				Description: "Combine ModeMultiple with EnableSearch for a searchable multi-select.",
+			},
+			comboboxMultiSearchPreview(),
+			`@combobox.Combobox(combobox.Config{
+    ID:             "languages",
+    Label:          "Languages",
+    Mode:           combobox.ModeMultiple,
+    EnableSearch:   true,
+    EnableClearAll: true,
+    Options:        languages,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Images",
+				Description: "Give each Option an Img to render an avatar beside its label.",
+			},
+			comboboxImagesPreview(),
+			`@combobox.Combobox(combobox.Config{
+    ID:    "user",
+    Label: "Share with",
+    Options: []combobox.Option{
+        {Value: "aiden", Label: "Aiden Walker", Img: "/avatars/avatar-1.webp"},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Pre-selected Values",
+				Description: "Pass Selected to seed the initial selection.",
+			},
+			comboboxPreselectedPreview(),
+			`@combobox.Combobox(combobox.Config{
+    ID:       "preselected",
+    Label:    "Frameworks",
+    Mode:     combobox.ModeMultiple,
+    Selected: []string{"react", "vue"},
+    Options:  frameworks,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks interaction. (For server-driven options, set HXMTEndpoint + HTMXSearchParam for HTMX lazy loading.)",
+			},
+			comboboxDisabledPreview(),
+			`@combobox.Combobox(combobox.Config{
+    ID:       "disabled",
+    Label:    "Disabled Combobox",
+    Disabled: true,
+    Options:  options,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id (seeds the trigger id <id>-trigger, label, and listbox)."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Form field name (multi-select submits as name[])."},
+			{Name: "Label", Type: "string", Default: `""`, Description: "Label above the combobox."},
+			{Name: "Placeholder", Type: "string", Default: `""`, Description: "Trigger placeholder when nothing is selected."},
+			{Name: "Options", Type: "[]Option", Default: "nil", Description: "Options (Value, Label, optional Img)."},
+			{Name: "Selected", Type: "[]string", Default: "nil", Description: "Initially selected option values."},
+			{Name: "Mode", Type: "SelectionMode", Default: "single", Description: `Selection: single or combobox.ModeMultiple (checkboxes).`},
+			{Name: "EnableSearch", Type: "bool", Default: "false", Description: "Add a search box to filter options."},
+			{Name: "EnableClearAll", Type: "bool", Default: "false", Description: "Show a clear-all action (multi-select)."},
+			{Name: "State", Type: "State", Default: "StateDefault", Description: "Validation state (default/error/success)."},
+			{Name: "Size", Type: "Size", Default: "md", Description: "Control size."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
+			{Name: "HXMTEndpoint", Type: "string", Default: `""`, Description: "Server URL for HTMX lazy-loaded options."},
+			{Name: "HTMXSearchParam", Type: "string", Default: `""`, Description: "Query param name for the search term sent to HXMTEndpoint."},
+			{Name: "NoResultsText", Type: "string", Default: `""`, Description: "Message shown when search yields no matches."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -127,8 +220,8 @@ func comboboxDemoContent() templ.Component {
 	})
 }
 
-// comboboxDemoPreview renders the Goshtoso combobox preview
-func comboboxDemoPreview() templ.Component {
+// comboboxSinglePreview renders the simple single-select combobox.
+func comboboxSinglePreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -149,7 +242,7 @@ func comboboxDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Single Select</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"combobox-single\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -176,7 +269,37 @@ func comboboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Single Select with Search</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// comboboxSearchPreview renders the searchable single-select.
+func comboboxSearchPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"combobox-search\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -211,7 +334,37 @@ func comboboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Multi-Select with Checkboxes</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// comboboxMultiPreview renders the multi-select with checkboxes.
+func comboboxMultiPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"combobox-multi\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -240,7 +393,37 @@ func comboboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Multi-Select with Search</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// comboboxMultiSearchPreview renders the searchable multi-select.
+func comboboxMultiSearchPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"combobox-multi-search\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -270,7 +453,37 @@ func comboboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With Images</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// comboboxImagesPreview renders the combobox with avatar images.
+func comboboxImagesPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"combobox-images\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -290,7 +503,37 @@ func comboboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Pre-selected Values</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// comboboxPreselectedPreview renders the combobox with pre-selected values.
+func comboboxPreselectedPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"combobox-preselected\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -312,7 +555,37 @@ func comboboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Disabled State</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// comboboxDisabledPreview renders the disabled combobox.
+func comboboxDisabledPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"combobox-disabled\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -329,7 +602,7 @@ func comboboxDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/dropdown.templ
+++ b/internal/pages/demo/components/dropdown.templ
@@ -10,76 +10,123 @@ templ DropdownDemoPage() {
 	@demo.Layout("Dropdown", "dropdown", dropdownDemoContent())
 }
 
-// dropdownDemoContent renders the actual content inside the layout
+// dropdownDemoContent renders the demo. Each dropdown variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/dropdown). Wrapped in #dropdown-fragment.
 templ dropdownDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Dropdown",
-			Description:   "A dropdown menu displays a list of actions or options that a user can choose from. Supports click, hover, and context menu triggers with keyboard navigation.",
-		},
-		dropdownDemoPreview(),
-		`// Click Dropdown
-@dropdown.Dropdown(dropdown.Config{
+	<div id="dropdown-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Dropdown",
+				Description: "A menu of actions or options triggered by click, hover, or right-click (context). Supports sections/dividers, item icons, keyboard navigation, button items with handlers, disabled and danger items, and an icon-only trigger.",
+			},
+			dropdownClickPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
     Label: "Actions Menu",
     Sections: []dropdown.Section{
         {Items: []dropdown.Item{
             {Label: "Dashboard", Href: "#"},
-            {Label: "Subscription", Href: "#"},
             {Label: "Settings", Href: "#"},
             {Label: "Sign Out", Href: "#"},
-        }},
-    },
-})
-
-// Hover Dropdown
-@dropdown.Dropdown(dropdown.Config{
-    Label:       "Actions Menu",
-    TriggerMode: dropdown.TriggerHover,
-    Sections:    []dropdown.Section{...},
-})
-
-// Dropdown with Dividers
-@dropdown.Dropdown(dropdown.Config{
-    Label: "Actions Menu",
-    Sections: []dropdown.Section{
-        {Items: []dropdown.Item{
-            {Label: "Dashboard", Href: "#"},
-            {Label: "Messages", Href: "#"},
-        }},
-        {Items: []dropdown.Item{
-            {Label: "Profile", Href: "#"},
-            {Label: "Settings", Href: "#"},
-        }},
-        {Items: []dropdown.Item{
-            {Label: "Sign Out", Href: "#"},
-        }},
-    },
-})
-
-// Context Menu
-@dropdown.Dropdown(dropdown.Config{
-    TriggerMode: dropdown.TriggerContext,
-    Sections: []dropdown.Section{
-        {Items: []dropdown.Item{
-            {Label: "Undo", Icon: undoIcon(), Shortcut: "Z"},
-        }},
-        {Items: []dropdown.Item{
-            {Label: "Cut", Icon: cutIcon(), Shortcut: "X"},
-            {Label: "Copy", Icon: copyIcon(), Shortcut: "C"},
-            {Label: "Paste", Icon: pasteIcon(), Shortcut: "V"},
         }},
     },
 })`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Hover to Open",
+				Description: "TriggerMode: dropdown.TriggerHover opens the menu on pointer hover.",
+			},
+			dropdownHoverPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
+    Label:       "Actions Menu",
+    TriggerMode: dropdown.TriggerHover,
+    Sections:    sections,
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Dividers",
+				Description: "Each dropdown.Section is separated by a divider — group related items.",
+			},
+			dropdownDividerPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
+    Label: "Actions Menu",
+    Sections: []dropdown.Section{
+        {Items: []dropdown.Item{{Label: "Dashboard", Href: "#"}, {Label: "Messages", Href: "#"}}},
+        {Items: []dropdown.Item{{Label: "Profile", Href: "#"}, {Label: "Settings", Href: "#"}}},
+        {Items: []dropdown.Item{{Label: "Sign Out", Href: "#"}}},
+    },
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Icons",
+				Description: "Give each dropdown.Item an Icon component for a leading glyph.",
+			},
+			dropdownIconsPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
+    Label: "Actions Menu",
+    Sections: []dropdown.Section{
+        {Items: []dropdown.Item{{Label: "Dashboard", Href: "#", Icon: dashboardIcon()}}},
+    },
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Context Menu",
+				Description: "TriggerMode: dropdown.TriggerContext opens on right-click. Items can carry a Shortcut hint.",
+			},
+			dropdownContextPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
+    TriggerMode: dropdown.TriggerContext,
+    Sections: []dropdown.Section{
+        {Items: []dropdown.Item{{Label: "Undo", Icon: undoIcon(), Shortcut: "Z"}}},
+        {Items: []dropdown.Item{{Label: "Copy", Icon: copyIcon(), Shortcut: "C"}}},
+    },
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Action Items (onclick / disabled / danger)",
+				Description: "Items can run OnClick handlers, be Disabled (with a Tooltip), or be styled Danger. Pair with an icon-only trigger via TriggerIcon + TriggerIconOnly.",
+			},
+			dropdownActionsPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
+    Label:           "cluster actions",
+    TriggerIcon:     dotsVerticalIcon(),
+    TriggerIconOnly: true,
+    Sections: []dropdown.Section{
+        {Items: []dropdown.Item{
+            {Label: "Edit", Icon: settingsIcon(), OnClick: "editOpen = true"},
+            {Label: "Archive", Disabled: true, Tooltip: "Not available"},
+        }},
+        {Items: []dropdown.Item{{Label: "Delete", Danger: true, OnClick: "deleteOpen = true"}}},
+    },
+})`,
+		)
+	</div>
+	// API reference lives outside #dropdown-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Label", Type: "string", Default: `""`, Description: "Trigger button text (also the aria-label for icon-only triggers)."},
+		{Name: "TriggerMode", Type: "TriggerMode", Default: "TriggerClick", Description: `Open on: "click", "hover", or "context" (right-click).`},
+		{Name: "Sections", Type: "[]Section", Default: "nil", Description: "Groups of Items; each section is divider-separated. Item: Label, Href/OnClick, Icon, Shortcut, Disabled, Danger, Tooltip, ID."},
+		{Name: "TriggerIcon", Type: "templ.Component", Default: "nil", Description: "Custom trigger icon."},
+		{Name: "TriggerIconOnly", Type: "bool", Default: "false", Description: "Render only the icon as the trigger (uses Label for aria-label)."},
+		{Name: "MenuAlign", Type: "MenuAlign", Default: "left", Description: "Horizontal alignment of the menu relative to the trigger."},
+		{Name: "ID", Type: "string", Default: `""`, Description: "Container id (scopes the menu and Alpine state)."},
+	})
 }
 
-// dropdownDemoPreview renders the Goshtoso dropdown preview
-templ dropdownDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-12">
-		// Click Dropdown
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Click to Open</h4>
-			<div class="pb-2">
+// dropdownClickPreview renders the click-trigger dropdown.
+templ dropdownClickPreview() {
+	<div id="dropdown-click-box" class="w-full max-w-md mx-auto">
+		<div class="flex justify-center pb-2">
 				@dropdown.Dropdown(dropdown.Config{
 					ID:    "dropdown-click",
 					Label: "Actions Menu",
@@ -94,11 +141,12 @@ templ dropdownDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Hover Dropdown
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Hover to Open</h4>
-			<div class="pb-2">
+// dropdownHoverPreview renders the hover-trigger dropdown.
+templ dropdownHoverPreview() {
+	<div id="dropdown-hover-box" class="w-full max-w-md mx-auto">
+		<div class="flex justify-center pb-2">
 				@dropdown.Dropdown(dropdown.Config{
 					ID:          "dropdown-hover",
 					Label:       "Actions Menu",
@@ -114,11 +162,12 @@ templ dropdownDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Dropdown with Dividers
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With Dividers</h4>
-			<div class="pb-2">
+// dropdownDividerPreview renders the multi-section (divider) dropdown.
+templ dropdownDividerPreview() {
+	<div id="dropdown-divider-box" class="w-full max-w-md mx-auto">
+		<div class="flex justify-center pb-2">
 				@dropdown.Dropdown(dropdown.Config{
 					ID:    "dropdown-divider",
 					Label: "Actions Menu",
@@ -139,11 +188,12 @@ templ dropdownDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Dropdown with Icons
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With Icons</h4>
-			<div class="pb-2">
+// dropdownIconsPreview renders the dropdown with item icons.
+templ dropdownIconsPreview() {
+	<div id="dropdown-icons-box" class="w-full max-w-md mx-auto">
+		<div class="flex justify-center pb-2">
 				@dropdown.Dropdown(dropdown.Config{
 					ID:    "dropdown-icons",
 					Label: "Actions Menu",
@@ -164,11 +214,12 @@ templ dropdownDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Context Menu
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Context Menu</h4>
-			<div class="pb-2">
+// dropdownContextPreview renders the right-click context menu.
+templ dropdownContextPreview() {
+	<div id="dropdown-context-box" class="w-full max-w-md mx-auto">
+		<div class="flex justify-center pb-2">
 				@dropdown.Dropdown(dropdown.Config{
 					ID:          "dropdown-context",
 					TriggerMode: dropdown.TriggerContext,
@@ -188,13 +239,12 @@ templ dropdownDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Actions Menu — button items with click handlers, disabled, danger
-		<div x-data="{ editOpen: false, deleteOpen: false, editCount: 0 }">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">
-				Actions Menu (button items: onclick / disabled / danger / icon-only trigger)
-			</h4>
-			<div class="pb-2 flex items-center gap-4">
+// dropdownActionsPreview renders the action-items dropdown with an icon-only trigger.
+templ dropdownActionsPreview() {
+	<div id="dropdown-actions-box" class="w-full max-w-md mx-auto" x-data="{ editOpen: false, deleteOpen: false, editCount: 0 }">
+		<div class="pb-2 flex items-center justify-center gap-4">
 				@dropdown.Dropdown(dropdown.Config{
 					ID:              "dropdown-actions",
 					Label:           "cluster actions",
@@ -234,7 +284,6 @@ templ dropdownDemoPreview() {
 				</div>
 			</div>
 		</div>
-	</div>
 }
 
 // ddDotsVerticalIcon renders a vertical three-dots icon for overflow triggers

--- a/internal/pages/demo/components/dropdown_templ.go
+++ b/internal/pages/demo/components/dropdown_templ.go
@@ -43,7 +43,9 @@ func DropdownDemoPage() templ.Component {
 	})
 }
 
-// dropdownDemoContent renders the actual content inside the layout
+// dropdownDemoContent renders the demo. Each dropdown variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/dropdown). Wrapped in #dropdown-fragment.
 func dropdownDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,61 +67,23 @@ func dropdownDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"dropdown-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Dropdown",
-				Description: "A dropdown menu displays a list of actions or options that a user can choose from. Supports click, hover, and context menu triggers with keyboard navigation.",
+				Description: "A menu of actions or options triggered by click, hover, or right-click (context). Supports sections/dividers, item icons, keyboard navigation, button items with handlers, disabled and danger items, and an icon-only trigger.",
 			},
-			dropdownDemoPreview(),
-			`// Click Dropdown
-@dropdown.Dropdown(dropdown.Config{
+			dropdownClickPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
     Label: "Actions Menu",
     Sections: []dropdown.Section{
         {Items: []dropdown.Item{
             {Label: "Dashboard", Href: "#"},
-            {Label: "Subscription", Href: "#"},
             {Label: "Settings", Href: "#"},
             {Label: "Sign Out", Href: "#"},
-        }},
-    },
-})
-
-// Hover Dropdown
-@dropdown.Dropdown(dropdown.Config{
-    Label:       "Actions Menu",
-    TriggerMode: dropdown.TriggerHover,
-    Sections:    []dropdown.Section{...},
-})
-
-// Dropdown with Dividers
-@dropdown.Dropdown(dropdown.Config{
-    Label: "Actions Menu",
-    Sections: []dropdown.Section{
-        {Items: []dropdown.Item{
-            {Label: "Dashboard", Href: "#"},
-            {Label: "Messages", Href: "#"},
-        }},
-        {Items: []dropdown.Item{
-            {Label: "Profile", Href: "#"},
-            {Label: "Settings", Href: "#"},
-        }},
-        {Items: []dropdown.Item{
-            {Label: "Sign Out", Href: "#"},
-        }},
-    },
-})
-
-// Context Menu
-@dropdown.Dropdown(dropdown.Config{
-    TriggerMode: dropdown.TriggerContext,
-    Sections: []dropdown.Section{
-        {Items: []dropdown.Item{
-            {Label: "Undo", Icon: undoIcon(), Shortcut: "Z"},
-        }},
-        {Items: []dropdown.Item{
-            {Label: "Cut", Icon: cutIcon(), Shortcut: "X"},
-            {Label: "Copy", Icon: copyIcon(), Shortcut: "C"},
-            {Label: "Paste", Icon: pasteIcon(), Shortcut: "V"},
         }},
     },
 })`,
@@ -127,12 +91,116 @@ func dropdownDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Hover to Open",
+				Description: "TriggerMode: dropdown.TriggerHover opens the menu on pointer hover.",
+			},
+			dropdownHoverPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
+    Label:       "Actions Menu",
+    TriggerMode: dropdown.TriggerHover,
+    Sections:    sections,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Dividers",
+				Description: "Each dropdown.Section is separated by a divider — group related items.",
+			},
+			dropdownDividerPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
+    Label: "Actions Menu",
+    Sections: []dropdown.Section{
+        {Items: []dropdown.Item{{Label: "Dashboard", Href: "#"}, {Label: "Messages", Href: "#"}}},
+        {Items: []dropdown.Item{{Label: "Profile", Href: "#"}, {Label: "Settings", Href: "#"}}},
+        {Items: []dropdown.Item{{Label: "Sign Out", Href: "#"}}},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Icons",
+				Description: "Give each dropdown.Item an Icon component for a leading glyph.",
+			},
+			dropdownIconsPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
+    Label: "Actions Menu",
+    Sections: []dropdown.Section{
+        {Items: []dropdown.Item{{Label: "Dashboard", Href: "#", Icon: dashboardIcon()}}},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Context Menu",
+				Description: "TriggerMode: dropdown.TriggerContext opens on right-click. Items can carry a Shortcut hint.",
+			},
+			dropdownContextPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
+    TriggerMode: dropdown.TriggerContext,
+    Sections: []dropdown.Section{
+        {Items: []dropdown.Item{{Label: "Undo", Icon: undoIcon(), Shortcut: "Z"}}},
+        {Items: []dropdown.Item{{Label: "Copy", Icon: copyIcon(), Shortcut: "C"}}},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Action Items (onclick / disabled / danger)",
+				Description: "Items can run OnClick handlers, be Disabled (with a Tooltip), or be styled Danger. Pair with an icon-only trigger via TriggerIcon + TriggerIconOnly.",
+			},
+			dropdownActionsPreview(),
+			`@dropdown.Dropdown(dropdown.Config{
+    Label:           "cluster actions",
+    TriggerIcon:     dotsVerticalIcon(),
+    TriggerIconOnly: true,
+    Sections: []dropdown.Section{
+        {Items: []dropdown.Item{
+            {Label: "Edit", Icon: settingsIcon(), OnClick: "editOpen = true"},
+            {Label: "Archive", Disabled: true, Tooltip: "Not available"},
+        }},
+        {Items: []dropdown.Item{{Label: "Delete", Danger: true, OnClick: "deleteOpen = true"}}},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Label", Type: "string", Default: `""`, Description: "Trigger button text (also the aria-label for icon-only triggers)."},
+			{Name: "TriggerMode", Type: "TriggerMode", Default: "TriggerClick", Description: `Open on: "click", "hover", or "context" (right-click).`},
+			{Name: "Sections", Type: "[]Section", Default: "nil", Description: "Groups of Items; each section is divider-separated. Item: Label, Href/OnClick, Icon, Shortcut, Disabled, Danger, Tooltip, ID."},
+			{Name: "TriggerIcon", Type: "templ.Component", Default: "nil", Description: "Custom trigger icon."},
+			{Name: "TriggerIconOnly", Type: "bool", Default: "false", Description: "Render only the icon as the trigger (uses Label for aria-label)."},
+			{Name: "MenuAlign", Type: "MenuAlign", Default: "left", Description: "Horizontal alignment of the menu relative to the trigger."},
+			{Name: "ID", Type: "string", Default: `""`, Description: "Container id (scopes the menu and Alpine state)."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// dropdownDemoPreview renders the Goshtoso dropdown preview
-func dropdownDemoPreview() templ.Component {
+// dropdownClickPreview renders the click-trigger dropdown.
+func dropdownClickPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -153,7 +221,7 @@ func dropdownDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-12\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Click to Open</h4><div class=\"pb-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"dropdown-click-box\" class=\"w-full max-w-md mx-auto\"><div class=\"flex justify-center pb-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -172,7 +240,37 @@ func dropdownDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Hover to Open</h4><div class=\"pb-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// dropdownHoverPreview renders the hover-trigger dropdown.
+func dropdownHoverPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"dropdown-hover-box\" class=\"w-full max-w-md mx-auto\"><div class=\"flex justify-center pb-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -192,7 +290,37 @@ func dropdownDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With Dividers</h4><div class=\"pb-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// dropdownDividerPreview renders the multi-section (divider) dropdown.
+func dropdownDividerPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"dropdown-divider-box\" class=\"w-full max-w-md mx-auto\"><div class=\"flex justify-center pb-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -217,7 +345,37 @@ func dropdownDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With Icons</h4><div class=\"pb-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// dropdownIconsPreview renders the dropdown with item icons.
+func dropdownIconsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"dropdown-icons-box\" class=\"w-full max-w-md mx-auto\"><div class=\"flex justify-center pb-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -242,7 +400,37 @@ func dropdownDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Context Menu</h4><div class=\"pb-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// dropdownContextPreview renders the right-click context menu.
+func dropdownContextPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"dropdown-context-box\" class=\"w-full max-w-md mx-auto\"><div class=\"flex justify-center pb-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -266,7 +454,37 @@ func dropdownDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div><div x-data=\"{ editOpen: false, deleteOpen: false, editCount: 0 }\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Actions Menu (button items: onclick / disabled / danger / icon-only trigger)</h4><div class=\"pb-2 flex items-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// dropdownActionsPreview renders the action-items dropdown with an icon-only trigger.
+func dropdownActionsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"dropdown-actions-box\" class=\"w-full max-w-md mx-auto\" x-data=\"{ editOpen: false, deleteOpen: false, editCount: 0 }\"><div class=\"pb-2 flex items-center justify-center gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -305,7 +523,7 @@ func dropdownDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted\" id=\"dropdown-actions-state\">editOpen=<span x-text=\"editOpen\"></span> · deleteOpen=<span x-text=\"deleteOpen\"></span> · editCount=<span x-text=\"editCount\"></span></div></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<div class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted\" id=\"dropdown-actions-state\">editOpen=<span x-text=\"editOpen\"></span> · deleteOpen=<span x-text=\"deleteOpen\"></span> · editCount=<span x-text=\"editCount\"></span></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -330,12 +548,12 @@ func ddDotsVerticalIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var4 == nil {
-			templ_7745c5c3_Var4 = templ.NopComponent
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-5\"><path fill-rule=\"evenodd\" d=\"M12 6.75a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Zm0 6.75a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Zm0 6.75a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-5\"><path fill-rule=\"evenodd\" d=\"M12 6.75a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Zm0 6.75a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Zm0 6.75a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -360,12 +578,12 @@ func ddDashboardIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var5 == nil {
-			templ_7745c5c3_Var5 = templ.NopComponent
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path d=\"M18.375 2.25c-1.035 0-1.875.84-1.875 1.875v15.75c0 1.035.84 1.875 1.875 1.875h.75c1.035 0 1.875-.84 1.875-1.875V4.125c0-1.036-.84-1.875-1.875-1.875h-.75zM9.75 8.625c0-1.036.84-1.875 1.875-1.875h.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-.75a1.875 1.875 0 01-1.875-1.875V8.625zM3 13.125c0-1.036.84-1.875 1.875-1.875h.75c1.036 0 1.875.84 1.875 1.875v6.75c0 1.035-.84 1.875-1.875 1.875h-.75A1.875 1.875 0 013 19.875v-6.75z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path d=\"M18.375 2.25c-1.035 0-1.875.84-1.875 1.875v15.75c0 1.035.84 1.875 1.875 1.875h.75c1.035 0 1.875-.84 1.875-1.875V4.125c0-1.036-.84-1.875-1.875-1.875h-.75zM9.75 8.625c0-1.036.84-1.875 1.875-1.875h.75c1.036 0 1.875.84 1.875 1.875v11.25c0 1.035-.84 1.875-1.875 1.875h-.75a1.875 1.875 0 01-1.875-1.875V8.625zM3 13.125c0-1.036.84-1.875 1.875-1.875h.75c1.036 0 1.875.84 1.875 1.875v6.75c0 1.035-.84 1.875-1.875 1.875h-.75A1.875 1.875 0 013 19.875v-6.75z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -389,12 +607,12 @@ func ddMessagesIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path d=\"M1.5 8.67v8.58a3 3 0 003 3h15a3 3 0 003-3V8.67l-8.928 5.493a3 3 0 01-3.144 0L1.5 8.67z\"></path> <path d=\"M22.5 6.908V6.75a3 3 0 00-3-3h-15a3 3 0 00-3 3v.158l9.714 5.978a1.5 1.5 0 001.572 0L22.5 6.908z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path d=\"M1.5 8.67v8.58a3 3 0 003 3h15a3 3 0 003-3V8.67l-8.928 5.493a3 3 0 01-3.144 0L1.5 8.67z\"></path> <path d=\"M22.5 6.908V6.75a3 3 0 00-3-3h-15a3 3 0 00-3 3v.158l9.714 5.978a1.5 1.5 0 001.572 0L22.5 6.908z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -418,12 +636,12 @@ func ddFavoritesIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.007 5.404.433c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.433 2.082-5.006z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.007 5.404.433c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.433 2.082-5.006z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -447,12 +665,12 @@ func ddProfileIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M7.5 6a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM3.751 20.105a8.25 8.25 0 0116.498 0 .75.75 0 01-.437.695A18.683 18.683 0 0112 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 01-.437-.695z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M7.5 6a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM3.751 20.105a8.25 8.25 0 0116.498 0 .75.75 0 01-.437.695A18.683 18.683 0 0112 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 01-.437-.695z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -476,12 +694,12 @@ func ddSettingsIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M11.078 2.25c-.917 0-1.699.663-1.85 1.567L9.05 4.889c-.02.12-.115.26-.297.348a7.493 7.493 0 00-.986.57c-.166.115-.334.126-.45.083L6.3 5.508a1.875 1.875 0 00-2.282.819l-.922 1.597a1.875 1.875 0 00.432 2.385l.84.692c.095.078.17.229.154.43a7.598 7.598 0 000 1.139c.015.2-.059.352-.153.43l-.841.692a1.875 1.875 0 00-.432 2.385l.922 1.597a1.875 1.875 0 002.282.818l1.019-.382c.115-.043.283-.031.45.082.312.214.641.405.985.57.182.088.277.228.297.35l.178 1.071c.151.904.933 1.567 1.85 1.567h1.844c.916 0 1.699-.663 1.85-1.567l.178-1.072c.02-.12.114-.26.297-.349.344-.165.673-.356.985-.57.167-.114.335-.125.45-.082l1.02.382a1.875 1.875 0 002.28-.819l.923-1.597a1.875 1.875 0 00-.432-2.385l-.84-.692c-.095-.078-.17-.229-.154-.43a7.614 7.614 0 000-1.139c-.016-.2.059-.352.153-.43l.84-.692c.708-.582.891-1.59.433-2.385l-.922-1.597a1.875 1.875 0 00-2.282-.818l-1.02.382c-.114.043-.282.031-.449-.083a7.49 7.49 0 00-.985-.57c-.183-.087-.277-.227-.297-.348l-.179-1.072a1.875 1.875 0 00-1.85-1.567h-1.843zM12 15.75a3.75 3.75 0 100-7.5 3.75 3.75 0 000 7.5z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path fill-rule=\"evenodd\" d=\"M11.078 2.25c-.917 0-1.699.663-1.85 1.567L9.05 4.889c-.02.12-.115.26-.297.348a7.493 7.493 0 00-.986.57c-.166.115-.334.126-.45.083L6.3 5.508a1.875 1.875 0 00-2.282.819l-.922 1.597a1.875 1.875 0 00.432 2.385l.84.692c.095.078.17.229.154.43a7.598 7.598 0 000 1.139c.015.2-.059.352-.153.43l-.841.692a1.875 1.875 0 00-.432 2.385l.922 1.597a1.875 1.875 0 002.282.818l1.019-.382c.115-.043.283-.031.45.082.312.214.641.405.985.57.182.088.277.228.297.35l.178 1.071c.151.904.933 1.567 1.85 1.567h1.844c.916 0 1.699-.663 1.85-1.567l.178-1.072c.02-.12.114-.26.297-.349.344-.165.673-.356.985-.57.167-.114.335-.125.45-.082l1.02.382a1.875 1.875 0 002.28-.819l.923-1.597a1.875 1.875 0 00-.432-2.385l-.84-.692c-.095-.078-.17-.229-.154-.43a7.614 7.614 0 000-1.139c-.016-.2.059-.352.153-.43l.84-.692c.708-.582.891-1.59.433-2.385l-.922-1.597a1.875 1.875 0 00-2.282-.818l-1.02.382c-.114.043-.282.031-.449-.083a7.49 7.49 0 00-.985-.57c-.183-.087-.277-.227-.297-.348l-.179-1.072a1.875 1.875 0 00-1.85-1.567h-1.843zM12 15.75a3.75 3.75 0 100-7.5 3.75 3.75 0 000 7.5z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -505,12 +723,12 @@ func ddHelpIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var10 == nil {
-			templ_7745c5c3_Var10 = templ.NopComponent
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path d=\"M12 .75a8.25 8.25 0 00-4.135 15.39c.686.398 1.115 1.008 1.134 1.623a.75.75 0 00.577.706c.352.083.71.148 1.074.195.323.041.6-.218.6-.544v-4.661a6.714 6.714 0 01-.937-.171.75.75 0 11.374-1.453 5.261 5.261 0 002.626 0 .75.75 0 11.374 1.452 6.712 6.712 0 01-.937.172v4.66c0 .327.277.586.6.545.364-.047.722-.112 1.074-.195a.75.75 0 00.577-.706c.02-.615.448-1.225 1.134-1.623A8.25 8.25 0 0012 .75z\"></path> <path fill-rule=\"evenodd\" d=\"M9.013 19.9a.75.75 0 01.877-.597 11.319 11.319 0 004.22 0 .75.75 0 11.28 1.473 12.819 12.819 0 01-4.78 0 .75.75 0 01-.597-.876zM9.754 22.344a.75.75 0 01.824-.668 13.682 13.682 0 002.844 0 .75.75 0 11.156 1.492 15.156 15.156 0 01-3.156 0 .75.75 0 01-.668-.824z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"size-4\"><path d=\"M12 .75a8.25 8.25 0 00-4.135 15.39c.686.398 1.115 1.008 1.134 1.623a.75.75 0 00.577.706c.352.083.71.148 1.074.195.323.041.6-.218.6-.544v-4.661a6.714 6.714 0 01-.937-.171.75.75 0 11.374-1.453 5.261 5.261 0 002.626 0 .75.75 0 11.374 1.452 6.712 6.712 0 01-.937.172v4.66c0 .327.277.586.6.545.364-.047.722-.112 1.074-.195a.75.75 0 00.577-.706c.02-.615.448-1.225 1.134-1.623A8.25 8.25 0 0012 .75z\"></path> <path fill-rule=\"evenodd\" d=\"M9.013 19.9a.75.75 0 01.877-.597 11.319 11.319 0 004.22 0 .75.75 0 11.28 1.473 12.819 12.819 0 01-4.78 0 .75.75 0 01-.597-.876zM9.754 22.344a.75.75 0 01.824-.668 13.682 13.682 0 002.844 0 .75.75 0 11.156 1.492 15.156 15.156 0 01-3.156 0 .75.75 0 01-.668-.824z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -534,12 +752,12 @@ func undoIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var11 == nil {
-			templ_7745c5c3_Var11 = templ.NopComponent
+		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var16 == nil {
+			templ_7745c5c3_Var16 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-4 h-4\"><path fill-rule=\"evenodd\" d=\"M9.53 2.47a.75.75 0 010 1.06L4.81 8.25H15a6.75 6.75 0 010 13.5h-3a.75.75 0 010-1.5h3a5.25 5.25 0 100-10.5H4.81l4.72 4.72a.75.75 0 11-1.06 1.06l-6-6a.75.75 0 010-1.06l6-6a.75.75 0 011.06 0z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-4 h-4\"><path fill-rule=\"evenodd\" d=\"M9.53 2.47a.75.75 0 010 1.06L4.81 8.25H15a6.75 6.75 0 010 13.5h-3a.75.75 0 010-1.5h3a5.25 5.25 0 100-10.5H4.81l4.72 4.72a.75.75 0 11-1.06 1.06l-6-6a.75.75 0 010-1.06l6-6a.75.75 0 011.06 0z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -563,12 +781,12 @@ func cutIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var12 == nil {
-			templ_7745c5c3_Var12 = templ.NopComponent
+		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var17 == nil {
+			templ_7745c5c3_Var17 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-4 h-4\"><path fill-rule=\"evenodd\" d=\"M8.128 9.155a3.751 3.751 0 11.713-1.321l1.136.656a.75.75 0 01.222 1.104l-.006.007a.75.75 0 01-1.032.157 1.421 1.421 0 00-.113-.072l-.92-.531zm-4.827-3.53a2.25 2.25 0 013.994 2.063.756.756 0 00-.122.23 2.25 2.25 0 01-3.872-2.293zM13.348 8.272a5.073 5.073 0 00-3.428 3.57c-.101.387-.158.79-.165 1.202a1.415 1.415 0 01-.707 1.201l-.96.554a3.751 3.751 0 10.734 1.309l13.729-7.926a.75.75 0 00-.181-1.374l-.803-.215a5.25 5.25 0 00-2.894.05l-5.325 1.629zm-9.223 7.03a2.25 2.25 0 102.25 3.897 2.25 2.25 0 00-2.25-3.897zM12 12.75a.75.75 0 100-1.5.75.75 0 000 1.5z\" clip-rule=\"evenodd\"></path> <path d=\"M16.372 12.615a.75.75 0 01.75 0l5.43 3.135a.75.75 0 01-.182 1.374l-.802.215a5.25 5.25 0 01-2.894-.051l-5.147-1.574a.75.75 0 01-.156-1.367l3-1.732z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-4 h-4\"><path fill-rule=\"evenodd\" d=\"M8.128 9.155a3.751 3.751 0 11.713-1.321l1.136.656a.75.75 0 01.222 1.104l-.006.007a.75.75 0 01-1.032.157 1.421 1.421 0 00-.113-.072l-.92-.531zm-4.827-3.53a2.25 2.25 0 013.994 2.063.756.756 0 00-.122.23 2.25 2.25 0 01-3.872-2.293zM13.348 8.272a5.073 5.073 0 00-3.428 3.57c-.101.387-.158.79-.165 1.202a1.415 1.415 0 01-.707 1.201l-.96.554a3.751 3.751 0 10.734 1.309l13.729-7.926a.75.75 0 00-.181-1.374l-.803-.215a5.25 5.25 0 00-2.894.05l-5.325 1.629zm-9.223 7.03a2.25 2.25 0 102.25 3.897 2.25 2.25 0 00-2.25-3.897zM12 12.75a.75.75 0 100-1.5.75.75 0 000 1.5z\" clip-rule=\"evenodd\"></path> <path d=\"M16.372 12.615a.75.75 0 01.75 0l5.43 3.135a.75.75 0 01-.182 1.374l-.802.215a5.25 5.25 0 01-2.894-.051l-5.147-1.574a.75.75 0 01-.156-1.367l3-1.732z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -592,12 +810,12 @@ func copyIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var13 == nil {
-			templ_7745c5c3_Var13 = templ.NopComponent
+		templ_7745c5c3_Var18 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var18 == nil {
+			templ_7745c5c3_Var18 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-4 h-4\"><path d=\"M7.5 3.375c0-1.036.84-1.875 1.875-1.875h.375a3.75 3.75 0 013.75 3.75v1.875C13.5 8.161 14.34 9 15.375 9h1.875A3.75 3.75 0 0121 12.75v3.375C21 17.16 20.16 18 19.125 18h-9.75A1.875 1.875 0 017.5 16.125V3.375z\"></path> <path d=\"M15 5.25a5.23 5.23 0 00-1.279-3.434 9.768 9.768 0 016.963 6.963A5.23 5.23 0 0017.25 7.5h-1.875A.375.375 0 0115 7.125V5.25zM4.875 6H6v10.125A3.375 3.375 0 009.375 19.5H16.5v1.125c0 1.035-.84 1.875-1.875 1.875h-9.75A1.875 1.875 0 013 20.625V7.875C3 6.839 3.84 6 4.875 6z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-4 h-4\"><path d=\"M7.5 3.375c0-1.036.84-1.875 1.875-1.875h.375a3.75 3.75 0 013.75 3.75v1.875C13.5 8.161 14.34 9 15.375 9h1.875A3.75 3.75 0 0121 12.75v3.375C21 17.16 20.16 18 19.125 18h-9.75A1.875 1.875 0 017.5 16.125V3.375z\"></path> <path d=\"M15 5.25a5.23 5.23 0 00-1.279-3.434 9.768 9.768 0 016.963 6.963A5.23 5.23 0 0017.25 7.5h-1.875A.375.375 0 0115 7.125V5.25zM4.875 6H6v10.125A3.375 3.375 0 009.375 19.5H16.5v1.125c0 1.035-.84 1.875-1.875 1.875h-9.75A1.875 1.875 0 013 20.625V7.875C3 6.839 3.84 6 4.875 6z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -621,12 +839,12 @@ func pasteIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var14 == nil {
-			templ_7745c5c3_Var14 = templ.NopComponent
+		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var19 == nil {
+			templ_7745c5c3_Var19 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-4 h-4\"><path fill-rule=\"evenodd\" d=\"M10.5 3A1.501 1.501 0 009 4.5h6A1.5 1.5 0 0013.5 3h-3zm-2.693.178A3 3 0 0110.5 1.5h3a3 3 0 012.694 1.678c.497.042.992.092 1.486.15 1.497.173 2.57 1.46 2.57 2.929V19.5a3 3 0 01-3 3H6.75a3 3 0 01-3-3V6.257c0-1.47 1.073-2.756 2.57-2.93.493-.057.989-.107 1.487-.15z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-4 h-4\"><path fill-rule=\"evenodd\" d=\"M10.5 3A1.501 1.501 0 009 4.5h6A1.5 1.5 0 0013.5 3h-3zm-2.693.178A3 3 0 0110.5 1.5h3a3 3 0 012.694 1.678c.497.042.992.092 1.486.15 1.497.173 2.57 1.46 2.57 2.929V19.5a3 3 0 01-3 3H6.75a3 3 0 01-3-3V6.257c0-1.47 1.073-2.756 2.57-2.93.493-.057.989-.107 1.487-.15z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -650,12 +868,12 @@ func printIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var15 == nil {
-			templ_7745c5c3_Var15 = templ.NopComponent
+		templ_7745c5c3_Var20 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var20 == nil {
+			templ_7745c5c3_Var20 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-4 h-4\"><path fill-rule=\"evenodd\" d=\"M7.875 1.5C6.839 1.5 6 2.34 6 3.375v2.99c-.426.053-.851.11-1.274.174-1.454.218-2.476 1.483-2.476 2.917v6.294a3 3 0 003 3h.27l-.155 1.705A1.875 1.875 0 007.232 22.5h9.536a1.875 1.875 0 001.867-2.045l-.155-1.705h.27a3 3 0 003-3V9.456c0-1.434-1.022-2.7-2.476-2.917A48.716 48.716 0 0018 6.366V3.375c0-1.036-.84-1.875-1.875-1.875h-8.25zM16.5 6.205v-2.83A.375.375 0 0016.125 3h-8.25a.375.375 0 00-.375.375v2.83a49.353 49.353 0 019 0zm-.217 8.265c.178.018.317.16.333.337l.526 5.784a.375.375 0 01-.374.409H7.232a.375.375 0 01-.374-.409l.526-5.784a.373.373 0 01.333-.337 41.741 41.741 0 018.566 0zm.967-3.97a.75.75 0 01.75-.75h.008a.75.75 0 01.75.75v.008a.75.75 0 01-.75.75H18a.75.75 0 01-.75-.75V10.5zM15 9.75a.75.75 0 00-.75.75v.008c0 .414.336.75.75.75h.008a.75.75 0 00.75-.75V10.5a.75.75 0 00-.75-.75H15z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-4 h-4\"><path fill-rule=\"evenodd\" d=\"M7.875 1.5C6.839 1.5 6 2.34 6 3.375v2.99c-.426.053-.851.11-1.274.174-1.454.218-2.476 1.483-2.476 2.917v6.294a3 3 0 003 3h.27l-.155 1.705A1.875 1.875 0 007.232 22.5h9.536a1.875 1.875 0 001.867-2.045l-.155-1.705h.27a3 3 0 003-3V9.456c0-1.434-1.022-2.7-2.476-2.917A48.716 48.716 0 0018 6.366V3.375c0-1.036-.84-1.875-1.875-1.875h-8.25zM16.5 6.205v-2.83A.375.375 0 0016.125 3h-8.25a.375.375 0 00-.375.375v2.83a49.353 49.353 0 019 0zm-.217 8.265c.178.018.317.16.333.337l.526 5.784a.375.375 0 01-.374.409H7.232a.375.375 0 01-.374-.409l.526-5.784a.373.373 0 01.333-.337 41.741 41.741 0 018.566 0zm.967-3.97a.75.75 0 01.75-.75h.008a.75.75 0 01.75.75v.008a.75.75 0 01-.75.75H18a.75.75 0 01-.75-.75V10.5zM15 9.75a.75.75 0 00-.75.75v.008c0 .414.336.75.75.75h.008a.75.75 0 00.75-.75V10.5a.75.75 0 00-.75-.75H15z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/fileinput.templ
+++ b/internal/pages/demo/components/fileinput.templ
@@ -10,100 +10,132 @@ templ FileInputDemoPage() {
 	@demo.Layout("File Input", "fileinput", fileInputDemoContent())
 }
 
-// fileInputDemoContent renders the actual content inside the layout
+// fileInputDemoContent renders the demo. Each file-input variant lives in its
+// own preview frame followed by its own code block (mirrors
+// penguinui.com/components/file-input). Wrapped in #fileinput-fragment.
 templ fileInputDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "File Input",
-			Description:   "A drag-and-drop file input component that allows users to browse or drag files into a drop zone.",
-		},
-		fileInputDemoPreview(),
-		`// Basic file input with drag and drop
-@fileinput.FileInput(fileinput.Config{
+	<div id="fileinput-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "File Input",
+				Description: "A drag-and-drop drop zone that lets users browse or drag files. Supports Accept filters, helper text, required, and disabled states.",
+			},
+			fileInputDefaultPreview(),
+			`@fileinput.FileInput(fileinput.Config{
     ID:         "coverPicture",
     Name:       "cover",
     Label:      "Cover Picture",
     Accept:     "image/*",
     HelperText: "PNG, JPG, WebP - Max 5MB",
-})
+})`,
+		)
 
-// Required file input
-@fileinput.FileInput(fileinput.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Required",
+				Description: "Required: true marks the field as required for form submission.",
+			},
+			fileInputRequiredPreview(),
+			`@fileinput.FileInput(fileinput.Config{
     ID:         "document",
     Name:       "document",
     Label:      "Upload Document",
     Accept:     ".pdf,.doc,.docx",
     HelperText: "PDF, DOC, DOCX - Max 10MB",
     Required:   true,
-})
+})`,
+		)
 
-// Disabled file input
-@fileinput.FileInput(fileinput.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks browsing and drops and dims the zone.",
+			},
+			fileInputDisabledPreview(),
+			`@fileinput.FileInput(fileinput.Config{
     ID:       "disabled",
     Name:     "disabled",
     Label:    "Disabled Upload",
     Disabled: true,
 })`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Without Label",
+				Description: "Omit Label for a bare drop zone (e.g. inside a labelled field group).",
+			},
+			fileInputNoLabelPreview(),
+			`@fileinput.FileInput(fileinput.Config{
+    ID:         "attachment",
+    Name:       "attachment",
+    Accept:     "image/*,.pdf",
+    HelperText: "Any image or PDF - Max 5MB",
+})`,
+		)
+	</div>
+	// API reference lives outside #fileinput-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the input (and label's for target)."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+		{Name: "Label", Type: "string", Default: `""`, Description: "Label above the drop zone (omit for none)."},
+		{Name: "Accept", Type: "string", Default: `""`, Description: `Accepted file types (e.g. "image/*", ".pdf,.doc").`},
+		{Name: "HelperText", Type: "string", Default: `""`, Description: "Hint text shown inside/under the zone."},
+		{Name: "Required", Type: "bool", Default: "false", Description: "Mark the field as required."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable browsing and drops."},
+		{Name: "Attrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the <input>."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+	})
 }
 
-// fileInputDemoPreview renders the Goshtoso file input preview
-templ fileInputDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Default drag and drop
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Drag and Drop</h4>
-			<div class="flex flex-wrap gap-4">
-				@fileinput.FileInput(fileinput.Config{
-					ID:         "demoCoverPicture",
-					Name:       "cover",
-					Label:      "Cover Picture",
-					Accept:     "image/*",
-					HelperText: "PNG, JPG, WebP - Max 5MB",
-				})
-			</div>
-		</div>
+// fileInputDefaultPreview renders the default drag-and-drop input.
+templ fileInputDefaultPreview() {
+	<div id="fileinput-default" class="w-full max-w-md mx-auto">
+		@fileinput.FileInput(fileinput.Config{
+			ID:         "demoCoverPicture",
+			Name:       "cover",
+			Label:      "Cover Picture",
+			Accept:     "image/*",
+			HelperText: "PNG, JPG, WebP - Max 5MB",
+		})
+	</div>
+}
 
-		// Required
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Required</h4>
-			<div class="flex flex-wrap gap-4">
-				@fileinput.FileInput(fileinput.Config{
-					ID:         "demoDocument",
-					Name:       "document",
-					Label:      "Upload Document",
-					Accept:     ".pdf,.doc,.docx",
-					HelperText: "PDF, DOC, DOCX - Max 10MB",
-					Required:   true,
-				})
-			</div>
-		</div>
+// fileInputRequiredPreview renders the required input.
+templ fileInputRequiredPreview() {
+	<div id="fileinput-required" class="w-full max-w-md mx-auto">
+		@fileinput.FileInput(fileinput.Config{
+			ID:         "demoDocument",
+			Name:       "document",
+			Label:      "Upload Document",
+			Accept:     ".pdf,.doc,.docx",
+			HelperText: "PDF, DOC, DOCX - Max 10MB",
+			Required:   true,
+		})
+	</div>
+}
 
-		// Disabled
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Disabled</h4>
-			<div class="flex flex-wrap gap-4">
-				@fileinput.FileInput(fileinput.Config{
-					ID:         "demoDisabled",
-					Name:       "disabled",
-					Label:      "Disabled Upload",
-					HelperText: "Uploads are currently disabled",
-					Disabled:   true,
-				})
-			</div>
-		</div>
+// fileInputDisabledPreview renders the disabled input.
+templ fileInputDisabledPreview() {
+	<div id="fileinput-disabled" class="w-full max-w-md mx-auto">
+		@fileinput.FileInput(fileinput.Config{
+			ID:         "demoDisabled",
+			Name:       "disabled",
+			Label:      "Disabled Upload",
+			HelperText: "Uploads are currently disabled",
+			Disabled:   true,
+		})
+	</div>
+}
 
-		// No label
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Without Label</h4>
-			<div class="flex flex-wrap gap-4">
-				@fileinput.FileInput(fileinput.Config{
-					ID:         "demoNoLabel",
-					Name:       "attachment",
-					Accept:     "image/*,.pdf",
-					HelperText: "Any image or PDF - Max 5MB",
-				})
-			</div>
-		</div>
+// fileInputNoLabelPreview renders the unlabelled input.
+templ fileInputNoLabelPreview() {
+	<div id="fileinput-nolabel" class="w-full max-w-md mx-auto">
+		@fileinput.FileInput(fileinput.Config{
+			ID:         "demoNoLabel",
+			Name:       "attachment",
+			Accept:     "image/*,.pdf",
+			HelperText: "Any image or PDF - Max 5MB",
+		})
 	</div>
 }

--- a/internal/pages/demo/components/fileinput_templ.go
+++ b/internal/pages/demo/components/fileinput_templ.go
@@ -43,7 +43,9 @@ func FileInputDemoPage() templ.Component {
 	})
 }
 
-// fileInputDemoContent renders the actual content inside the layout
+// fileInputDemoContent renders the demo. Each file-input variant lives in its
+// own preview frame followed by its own code block (mirrors
+// penguinui.com/components/file-input). Wrapped in #fileinput-fragment.
 func fileInputDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,33 +67,52 @@ func fileInputDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"fileinput-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "File Input",
-				Description: "A drag-and-drop file input component that allows users to browse or drag files into a drop zone.",
+				Description: "A drag-and-drop drop zone that lets users browse or drag files. Supports Accept filters, helper text, required, and disabled states.",
 			},
-			fileInputDemoPreview(),
-			`// Basic file input with drag and drop
-@fileinput.FileInput(fileinput.Config{
+			fileInputDefaultPreview(),
+			`@fileinput.FileInput(fileinput.Config{
     ID:         "coverPicture",
     Name:       "cover",
     Label:      "Cover Picture",
     Accept:     "image/*",
     HelperText: "PNG, JPG, WebP - Max 5MB",
-})
-
-// Required file input
-@fileinput.FileInput(fileinput.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Required",
+				Description: "Required: true marks the field as required for form submission.",
+			},
+			fileInputRequiredPreview(),
+			`@fileinput.FileInput(fileinput.Config{
     ID:         "document",
     Name:       "document",
     Label:      "Upload Document",
     Accept:     ".pdf,.doc,.docx",
     HelperText: "PDF, DOC, DOCX - Max 10MB",
     Required:   true,
-})
-
-// Disabled file input
-@fileinput.FileInput(fileinput.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks browsing and drops and dims the zone.",
+			},
+			fileInputDisabledPreview(),
+			`@fileinput.FileInput(fileinput.Config{
     ID:       "disabled",
     Name:     "disabled",
     Label:    "Disabled Upload",
@@ -101,12 +122,46 @@ func fileInputDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Without Label",
+				Description: "Omit Label for a bare drop zone (e.g. inside a labelled field group).",
+			},
+			fileInputNoLabelPreview(),
+			`@fileinput.FileInput(fileinput.Config{
+    ID:         "attachment",
+    Name:       "attachment",
+    Accept:     "image/*,.pdf",
+    HelperText: "Any image or PDF - Max 5MB",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the input (and label's for target)."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+			{Name: "Label", Type: "string", Default: `""`, Description: "Label above the drop zone (omit for none)."},
+			{Name: "Accept", Type: "string", Default: `""`, Description: `Accepted file types (e.g. "image/*", ".pdf,.doc").`},
+			{Name: "HelperText", Type: "string", Default: `""`, Description: "Hint text shown inside/under the zone."},
+			{Name: "Required", Type: "bool", Default: "false", Description: "Mark the field as required."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable browsing and drops."},
+			{Name: "Attrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the <input>."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// fileInputDemoPreview renders the Goshtoso file input preview
-func fileInputDemoPreview() templ.Component {
+// fileInputDefaultPreview renders the default drag-and-drop input.
+func fileInputDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -127,7 +182,7 @@ func fileInputDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Drag and Drop</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"fileinput-default\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -141,7 +196,37 @@ func fileInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Required</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// fileInputRequiredPreview renders the required input.
+func fileInputRequiredPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"fileinput-required\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -156,7 +241,37 @@ func fileInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Disabled</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// fileInputDisabledPreview renders the disabled input.
+func fileInputDisabledPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"fileinput-disabled\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -170,7 +285,37 @@ func fileInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Without Label</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// fileInputNoLabelPreview renders the unlabelled input.
+func fileInputNoLabelPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"fileinput-nolabel\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -183,7 +328,7 @@ func fileInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/form.templ
+++ b/internal/pages/demo/components/form.templ
@@ -16,14 +16,60 @@ templ FormDemoPage() {
 }
 
 templ formDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:       "Form",
-			Description: "A composable form layout with sections, collapsible areas, flip-card read/edit panels, and built-in Goshtoso field rendering. Supports HTMX validation and external submit triggers.",
-		},
-		formDemoPreview(),
-		formDemoCode,
-	)
+	<div id="form-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Form",
+				Description: "A composable form layout with sections, collapsible areas, flip-card read/edit panels, sub-sections, and built-in Goshtoso field rendering. Supports HTMX validation and external submit triggers.",
+			},
+			formCompletePreview(),
+			formDemoCode,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Field Validation States",
+				Description: "FieldGroup surfaces success/error input states, error messages (Errors), and helper hints (Hints).",
+			},
+			formValidationPreview(),
+			`@form.FieldGroup(form.FieldGroupConfig{
+    ID: "error-field", Label: "Error Field", Required: true,
+    Errors: []string{"This cluster ID is already taken"},
+    Input:  &textinput.Config{ID: "error-field", Name: "error", State: textinput.StateError},
+})
+@form.FieldGroup(form.FieldGroupConfig{
+    ID: "hint-field", Label: "Field with Hints",
+    Hints: []string{"Must be 3-63 characters", "Lowercase letters, numbers, hyphens"},
+    Input: &textinput.Config{ID: "hint-field", Name: "hints"},
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "External Submit (Modal Pattern)",
+				Description: "Render the form with no Footer; a button outside the form uses the form=\"...\" attribute to submit it — the typical modal pattern.",
+			},
+			formExternalPreview(),
+			`@form.Form(form.Config{ID: "external-form", Action: "#"}) {
+    @form.Section(form.SectionConfig{Title: "Upgrade"}) { ... }
+}
+<button type="submit" form="external-form">Upgrade (External Button)</button>`,
+		)
+	</div>
+	// API reference lives outside #form-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Form element id (target of external submit buttons via form=\"...\")."},
+		{Name: "Action", Type: "string", Default: `""`, Description: "Non-HTMX form action URL."},
+		{Name: "Method", Type: "string", Default: `"post"`, Description: "HTTP method for non-HTMX submits."},
+		{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "HTMX submit config (Post/Put/Target/Swap, inline validation)."},
+		{Name: "PreventEnterSubmit", Type: "*bool", Default: "nil", Description: "When true, Enter in a field does not submit the form."},
+		{Name: "Footer", Type: "*FooterConfig", Default: "nil", Description: "Submit/cancel footer; omit for the external-submit pattern."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the <form>."},
+		{Name: "FieldGroup", Type: "FieldGroupConfig", Default: "—", Description: "Per-field wrapper: Label, Required, Errors, Hints + one built-in (Input/Combobox/Textarea/Toggle/...) or children."},
+		{Name: "Section / SubSection", Type: "SectionConfig", Default: "—", Description: "Group fields under a titled section; SubSection nests within a Section."},
+		{Name: "CollapsibleSection", Type: "CollapsibleSectionConfig", Default: "—", Description: "A Section that collapses, with a Summary shown when collapsed."},
+		{Name: "FlipSection", Type: "FlipSectionConfig", Default: "—", Description: "A section with a read-only front view and an editable back."},
+	})
 }
 
 var formDemoCode = `// Built-in field types — set Input, Combobox, Textarea, Toggle, etc. directly
@@ -55,13 +101,11 @@ var formDemoCode = `// Built-in field types — set Input, Combobox, Textarea, T
 @form.Form(form.Config{ID: "modal-form", HTMX: &form.HTMXConfig{Post: "/api", Swap: "none"}}) { ... }
 <button type="submit" form="modal-form">Submit</button>`
 
-templ formDemoPreview() {
-	<div class="space-y-12">
-		<!-- Full Form Demo -->
-		<div>
-			<h4 class="mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">Complete Form (built-in field types)</h4>
-			@form.Form(form.Config{
-				ID:     "demo-form",
+// formCompletePreview renders the full composable form.
+templ formCompletePreview() {
+	<div id="form-complete" class="w-full max-w-2xl mx-auto">
+		@form.Form(form.Config{
+			ID:     "demo-form",
 				Action: "#",
 				Footer: &form.FooterConfig{
 					SubmitText: "Create Cluster",
@@ -243,10 +287,12 @@ templ formDemoPreview() {
 			}
 		</div>
 
-		<!-- Validation States Demo -->
-		<div>
-			<h4 class="mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">Field Validation States</h4>
-			@form.Section(form.SectionConfig{Title: "Validation Examples"}) {
+}
+
+// formValidationPreview renders the validation-state examples.
+templ formValidationPreview() {
+	<div id="form-validation-states" class="w-full max-w-2xl mx-auto">
+		@form.Section(form.SectionConfig{Title: "Validation Examples"}) {
 				@form.FieldGroup(form.FieldGroupConfig{
 					ID:       "valid-field",
 					Label:    "Valid Field",
@@ -283,13 +329,12 @@ templ formDemoPreview() {
 			}
 		</div>
 
-		<!-- External Submit (Modal Pattern) -->
-		<div>
-			<h4 class="mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">External Submit (Modal Pattern)</h4>
-			<p class="mb-4 text-sm text-on-surface-muted dark:text-on-surface-dark-muted">
-				The form has no footer. The submit button uses <code class="text-xs bg-surface-alt dark:bg-surface-dark-alt px-1 py-0.5 rounded">form="external-form"</code> to trigger submission from outside.
-			</p>
-			<div class="flex flex-col gap-4">
+}
+
+// formExternalPreview renders the external-submit (modal) pattern.
+templ formExternalPreview() {
+	<div id="form-external" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-col gap-4">
 				@form.Form(form.Config{
 					ID:     "external-form",
 					Action: "#",
@@ -323,7 +368,6 @@ templ formDemoPreview() {
 				</div>
 			</div>
 		</div>
-	</div>
 }
 
 

--- a/internal/pages/demo/components/form_templ.go
+++ b/internal/pages/demo/components/form_templ.go
@@ -69,14 +69,72 @@ func formDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"form-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Form",
-				Description: "A composable form layout with sections, collapsible areas, flip-card read/edit panels, and built-in Goshtoso field rendering. Supports HTMX validation and external submit triggers.",
+				Description: "A composable form layout with sections, collapsible areas, flip-card read/edit panels, sub-sections, and built-in Goshtoso field rendering. Supports HTMX validation and external submit triggers.",
 			},
-			formDemoPreview(),
+			formCompletePreview(),
 			formDemoCode,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Field Validation States",
+				Description: "FieldGroup surfaces success/error input states, error messages (Errors), and helper hints (Hints).",
+			},
+			formValidationPreview(),
+			`@form.FieldGroup(form.FieldGroupConfig{
+    ID: "error-field", Label: "Error Field", Required: true,
+    Errors: []string{"This cluster ID is already taken"},
+    Input:  &textinput.Config{ID: "error-field", Name: "error", State: textinput.StateError},
+})
+@form.FieldGroup(form.FieldGroupConfig{
+    ID: "hint-field", Label: "Field with Hints",
+    Hints: []string{"Must be 3-63 characters", "Lowercase letters, numbers, hyphens"},
+    Input: &textinput.Config{ID: "hint-field", Name: "hints"},
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "External Submit (Modal Pattern)",
+				Description: "Render the form with no Footer; a button outside the form uses the form=\"...\" attribute to submit it — the typical modal pattern.",
+			},
+			formExternalPreview(),
+			`@form.Form(form.Config{ID: "external-form", Action: "#"}) {
+    @form.Section(form.SectionConfig{Title: "Upgrade"}) { ... }
+}
+<button type="submit" form="external-form">Upgrade (External Button)</button>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Form element id (target of external submit buttons via form=\"...\")."},
+			{Name: "Action", Type: "string", Default: `""`, Description: "Non-HTMX form action URL."},
+			{Name: "Method", Type: "string", Default: `"post"`, Description: "HTTP method for non-HTMX submits."},
+			{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "HTMX submit config (Post/Put/Target/Swap, inline validation)."},
+			{Name: "PreventEnterSubmit", Type: "*bool", Default: "nil", Description: "When true, Enter in a field does not submit the form."},
+			{Name: "Footer", Type: "*FooterConfig", Default: "nil", Description: "Submit/cancel footer; omit for the external-submit pattern."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the <form>."},
+			{Name: "FieldGroup", Type: "FieldGroupConfig", Default: "—", Description: "Per-field wrapper: Label, Required, Errors, Hints + one built-in (Input/Combobox/Textarea/Toggle/...) or children."},
+			{Name: "Section / SubSection", Type: "SectionConfig", Default: "—", Description: "Group fields under a titled section; SubSection nests within a Section."},
+			{Name: "CollapsibleSection", Type: "CollapsibleSectionConfig", Default: "—", Description: "A Section that collapses, with a Summary shown when collapsed."},
+			{Name: "FlipSection", Type: "FlipSectionConfig", Default: "—", Description: "A section with a read-only front view and an editable back."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -113,7 +171,8 @@ var formDemoCode = `// Built-in field types — set Input, Combobox, Textarea, T
 @form.Form(form.Config{ID: "modal-form", HTMX: &form.HTMXConfig{Post: "/api", Swap: "none"}}) { ... }
 <button type="submit" form="modal-form">Submit</button>`
 
-func formDemoPreview() templ.Component {
+// formCompletePreview renders the full composable form.
+func formCompletePreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -134,7 +193,7 @@ func formDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-12\"><!-- Full Form Demo --><div><h4 class=\"mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Complete Form (built-in field types)</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"form-complete\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -150,7 +209,7 @@ func formDemoPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<!-- Regular Section --> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<!-- Regular Section --> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -180,7 +239,7 @@ func formDemoPreview() templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -196,7 +255,7 @@ func formDemoPreview() templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -218,7 +277,7 @@ func formDemoPreview() templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -235,7 +294,7 @@ func formDemoPreview() templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " <!-- Custom component via children (not a built-in type) --> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " <!-- Custom component via children (not a built-in type) --> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -276,7 +335,7 @@ func formDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, " <!-- Flip Section (read/edit pattern) --> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, " <!-- Flip Section (read/edit pattern) --> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -305,7 +364,7 @@ func formDemoPreview() templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -330,7 +389,7 @@ func formDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, " <!-- Collapsible Section --> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, " <!-- Collapsible Section --> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -364,7 +423,7 @@ func formDemoPreview() templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -391,7 +450,7 @@ func formDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, " <!-- Section with SubSections --> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " <!-- Section with SubSections --> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -432,7 +491,7 @@ func formDemoPreview() templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -458,7 +517,7 @@ func formDemoPreview() templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -487,7 +546,7 @@ func formDemoPreview() templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -533,11 +592,41 @@ func formDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</div><!-- Validation States Demo --><div><h4 class=\"mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Field Validation States</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var12 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		return nil
+	})
+}
+
+// formValidationPreview renders the validation-state examples.
+func formValidationPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<div id=\"form-validation-states\" class=\"w-full max-w-2xl mx-auto\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var13 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -563,7 +652,7 @@ func formDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -582,7 +671,7 @@ func formDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -601,15 +690,45 @@ func formDemoPreview() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = form.Section(form.SectionConfig{Title: "Validation Examples"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = form.Section(form.SectionConfig{Title: "Validation Examples"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var13), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div><!-- External Submit (Modal Pattern) --><div><h4 class=\"mb-4 text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">External Submit (Modal Pattern)</h4><p class=\"mb-4 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">The form has no footer. The submit button uses <code class=\"text-xs bg-surface-alt dark:bg-surface-dark-alt px-1 py-0.5 rounded\">form=\"external-form\"</code> to trigger submission from outside.</p><div class=\"flex flex-col gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var13 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		return nil
+	})
+}
+
+// formExternalPreview renders the external-submit (modal) pattern.
+func formExternalPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<div id=\"form-external\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-col gap-4\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var15 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -621,7 +740,7 @@ func formDemoPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Var14 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var16 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -652,7 +771,7 @@ func formDemoPreview() templ.Component {
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = form.Section(form.SectionConfig{Title: "Upgrade"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = form.Section(form.SectionConfig{Title: "Upgrade"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var16), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -661,11 +780,11 @@ func formDemoPreview() templ.Component {
 		templ_7745c5c3_Err = form.Form(form.Config{
 			ID:     "external-form",
 			Action: "#",
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var13), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<!-- External button --><div class=\"flex justify-end\"><button type=\"submit\" form=\"external-form\" class=\"inline-flex items-center justify-center px-6 py-2.5 rounded-radius text-sm font-medium text-on-primary dark:text-on-primary-dark bg-primary dark:bg-primary-dark border border-primary dark:border-primary-dark hover:opacity-75 transition\">Upgrade (External Button)</button></div></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<!-- External button --><div class=\"flex justify-end\"><button type=\"submit\" form=\"external-form\" class=\"inline-flex items-center justify-center px-6 py-2.5 rounded-radius text-sm font-medium text-on-primary dark:text-on-primary-dark bg-primary dark:bg-primary-dark border border-primary dark:border-primary-dark hover:opacity-75 transition\">Upgrade (External Button)</button></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -690,12 +809,12 @@ func networkReadView() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var15 == nil {
-			templ_7745c5c3_Var15 = templ.NopComponent
+		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var17 == nil {
+			templ_7745c5c3_Var17 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div class=\"grid grid-cols-1 md:grid-cols-2 gap-4\"><div class=\"flex flex-col gap-1\"><span class=\"text-xs font-medium text-on-surface-muted dark:text-on-surface-dark-muted uppercase tracking-wider\">Pod Subnet CIDR</span> <span class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">10.244.0.0/16</span></div><div class=\"flex flex-col gap-1\"><span class=\"text-xs font-medium text-on-surface-muted dark:text-on-surface-dark-muted uppercase tracking-wider\">Service Subnet CIDR</span> <span class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">10.96.0.0/12</span></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div class=\"grid grid-cols-1 md:grid-cols-2 gap-4\"><div class=\"flex flex-col gap-1\"><span class=\"text-xs font-medium text-on-surface-muted dark:text-on-surface-dark-muted uppercase tracking-wider\">Pod Subnet CIDR</span> <span class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">10.244.0.0/16</span></div><div class=\"flex flex-col gap-1\"><span class=\"text-xs font-medium text-on-surface-muted dark:text-on-surface-dark-muted uppercase tracking-wider\">Service Subnet CIDR</span> <span class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">10.96.0.0/12</span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/form_validation.templ
+++ b/internal/pages/demo/components/form_validation.templ
@@ -13,14 +13,29 @@ templ FormValidationDemoPage() {
 }
 
 templ formValidationDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:       "Form Validation",
-			Description: "Server-side field validation with HTMX. Fields validate on change, dependent fields update automatically (e.g. slug from name), and full-form submit validates everything at once.",
-		},
-		formValidationDemoPreview(),
-		formValidationDemoCode,
-	)
+	<div id="form-validation-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Form Validation",
+				Description: "Server-side field validation with HTMX. Fields validate on change, dependent fields update automatically (e.g. slug from name), and full-form submit validates everything at once.",
+			},
+			formValidationDemoPreview(),
+			formValidationDemoCode,
+		)
+	</div>
+	// API reference lives outside #form-validation-fragment. These document the
+	// validation package types used to wire up HTMX field validation.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "FormDef.FormID", Type: "string", Default: `""`, Description: "DOM id of the form (must match form.Config.ID)."},
+		{Name: "FormDef.Endpoint", Type: "string", Default: `""`, Description: "Server URL that handles field + full-form validation requests."},
+		{Name: "FormDef.Fields", Type: "map[string]*FieldDef", Default: "nil", Description: "Per-field definitions keyed by field name."},
+		{Name: "FieldDef.Name", Type: "string", Default: `""`, Description: "Form field name (matches the input's Name)."},
+		{Name: "FieldDef.FieldGroup", Type: "*form.FieldGroupConfig", Default: "nil", Description: "The field's FieldGroup (label, input, hints, errors)."},
+		{Name: "FieldDef.OnChange", Type: "bool", Default: "false", Description: "Validate this field on change (blur), not just on submit."},
+		{Name: "FieldDef.DependsOn", Type: "[]string", Default: "nil", Description: "Other field names that re-trigger this field's validation (e.g. slug depends on name)."},
+		{Name: "def.Bind()", Type: "method", Default: "—", Description: "Wires HTMX attributes + metadata onto each FieldGroup; call once after defining."},
+		{Name: "validation.Handle", Type: "func", Default: "—", Description: "Server entry point: routes field vs full-form requests and runs your per-field validator."},
+	})
 }
 
 var formValidationDemoCode = `// 1. Define the form fields and validation rules

--- a/internal/pages/demo/components/form_validation_templ.go
+++ b/internal/pages/demo/components/form_validation_templ.go
@@ -66,6 +66,10 @@ func formValidationDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"form-validation-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Form Validation",
@@ -74,6 +78,24 @@ func formValidationDemoContent() templ.Component {
 			formValidationDemoPreview(),
 			formValidationDemoCode,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "FormDef.FormID", Type: "string", Default: `""`, Description: "DOM id of the form (must match form.Config.ID)."},
+			{Name: "FormDef.Endpoint", Type: "string", Default: `""`, Description: "Server URL that handles field + full-form validation requests."},
+			{Name: "FormDef.Fields", Type: "map[string]*FieldDef", Default: "nil", Description: "Per-field definitions keyed by field name."},
+			{Name: "FieldDef.Name", Type: "string", Default: `""`, Description: "Form field name (matches the input's Name)."},
+			{Name: "FieldDef.FieldGroup", Type: "*form.FieldGroupConfig", Default: "nil", Description: "The field's FieldGroup (label, input, hints, errors)."},
+			{Name: "FieldDef.OnChange", Type: "bool", Default: "false", Description: "Validate this field on change (blur), not just on submit."},
+			{Name: "FieldDef.DependsOn", Type: "[]string", Default: "nil", Description: "Other field names that re-trigger this field's validation (e.g. slug depends on name)."},
+			{Name: "def.Bind()", Type: "method", Default: "—", Description: "Wires HTMX attributes + metadata onto each FieldGroup; call once after defining."},
+			{Name: "validation.Handle", Type: "func", Default: "—", Description: "Server entry point: routes field vs full-form requests and runs your per-field validator."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -160,7 +182,7 @@ func formValidationDemoPreview() templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		def := buildDemoValidationFormDef()
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-2xl mx-auto space-y-6\"><div><h4 class=\"mb-2 text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Try it out</h4><p class=\"mb-4 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Type in the fields below and tab out to see validation in action. The slug field auto-generates from name. Try \"admin\", \"test\", or \"demo\" as slugs to see the uniqueness check.</p></div><div id=\"form-result\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"w-full max-w-2xl mx-auto space-y-6\"><div><h4 class=\"mb-2 text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Try it out</h4><p class=\"mb-4 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Type in the fields below and tab out to see validation in action. The slug field auto-generates from name. Try \"admin\", \"test\", or \"demo\" as slugs to see the uniqueness check.</p></div><div id=\"form-result\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -172,7 +194,7 @@ func formValidationDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -267,7 +289,7 @@ func FormValidationFormSection(nameField *form.FieldGroupConfig, slugField *form
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -275,7 +297,7 @@ func FormValidationFormSection(nameField *form.FieldGroupConfig, slugField *form
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/internal/pages/demo/components/keyvalue.templ
+++ b/internal/pages/demo/components/keyvalue.templ
@@ -11,49 +11,72 @@ templ KeyValueDemoPage() {
 }
 
 templ keyValueDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:       "Key Value",
-			Description: "Dynamic key-value pair rows for labels, environment variables, and other map-style data. Powered by Alpine.js.",
-		},
-		keyValueDemoPreview(),
-		`// Key-Value with initial entries
-@keyvalue.KeyValue(keyvalue.Config{
+	<div id="keyvalue-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Key Value",
+				Description: "Dynamic key-value pair rows for labels, environment variables, and other map-style data. Powered by Alpine.js.",
+			},
+			keyValueInitialPreview(),
+			`@keyvalue.KeyValue(keyvalue.Config{
     ID:               "labels",
     Name:             "labels",
     Entries:          []keyvalue.Entry{{Key: "app", Value: "web"}, {Key: "env", Value: "prod"}},
     KeyPlaceholder:   "key",
     ValuePlaceholder: "value",
 })`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Empty (Start Adding)",
+				Description: "With no Entries the list starts empty; set AddLabel to customize the add button.",
+			},
+			keyValueEmptyPreview(),
+			`@keyvalue.KeyValue(keyvalue.Config{
+    ID:               "env",
+    Name:             "env",
+    KeyPlaceholder:   "VARIABLE_NAME",
+    ValuePlaceholder: "value",
+    AddLabel:         "Add variable",
+})`,
+		)
+	</div>
+	// API reference lives outside #keyvalue-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the key-value root (Alpine scope)."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Base form field name for the submitted map."},
+		{Name: "Entries", Type: "[]Entry", Default: "nil", Description: "Initial key/value pairs."},
+		{Name: "KeyPlaceholder", Type: "string", Default: `""`, Description: "Placeholder for the key input."},
+		{Name: "ValuePlaceholder", Type: "string", Default: `""`, Description: "Placeholder for the value input."},
+		{Name: "AddLabel", Type: "string", Default: `"Add"`, Description: "Label of the add-row button."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Render read-only rows."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+	})
 }
 
-templ keyValueDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With Initial Entries</h4>
-			<div class="max-w-lg">
-				@keyvalue.KeyValue(keyvalue.Config{
-					ID:               "labelsDemo",
-					Name:             "labels",
-					Entries:          []keyvalue.Entry{{Key: "app", Value: "web"}, {Key: "env", Value: "prod"}},
-					KeyPlaceholder:   "key",
-					ValuePlaceholder: "value",
-				})
-			</div>
-		</div>
+// keyValueInitialPreview renders a key-value list seeded with entries.
+templ keyValueInitialPreview() {
+	<div id="keyvalue-initial" class="w-full max-w-lg mx-auto">
+		@keyvalue.KeyValue(keyvalue.Config{
+			ID:               "labelsDemo",
+			Name:             "labels",
+			Entries:          []keyvalue.Entry{{Key: "app", Value: "web"}, {Key: "env", Value: "prod"}},
+			KeyPlaceholder:   "key",
+			ValuePlaceholder: "value",
+		})
+	</div>
+}
 
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Empty (Start Adding)</h4>
-			<div class="max-w-lg">
-				@keyvalue.KeyValue(keyvalue.Config{
-					ID:               "envVarsDemo",
-					Name:             "env",
-					KeyPlaceholder:   "VARIABLE_NAME",
-					ValuePlaceholder: "value",
-					AddLabel:         "Add variable",
-				})
-			</div>
-		</div>
+// keyValueEmptyPreview renders an empty key-value list.
+templ keyValueEmptyPreview() {
+	<div id="keyvalue-empty" class="w-full max-w-lg mx-auto">
+		@keyvalue.KeyValue(keyvalue.Config{
+			ID:               "envVarsDemo",
+			Name:             "env",
+			KeyPlaceholder:   "VARIABLE_NAME",
+			ValuePlaceholder: "value",
+			AddLabel:         "Add variable",
+		})
 	</div>
 }

--- a/internal/pages/demo/components/keyvalue_templ.go
+++ b/internal/pages/demo/components/keyvalue_templ.go
@@ -64,14 +64,17 @@ func keyValueDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"keyvalue-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Key Value",
 				Description: "Dynamic key-value pair rows for labels, environment variables, and other map-style data. Powered by Alpine.js.",
 			},
-			keyValueDemoPreview(),
-			`// Key-Value with initial entries
-@keyvalue.KeyValue(keyvalue.Config{
+			keyValueInitialPreview(),
+			`@keyvalue.KeyValue(keyvalue.Config{
     ID:               "labels",
     Name:             "labels",
     Entries:          []keyvalue.Entry{{Key: "app", Value: "web"}, {Key: "env", Value: "prod"}},
@@ -82,11 +85,46 @@ func keyValueDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Empty (Start Adding)",
+				Description: "With no Entries the list starts empty; set AddLabel to customize the add button.",
+			},
+			keyValueEmptyPreview(),
+			`@keyvalue.KeyValue(keyvalue.Config{
+    ID:               "env",
+    Name:             "env",
+    KeyPlaceholder:   "VARIABLE_NAME",
+    ValuePlaceholder: "value",
+    AddLabel:         "Add variable",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the key-value root (Alpine scope)."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Base form field name for the submitted map."},
+			{Name: "Entries", Type: "[]Entry", Default: "nil", Description: "Initial key/value pairs."},
+			{Name: "KeyPlaceholder", Type: "string", Default: `""`, Description: "Placeholder for the key input."},
+			{Name: "ValuePlaceholder", Type: "string", Default: `""`, Description: "Placeholder for the value input."},
+			{Name: "AddLabel", Type: "string", Default: `"Add"`, Description: "Label of the add-row button."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Render read-only rows."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-func keyValueDemoPreview() templ.Component {
+// keyValueInitialPreview renders a key-value list seeded with entries.
+func keyValueInitialPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -107,7 +145,7 @@ func keyValueDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With Initial Entries</h4><div class=\"max-w-lg\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"keyvalue-initial\" class=\"w-full max-w-lg mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -121,7 +159,37 @@ func keyValueDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Empty (Start Adding)</h4><div class=\"max-w-lg\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// keyValueEmptyPreview renders an empty key-value list.
+func keyValueEmptyPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"keyvalue-empty\" class=\"w-full max-w-lg mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -135,7 +203,7 @@ func keyValueDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/modal.templ
+++ b/internal/pages/demo/components/modal.templ
@@ -10,26 +10,34 @@ templ ModalDemoPage() {
 	@demo.Layout("Modal", "modal", modalDemoContent())
 }
 
-// modalDemoContent renders the actual content inside the layout
+// modalDemoContent renders the demo. Each modal variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/modal).
+// Wrapped in #modal-fragment.
 templ modalDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Modal",
-			Description:   "Modals display focused content that requires user attention or interaction. They support default and alert variants, with optional HTMX and JavaScript actions on buttons.",
-		},
-		modalDemoPreview(),
-		`// Default Modal
-@modal.Modal(modal.Config{
+	<div id="modal-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Modal",
+				Description: "Focused overlay content with default and alert variants, plus optional HTMX or JavaScript actions on the primary/secondary buttons.",
+			},
+			modalDefaultPreview(),
+			`@modal.Modal(modal.Config{
     ID:            "offer",
     Title:         "Special Offer",
     Body:          "Upgrade your account now to unlock premium features.",
     TriggerText:   "Open Modal",
     PrimaryText:   "Upgrade Now",
     SecondaryText: "Remind me later",
-})
+})`,
+		)
 
-// Alert Modal (Success)
-@modal.Modal(modal.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Alert Modals",
+				Description: "AlertMode: true plus a Variant renders a compact, icon-led alert dialog (Success, Info, Warning, Danger).",
+			},
+			modalAlertPreview(),
+			`@modal.Modal(modal.Config{
     ID:          "txComplete",
     Title:       "Transaction Complete",
     Body:        "Your funds transfer was successful.",
@@ -37,10 +45,16 @@ templ modalDemoContent() {
     PrimaryText: "Go to My Balance",
     Variant:     modal.Success,
     AlertMode:   true,
-})
+})`,
+		)
 
-// Modal with HTMX action
-@modal.Modal(modal.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With HTMX Action",
+				Description: "Give a button a PrimaryAction with hx-* fields to fire a server request on confirm.",
+			},
+			modalHTMXPreview(),
+			`@modal.Modal(modal.Config{
     ID:            "htmxDemo",
     Title:         "Confirm Action",
     Body:          "This will send a request to the server.",
@@ -49,46 +63,63 @@ templ modalDemoContent() {
     SecondaryText: "Cancel",
     PrimaryAction: &modal.ButtonAction{
         HxPost:   "/api/hello",
-        HxTarget: "#result",
+        HxTarget: "#modal-htmx-result",
         HxSwap:   "innerHTML",
     },
-})
+})`,
+		)
 
-// Modal with JS action
-@modal.Modal(modal.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With JavaScript Action",
+				Description: "Use PrimaryAction.OnClick for a client-side handler.",
+			},
+			modalJSPreview(),
+			`@modal.Modal(modal.Config{
     ID:            "jsDemo",
     Title:         "Confirm Delete",
     Body:          "Are you sure? This cannot be undone.",
     TriggerText:   "JS Action Modal",
     PrimaryText:   "Delete",
     SecondaryText: "Cancel",
-    PrimaryAction: &modal.ButtonAction{
-        OnClick: "alert('Deleted!')",
-    },
+    PrimaryAction: &modal.ButtonAction{OnClick: "alert('Deleted!')"},
 })`,
-	)
+		)
+	</div>
+	// API reference lives outside #modal-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id (wires the trigger to the dialog and scopes Alpine state)."},
+		{Name: "Title", Type: "string", Default: `""`, Description: "Dialog heading."},
+		{Name: "Body", Type: "string", Default: `""`, Description: "Dialog body text."},
+		{Name: "TriggerText", Type: "string", Default: `""`, Description: "Label of the button that opens the modal."},
+		{Name: "PrimaryText", Type: "string", Default: `""`, Description: "Primary button label."},
+		{Name: "PrimaryAction", Type: "*ButtonAction", Default: "nil", Description: "Primary button behavior (OnClick or hx-* fields)."},
+		{Name: "SecondaryText", Type: "string", Default: `""`, Description: "Secondary button label (omit to hide)."},
+		{Name: "SecondaryAction", Type: "*ButtonAction", Default: "nil", Description: "Secondary button behavior."},
+		{Name: "Variant", Type: "Variant", Default: "Default", Description: `Alert color: "default", "success", "info", "warning", "danger".`},
+		{Name: "AlertMode", Type: "bool", Default: "false", Description: "Render the compact icon-led alert dialog layout."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the dialog."},
+	})
 }
 
-// modalDemoPreview renders the Goshtoso modal preview
-templ modalDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Default Modal
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Modal</h4>
-			@modal.Modal(modal.Config{
-				ID:            "defaultDemo",
-				Title:         "Special Offer",
-				Body:          "As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.",
-				TriggerText:   "Open Modal",
-				PrimaryText:   "Upgrade Now",
-				SecondaryText: "Remind me later",
-			})
-		</div>
+// modalDefaultPreview renders the default modal trigger.
+templ modalDefaultPreview() {
+	<div id="modal-default" class="w-full max-w-2xl mx-auto">
+		@modal.Modal(modal.Config{
+			ID:            "defaultDemo",
+			Title:         "Special Offer",
+			Body:          "As a token of appreciation, we have an exclusive offer just for you. Upgrade your account now to unlock premium features and enjoy a seamless experience.",
+			TriggerText:   "Open Modal",
+			PrimaryText:   "Upgrade Now",
+			SecondaryText: "Remind me later",
+		})
+	</div>
+}
 
-		// Alert Modals
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Alert Modals</h4>
-			<div class="flex flex-wrap gap-3">
+// modalAlertPreview renders the four alert-mode variants.
+templ modalAlertPreview() {
+	<div id="modal-alert" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-3">
 				@modal.Modal(modal.Config{
 					ID:          "successDemo",
 					Title:       "Transaction Complete",
@@ -127,11 +158,12 @@ templ modalDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Modal with HTMX Action
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Modal with HTMX Action</h4>
-			<div class="space-y-3">
+// modalHTMXPreview renders the HTMX-action modal and its result target.
+templ modalHTMXPreview() {
+	<div id="modal-htmx" class="w-full max-w-2xl mx-auto">
+		<div class="space-y-3">
 				@modal.Modal(modal.Config{
 					ID:            "htmxDemo",
 					Title:         "Confirm Action",
@@ -148,12 +180,13 @@ templ modalDemoPreview() {
 				<div id="modal-htmx-result" class="mt-2 text-sm min-h-[1.5rem]"></div>
 			</div>
 		</div>
+}
 
-		// Modal with JS Action
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Modal with JavaScript Action</h4>
-			@modal.Modal(modal.Config{
-				ID:            "jsDemo",
+// modalJSPreview renders the JavaScript-action modal.
+templ modalJSPreview() {
+	<div id="modal-js" class="w-full max-w-2xl mx-auto">
+		@modal.Modal(modal.Config{
+			ID:            "jsDemo",
 				Title:         "Confirm Delete",
 				Body:          "Are you sure you want to delete this item? This action cannot be undone.",
 				TriggerText:   "Open JS Modal",
@@ -163,6 +196,5 @@ templ modalDemoPreview() {
 					OnClick: "alert('Item deleted successfully!')",
 				},
 			})
-		</div>
 	</div>
 }

--- a/internal/pages/demo/components/modal_templ.go
+++ b/internal/pages/demo/components/modal_templ.go
@@ -43,7 +43,9 @@ func ModalDemoPage() templ.Component {
 	})
 }
 
-// modalDemoContent renders the actual content inside the layout
+// modalDemoContent renders the demo. Each modal variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/modal).
+// Wrapped in #modal-fragment.
 func modalDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,24 +67,35 @@ func modalDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"modal-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Modal",
-				Description: "Modals display focused content that requires user attention or interaction. They support default and alert variants, with optional HTMX and JavaScript actions on buttons.",
+				Description: "Focused overlay content with default and alert variants, plus optional HTMX or JavaScript actions on the primary/secondary buttons.",
 			},
-			modalDemoPreview(),
-			`// Default Modal
-@modal.Modal(modal.Config{
+			modalDefaultPreview(),
+			`@modal.Modal(modal.Config{
     ID:            "offer",
     Title:         "Special Offer",
     Body:          "Upgrade your account now to unlock premium features.",
     TriggerText:   "Open Modal",
     PrimaryText:   "Upgrade Now",
     SecondaryText: "Remind me later",
-})
-
-// Alert Modal (Success)
-@modal.Modal(modal.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Alert Modals",
+				Description: "AlertMode: true plus a Variant renders a compact, icon-led alert dialog (Success, Info, Warning, Danger).",
+			},
+			modalAlertPreview(),
+			`@modal.Modal(modal.Config{
     ID:          "txComplete",
     Title:       "Transaction Complete",
     Body:        "Your funds transfer was successful.",
@@ -90,10 +103,18 @@ func modalDemoContent() templ.Component {
     PrimaryText: "Go to My Balance",
     Variant:     modal.Success,
     AlertMode:   true,
-})
-
-// Modal with HTMX action
-@modal.Modal(modal.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With HTMX Action",
+				Description: "Give a button a PrimaryAction with hx-* fields to fire a server request on confirm.",
+			},
+			modalHTMXPreview(),
+			`@modal.Modal(modal.Config{
     ID:            "htmxDemo",
     Title:         "Confirm Action",
     Body:          "This will send a request to the server.",
@@ -102,24 +123,50 @@ func modalDemoContent() templ.Component {
     SecondaryText: "Cancel",
     PrimaryAction: &modal.ButtonAction{
         HxPost:   "/api/hello",
-        HxTarget: "#result",
+        HxTarget: "#modal-htmx-result",
         HxSwap:   "innerHTML",
     },
-})
-
-// Modal with JS action
-@modal.Modal(modal.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With JavaScript Action",
+				Description: "Use PrimaryAction.OnClick for a client-side handler.",
+			},
+			modalJSPreview(),
+			`@modal.Modal(modal.Config{
     ID:            "jsDemo",
     Title:         "Confirm Delete",
     Body:          "Are you sure? This cannot be undone.",
     TriggerText:   "JS Action Modal",
     PrimaryText:   "Delete",
     SecondaryText: "Cancel",
-    PrimaryAction: &modal.ButtonAction{
-        OnClick: "alert('Deleted!')",
-    },
+    PrimaryAction: &modal.ButtonAction{OnClick: "alert('Deleted!')"},
 })`,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id (wires the trigger to the dialog and scopes Alpine state)."},
+			{Name: "Title", Type: "string", Default: `""`, Description: "Dialog heading."},
+			{Name: "Body", Type: "string", Default: `""`, Description: "Dialog body text."},
+			{Name: "TriggerText", Type: "string", Default: `""`, Description: "Label of the button that opens the modal."},
+			{Name: "PrimaryText", Type: "string", Default: `""`, Description: "Primary button label."},
+			{Name: "PrimaryAction", Type: "*ButtonAction", Default: "nil", Description: "Primary button behavior (OnClick or hx-* fields)."},
+			{Name: "SecondaryText", Type: "string", Default: `""`, Description: "Secondary button label (omit to hide)."},
+			{Name: "SecondaryAction", Type: "*ButtonAction", Default: "nil", Description: "Secondary button behavior."},
+			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Alert color: "default", "success", "info", "warning", "danger".`},
+			{Name: "AlertMode", Type: "bool", Default: "false", Description: "Render the compact icon-led alert dialog layout."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the dialog."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -127,8 +174,8 @@ func modalDemoContent() templ.Component {
 	})
 }
 
-// modalDemoPreview renders the Goshtoso modal preview
-func modalDemoPreview() templ.Component {
+// modalDefaultPreview renders the default modal trigger.
+func modalDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -149,7 +196,7 @@ func modalDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Modal</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"modal-default\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -164,7 +211,37 @@ func modalDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Alert Modals</h4><div class=\"flex flex-wrap gap-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// modalAlertPreview renders the four alert-mode variants.
+func modalAlertPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"modal-alert\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -216,7 +293,37 @@ func modalDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Modal with HTMX Action</h4><div class=\"space-y-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// modalHTMXPreview renders the HTMX-action modal and its result target.
+func modalHTMXPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"modal-htmx\" class=\"w-full max-w-2xl mx-auto\"><div class=\"space-y-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -236,7 +343,37 @@ func modalDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div id=\"modal-htmx-result\" class=\"mt-2 text-sm min-h-[1.5rem]\"></div></div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Modal with JavaScript Action</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div id=\"modal-htmx-result\" class=\"mt-2 text-sm min-h-[1.5rem]\"></div></div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// modalJSPreview renders the JavaScript-action modal.
+func modalJSPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"modal-js\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -254,7 +391,7 @@ func modalDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/navbar.templ
+++ b/internal/pages/demo/components/navbar.templ
@@ -10,112 +10,126 @@ templ NavbarDemoPage() {
 	@demo.Layout("Navbar", "navbar", navbarDemoContent())
 }
 
+// navbarDemoContent renders the demo. Each navbar variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/navbar). The simple navbar stays first so the e2e
+// .First() selectors keep resolving to it. Wrapped in #navbar-fragment.
 templ navbarDemoContent() {
-	<div class="space-y-12">
-		<div>
-			<h1 class="text-3xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong">Navbar</h1>
-			<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted">Tailwind CSS and Alpine JS Responsive Navbar</p>
-			<p class="mt-2 text-on-surface dark:text-on-surface-dark">A responsive navigation bar with brand, links, user avatar dropdown, and mobile menu. Supports custom right-side slots for additional controls.</p>
-		</div>
+	<div id="navbar-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Navbar",
+				Description: "A responsive navigation bar with brand, links, a user-avatar dropdown, a custom right-side slot, and a mobile menu. Built with Alpine.js.",
+			},
+			navbarSimplePreview(),
+			`@navbar.Navbar(navbar.Config{
+    Brand: brand(),
+    Links: []navbar.NavLink{
+        {Label: "Products", Href: "#", Active: true},
+        {Label: "Pricing", Href: "#"},
+        {Label: "Blog", Href: "#"},
+    },
+})`,
+		)
 
-		@simpleNavbarDemo()
-		@navbarWithUserDemo()
-		@navbarWithRightSlotDemo()
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With User Profile",
+				Description: "Pass a User and UserMenu to render an avatar button that opens a dropdown with name, email, and action items.",
+			},
+			navbarWithUserPreview(),
+			`@navbar.Navbar(navbar.Config{
+    Brand: brand(),
+    Links: links,
+    User:  &navbar.UserProfile{Name: "Alice Brown", Email: "alice.brown@example.com"},
+    UserMenu: []navbar.UserMenuItem{
+        {Label: "Dashboard", Href: "#"},
+        {Label: "Sign Out", Href: "#", Danger: true},
+    },
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Right Slot",
+				Description: "RightSlot takes any templ.Component (e.g. a dark-mode toggle) rendered beside the user avatar.",
+			},
+			navbarWithRightSlotPreview(),
+			`@navbar.Navbar(navbar.Config{
+    Brand:     brand(),
+    RightSlot: darkModeToggle(),
+    User:      &navbar.UserProfile{Name: "Alice Brown", Email: "alice.brown@example.com"},
+    UserMenu:  menu,
+})`,
+		)
+	</div>
+	// API reference lives outside #navbar-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Brand", Type: "templ.Component", Default: "nil", Description: "Brand/logo content shown at the start of the bar."},
+		{Name: "BrandHref", Type: "string", Default: `""`, Description: "Link target for the brand."},
+		{Name: "Links", Type: "[]NavLink", Default: "nil", Description: "Primary nav links (Label, Href, Active)."},
+		{Name: "Actions", Type: "[]ActionItem", Default: "nil", Description: "Trailing action items (buttons/links)."},
+		{Name: "User", Type: "*UserProfile", Default: "nil", Description: "User profile (Name, Email, Avatar) — renders the avatar dropdown trigger."},
+		{Name: "UserMenu", Type: "[]UserMenuItem", Default: "nil", Description: "Items in the user dropdown (Label, Href, Danger)."},
+		{Name: "RightSlot", Type: "templ.Component", Default: "nil", Description: "Custom content rendered before the user avatar."},
+		{Name: "NavAttrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the <nav>."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
+	})
+}
+
+// navbarSimplePreview renders the basic navbar (kept first for e2e .First()).
+templ navbarSimplePreview() {
+	<div id="navbar-simple" class="w-full">
+		@navbar.Navbar(navbar.Config{
+			Brand: demoBrandText(),
+			Links: []navbar.NavLink{
+				{Label: "Products", Href: "#", Active: true},
+				{Label: "Pricing", Href: "#"},
+				{Label: "Blog", Href: "#"},
+				{Label: "Login", Href: "#"},
+			},
+		})
 	</div>
 }
 
-// --- Variant 1: Simple Navbar ---
-
-templ simpleNavbarDemo() {
-	<div class="not-prose">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2">Simple Navbar</h3>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Basic navbar with brand and navigation links.</p>
-		<div class="border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
-			<div class="flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark">
-				<span class="size-3 rounded-full bg-red-400"></span>
-				<span class="size-3 rounded-full bg-yellow-400"></span>
-				<span class="size-3 rounded-full bg-green-400"></span>
-				<span class="ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted">Preview</span>
-			</div>
-			<div class="bg-surface dark:bg-surface-dark">
-				@navbar.Navbar(navbar.Config{
-					Brand: demoBrandText(),
-					Links: []navbar.NavLink{
-						{Label: "Products", Href: "#", Active: true},
-						{Label: "Pricing", Href: "#"},
-						{Label: "Blog", Href: "#"},
-						{Label: "Login", Href: "#"},
-					},
-				})
-			</div>
-		</div>
+// navbarWithUserPreview renders the navbar with a user-profile dropdown.
+templ navbarWithUserPreview() {
+	<div id="navbar-user" class="w-full" style="min-height: 200px;">
+		@navbar.Navbar(navbar.Config{
+			Brand: demoBrandText(),
+			Links: []navbar.NavLink{
+				{Label: "Products", Href: "#", Active: true},
+				{Label: "Pricing", Href: "#"},
+				{Label: "Blog", Href: "#"},
+			},
+			User: &navbar.UserProfile{
+				Name:  "Alice Brown",
+				Email: "alice.brown@example.com",
+			},
+			UserMenu: []navbar.UserMenuItem{
+				{Label: "Dashboard", Href: "#"},
+				{Label: "Settings", Href: "#"},
+				{Label: "Sign Out", Href: "#", Danger: true},
+			},
+		})
 	</div>
 }
 
-// --- Variant 2: With User Profile ---
-
-templ navbarWithUserDemo() {
-	<div class="not-prose">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2">With User Profile</h3>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Navbar with an avatar button that opens a user dropdown menu with name, email, and action items.</p>
-		<div class="border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
-			<div class="flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark">
-				<span class="size-3 rounded-full bg-red-400"></span>
-				<span class="size-3 rounded-full bg-yellow-400"></span>
-				<span class="size-3 rounded-full bg-green-400"></span>
-				<span class="ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted">Preview</span>
-			</div>
-			<div class="bg-surface dark:bg-surface-dark" style="min-height: 200px;">
-				@navbar.Navbar(navbar.Config{
-					Brand: demoBrandText(),
-					Links: []navbar.NavLink{
-						{Label: "Products", Href: "#", Active: true},
-						{Label: "Pricing", Href: "#"},
-						{Label: "Blog", Href: "#"},
-					},
-					User: &navbar.UserProfile{
-						Name:  "Alice Brown",
-						Email: "alice.brown@example.com",
-					},
-					UserMenu: []navbar.UserMenuItem{
-						{Label: "Dashboard", Href: "#"},
-						{Label: "Settings", Href: "#"},
-						{Label: "Sign Out", Href: "#", Danger: true},
-					},
-				})
-			</div>
-		</div>
-	</div>
-}
-
-// --- Variant 3: With Right Slot ---
-
-templ navbarWithRightSlotDemo() {
-	<div class="not-prose">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2">With Right Slot</h3>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Navbar with a custom right slot for additional controls (e.g., dark mode toggle) alongside the user avatar.</p>
-		<div class="border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
-			<div class="flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark">
-				<span class="size-3 rounded-full bg-red-400"></span>
-				<span class="size-3 rounded-full bg-yellow-400"></span>
-				<span class="size-3 rounded-full bg-green-400"></span>
-				<span class="ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted">Preview</span>
-			</div>
-			<div class="bg-surface dark:bg-surface-dark" style="min-height: 200px;">
-				@navbar.Navbar(navbar.Config{
-					Brand:     demoBrandText(),
-					RightSlot: demoRightSlot(),
-					User: &navbar.UserProfile{
-						Name:  "Alice Brown",
-						Email: "alice.brown@example.com",
-					},
-					UserMenu: []navbar.UserMenuItem{
-						{Label: "Settings", Href: "#"},
-						{Label: "Sign Out", Href: "#", Danger: true},
-					},
-				})
-			</div>
-		</div>
+// navbarWithRightSlotPreview renders the navbar with a custom right slot.
+templ navbarWithRightSlotPreview() {
+	<div id="navbar-right-slot" class="w-full" style="min-height: 200px;">
+		@navbar.Navbar(navbar.Config{
+			Brand:     demoBrandText(),
+			RightSlot: demoRightSlot(),
+			User: &navbar.UserProfile{
+				Name:  "Alice Brown",
+				Email: "alice.brown@example.com",
+			},
+			UserMenu: []navbar.UserMenuItem{
+				{Label: "Settings", Href: "#"},
+				{Label: "Sign Out", Href: "#", Danger: true},
+			},
+		})
 	</div>
 }
 

--- a/internal/pages/demo/components/navbar_templ.go
+++ b/internal/pages/demo/components/navbar_templ.go
@@ -43,6 +43,10 @@ func NavbarDemoPage() templ.Component {
 	})
 }
 
+// navbarDemoContent renders the demo. Each navbar variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/navbar). The simple navbar stays first so the e2e
+// .First() selectors keep resolving to it. Wrapped in #navbar-fragment.
 func navbarDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -64,19 +68,60 @@ func navbarDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-12\"><div><h1 class=\"text-3xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">Navbar</h1><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Tailwind CSS and Alpine JS Responsive Navbar</p><p class=\"mt-2 text-on-surface dark:text-on-surface-dark\">A responsive navigation bar with brand, links, user avatar dropdown, and mobile menu. Supports custom right-side slots for additional controls.</p></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"navbar-fragment\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = simpleNavbarDemo().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Navbar",
+				Description: "A responsive navigation bar with brand, links, a user-avatar dropdown, a custom right-side slot, and a mobile menu. Built with Alpine.js.",
+			},
+			navbarSimplePreview(),
+			`@navbar.Navbar(navbar.Config{
+    Brand: brand(),
+    Links: []navbar.NavLink{
+        {Label: "Products", Href: "#", Active: true},
+        {Label: "Pricing", Href: "#"},
+        {Label: "Blog", Href: "#"},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = navbarWithUserDemo().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With User Profile",
+				Description: "Pass a User and UserMenu to render an avatar button that opens a dropdown with name, email, and action items.",
+			},
+			navbarWithUserPreview(),
+			`@navbar.Navbar(navbar.Config{
+    Brand: brand(),
+    Links: links,
+    User:  &navbar.UserProfile{Name: "Alice Brown", Email: "alice.brown@example.com"},
+    UserMenu: []navbar.UserMenuItem{
+        {Label: "Dashboard", Href: "#"},
+        {Label: "Sign Out", Href: "#", Danger: true},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = navbarWithRightSlotDemo().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Right Slot",
+				Description: "RightSlot takes any templ.Component (e.g. a dark-mode toggle) rendered beside the user avatar.",
+			},
+			navbarWithRightSlotPreview(),
+			`@navbar.Navbar(navbar.Config{
+    Brand:     brand(),
+    RightSlot: darkModeToggle(),
+    User:      &navbar.UserProfile{Name: "Alice Brown", Email: "alice.brown@example.com"},
+    UserMenu:  menu,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -84,12 +129,26 @@ func navbarDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Brand", Type: "templ.Component", Default: "nil", Description: "Brand/logo content shown at the start of the bar."},
+			{Name: "BrandHref", Type: "string", Default: `""`, Description: "Link target for the brand."},
+			{Name: "Links", Type: "[]NavLink", Default: "nil", Description: "Primary nav links (Label, Href, Active)."},
+			{Name: "Actions", Type: "[]ActionItem", Default: "nil", Description: "Trailing action items (buttons/links)."},
+			{Name: "User", Type: "*UserProfile", Default: "nil", Description: "User profile (Name, Email, Avatar) — renders the avatar dropdown trigger."},
+			{Name: "UserMenu", Type: "[]UserMenuItem", Default: "nil", Description: "Items in the user dropdown (Label, Href, Danger)."},
+			{Name: "RightSlot", Type: "templ.Component", Default: "nil", Description: "Custom content rendered before the user avatar."},
+			{Name: "NavAttrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the <nav>."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// --- Variant 1: Simple Navbar ---
-func simpleNavbarDemo() templ.Component {
+// navbarSimplePreview renders the basic navbar (kept first for e2e .First()).
+func navbarSimplePreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -110,7 +169,7 @@ func simpleNavbarDemo() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"not-prose\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">Simple Navbar</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Basic navbar with brand and navigation links.</p><div class=\"border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark\"><span class=\"size-3 rounded-full bg-red-400\"></span> <span class=\"size-3 rounded-full bg-yellow-400\"></span> <span class=\"size-3 rounded-full bg-green-400\"></span> <span class=\"ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">Preview</span></div><div class=\"bg-surface dark:bg-surface-dark\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"navbar-simple\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -126,7 +185,7 @@ func simpleNavbarDemo() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -134,8 +193,8 @@ func simpleNavbarDemo() templ.Component {
 	})
 }
 
-// --- Variant 2: With User Profile ---
-func navbarWithUserDemo() templ.Component {
+// navbarWithUserPreview renders the navbar with a user-profile dropdown.
+func navbarWithUserPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -156,7 +215,7 @@ func navbarWithUserDemo() templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"not-prose\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">With User Profile</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Navbar with an avatar button that opens a user dropdown menu with name, email, and action items.</p><div class=\"border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark\"><span class=\"size-3 rounded-full bg-red-400\"></span> <span class=\"size-3 rounded-full bg-yellow-400\"></span> <span class=\"size-3 rounded-full bg-green-400\"></span> <span class=\"ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">Preview</span></div><div class=\"bg-surface dark:bg-surface-dark\" style=\"min-height: 200px;\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"navbar-user\" class=\"w-full\" style=\"min-height: 200px;\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -180,7 +239,7 @@ func navbarWithUserDemo() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -188,8 +247,8 @@ func navbarWithUserDemo() templ.Component {
 	})
 }
 
-// --- Variant 3: With Right Slot ---
-func navbarWithRightSlotDemo() templ.Component {
+// navbarWithRightSlotPreview renders the navbar with a custom right slot.
+func navbarWithRightSlotPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -210,7 +269,7 @@ func navbarWithRightSlotDemo() templ.Component {
 			templ_7745c5c3_Var5 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"not-prose\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">With Right Slot</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Navbar with a custom right slot for additional controls (e.g., dark mode toggle) alongside the user avatar.</p><div class=\"border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark\"><span class=\"size-3 rounded-full bg-red-400\"></span> <span class=\"size-3 rounded-full bg-yellow-400\"></span> <span class=\"size-3 rounded-full bg-green-400\"></span> <span class=\"ml-2 text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">Preview</span></div><div class=\"bg-surface dark:bg-surface-dark\" style=\"min-height: 200px;\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"navbar-right-slot\" class=\"w-full\" style=\"min-height: 200px;\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -229,7 +288,7 @@ func navbarWithRightSlotDemo() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/pagination.templ
+++ b/internal/pages/demo/components/pagination.templ
@@ -10,32 +10,88 @@ templ PaginationDemoPage() {
 	@demo.Layout("Pagination", "pagination", paginationDemoContent())
 }
 
-// paginationDemoContent renders the actual content inside the layout
+// paginationDemoContent renders the demo. Each pagination variant lives in its
+// own preview frame followed by its own code block (mirrors
+// penguinui.com/components/pagination). Wrapped in #pagination-fragment.
 templ paginationDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Pagination",
-			Description:   "Pagination components allow users to navigate between pages of content. Supports simple prev/next and ellipsis variants.",
-		},
-		paginationDemoPreview(),
-		`// Simple pagination (prev/next only)
-@pagination.Pagination(pagination.Config{
+	<div id="pagination-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Pagination",
+				Description: "Navigate between pages of content. Simple prev/next and ellipsis page-number variants, with optional HTMX wiring.",
+			},
+			paginationSimplePreview(),
+			`@pagination.Pagination(pagination.Config{
     Variant:     pagination.Simple,
     CurrentPage: 3,
     TotalPages:  10,
     BaseURL:     "/items",
-})
+})`,
+		)
 
-// With ellipsis and page numbers
-@pagination.Pagination(pagination.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Simple — First Page",
+				Description: "The Previous control auto-disables on the first page (and Next on the last).",
+			},
+			paginationFirstPreview(),
+			`@pagination.Pagination(pagination.Config{
+    Variant:     pagination.Simple,
+    CurrentPage: 1,
+    TotalPages:  10,
+    BaseURL:     "/items",
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Ellipsis — Beginning",
+				Description: "Variant: pagination.WithEllipsis shows page numbers, collapsing large ranges with an ellipsis.",
+			},
+			paginationEllipsisBeginPreview(),
+			`@pagination.Pagination(pagination.Config{
     Variant:     pagination.WithEllipsis,
     CurrentPage: 2,
     TotalPages:  30,
     BaseURL:     "/items",
-})
+})`,
+		)
 
-// With HTMX integration
-@pagination.Pagination(pagination.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Ellipsis — Middle",
+				Description: "A current page in the middle collapses both sides with ellipses.",
+			},
+			paginationEllipsisMidPreview(),
+			`@pagination.Pagination(pagination.Config{
+    Variant:     pagination.WithEllipsis,
+    CurrentPage: 15,
+    TotalPages:  30,
+    BaseURL:     "/items",
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Ellipsis — End",
+				Description: "Near the end, only the leading range collapses.",
+			},
+			paginationEllipsisEndPreview(),
+			`@pagination.Pagination(pagination.Config{
+    Variant:     pagination.WithEllipsis,
+    CurrentPage: 29,
+    TotalPages:  30,
+    BaseURL:     "/items",
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Small Page Count",
+				Description: "With 7 or fewer pages, every page number is shown (no ellipsis). Add HTMXTarget + HTMXSwap to swap content in place instead of navigating.",
+			},
+			paginationSmallPreview(),
+			`@pagination.Pagination(pagination.Config{
     Variant:     pagination.WithEllipsis,
     CurrentPage: 5,
     TotalPages:  30,
@@ -43,82 +99,59 @@ templ paginationDemoContent() {
     HTMXTarget:  "#items-tbody",
     HTMXSwap:    "innerHTML",
 })`,
-	)
+		)
+	</div>
+	// API reference lives outside #pagination-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Variant", Type: "Variant", Default: "WithEllipsis", Description: `Style: "simple" (prev/next only) or "ellipsis" (page numbers).`},
+		{Name: "CurrentPage", Type: "int", Default: "1", Description: "The active page (1-indexed)."},
+		{Name: "TotalPages", Type: "int", Default: "1", Description: "Total number of pages."},
+		{Name: "BaseURL", Type: "string", Default: `""`, Description: "Base href for page links (page appended as a query/path)."},
+		{Name: "HTMXTarget", Type: "string", Default: `""`, Description: "CSS selector to swap on click (enables in-place HTMX navigation)."},
+		{Name: "HTMXSwap", Type: "string", Default: `""`, Description: "HTMX swap strategy used with HTMXTarget."},
+		{Name: "ID", Type: "string", Default: `""`, Description: "Optional element id on the nav."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
+	})
 }
 
-// paginationDemoPreview renders the Goshtoso pagination preview
-templ paginationDemoPreview() {
-	<div class="w-full max-w-3xl mx-auto space-y-12">
-		// Simple Pagination (prev/next only)
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Simple Pagination (Prev/Next)</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4">A minimal pagination with only previous and next buttons.</p>
-			@pagination.Pagination(pagination.Config{
-				Variant:     pagination.Simple,
-				CurrentPage: 3,
-				TotalPages:  10,
-				BaseURL:     "#",
-			})
-		</div>
+// paginationSimplePreview renders the simple prev/next variant.
+templ paginationSimplePreview() {
+	<div id="pagination-simple" class="w-full max-w-2xl mx-auto">
+		@pagination.Pagination(pagination.Config{Variant: pagination.Simple, CurrentPage: 3, TotalPages: 10, BaseURL: "#"})
+	</div>
+}
 
-		// Simple Pagination - First Page (prev disabled)
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Simple Pagination (First Page)</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Previous button is disabled on the first page.</p>
-			@pagination.Pagination(pagination.Config{
-				Variant:     pagination.Simple,
-				CurrentPage: 1,
-				TotalPages:  10,
-				BaseURL:     "#",
-			})
-		</div>
+// paginationFirstPreview renders the simple variant on the first page.
+templ paginationFirstPreview() {
+	<div id="pagination-first" class="w-full max-w-2xl mx-auto">
+		@pagination.Pagination(pagination.Config{Variant: pagination.Simple, CurrentPage: 1, TotalPages: 10, BaseURL: "#"})
+	</div>
+}
 
-		// With Ellipsis - Beginning
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Pagination with Ellipsis (Page 2 of 30)</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Shows page numbers with ellipsis for large page ranges.</p>
-			@pagination.Pagination(pagination.Config{
-				Variant:     pagination.WithEllipsis,
-				CurrentPage: 2,
-				TotalPages:  30,
-				BaseURL:     "#",
-			})
-		</div>
+// paginationEllipsisBeginPreview renders ellipsis pagination near the start.
+templ paginationEllipsisBeginPreview() {
+	<div id="pagination-ellipsis-begin" class="w-full max-w-2xl mx-auto">
+		@pagination.Pagination(pagination.Config{Variant: pagination.WithEllipsis, CurrentPage: 2, TotalPages: 30, BaseURL: "#"})
+	</div>
+}
 
-		// With Ellipsis - Middle
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Pagination with Ellipsis (Page 15 of 30)</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Current page in the middle shows ellipsis on both sides.</p>
-			@pagination.Pagination(pagination.Config{
-				Variant:     pagination.WithEllipsis,
-				CurrentPage: 15,
-				TotalPages:  30,
-				BaseURL:     "#",
-			})
-		</div>
+// paginationEllipsisMidPreview renders ellipsis pagination in the middle.
+templ paginationEllipsisMidPreview() {
+	<div id="pagination-ellipsis-mid" class="w-full max-w-2xl mx-auto">
+		@pagination.Pagination(pagination.Config{Variant: pagination.WithEllipsis, CurrentPage: 15, TotalPages: 30, BaseURL: "#"})
+	</div>
+}
 
-		// With Ellipsis - End
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Pagination with Ellipsis (Page 29 of 30)</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Near the end, ellipsis only appears before the range.</p>
-			@pagination.Pagination(pagination.Config{
-				Variant:     pagination.WithEllipsis,
-				CurrentPage: 29,
-				TotalPages:  30,
-				BaseURL:     "#",
-			})
-		</div>
+// paginationEllipsisEndPreview renders ellipsis pagination near the end.
+templ paginationEllipsisEndPreview() {
+	<div id="pagination-ellipsis-end" class="w-full max-w-2xl mx-auto">
+		@pagination.Pagination(pagination.Config{Variant: pagination.WithEllipsis, CurrentPage: 29, TotalPages: 30, BaseURL: "#"})
+	</div>
+}
 
-		// Small page count (no ellipsis needed)
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Small Page Count (No Ellipsis)</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4">When total pages are 7 or fewer, all pages are shown.</p>
-			@pagination.Pagination(pagination.Config{
-				Variant:     pagination.WithEllipsis,
-				CurrentPage: 3,
-				TotalPages:  5,
-				BaseURL:     "#",
-			})
-		</div>
+// paginationSmallPreview renders a small page count (no ellipsis).
+templ paginationSmallPreview() {
+	<div id="pagination-small" class="w-full max-w-2xl mx-auto">
+		@pagination.Pagination(pagination.Config{Variant: pagination.WithEllipsis, CurrentPage: 3, TotalPages: 5, BaseURL: "#"})
 	</div>
 }

--- a/internal/pages/demo/components/pagination_templ.go
+++ b/internal/pages/demo/components/pagination_templ.go
@@ -43,7 +43,9 @@ func PaginationDemoPage() templ.Component {
 	})
 }
 
-// paginationDemoContent renders the actual content inside the layout
+// paginationDemoContent renders the demo. Each pagination variant lives in its
+// own preview frame followed by its own code block (mirrors
+// penguinui.com/components/pagination). Wrapped in #pagination-fragment.
 func paginationDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,30 +67,97 @@ func paginationDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"pagination-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Pagination",
-				Description: "Pagination components allow users to navigate between pages of content. Supports simple prev/next and ellipsis variants.",
+				Description: "Navigate between pages of content. Simple prev/next and ellipsis page-number variants, with optional HTMX wiring.",
 			},
-			paginationDemoPreview(),
-			`// Simple pagination (prev/next only)
-@pagination.Pagination(pagination.Config{
+			paginationSimplePreview(),
+			`@pagination.Pagination(pagination.Config{
     Variant:     pagination.Simple,
     CurrentPage: 3,
     TotalPages:  10,
     BaseURL:     "/items",
-})
-
-// With ellipsis and page numbers
-@pagination.Pagination(pagination.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Simple — First Page",
+				Description: "The Previous control auto-disables on the first page (and Next on the last).",
+			},
+			paginationFirstPreview(),
+			`@pagination.Pagination(pagination.Config{
+    Variant:     pagination.Simple,
+    CurrentPage: 1,
+    TotalPages:  10,
+    BaseURL:     "/items",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Ellipsis — Beginning",
+				Description: "Variant: pagination.WithEllipsis shows page numbers, collapsing large ranges with an ellipsis.",
+			},
+			paginationEllipsisBeginPreview(),
+			`@pagination.Pagination(pagination.Config{
     Variant:     pagination.WithEllipsis,
     CurrentPage: 2,
     TotalPages:  30,
     BaseURL:     "/items",
-})
-
-// With HTMX integration
-@pagination.Pagination(pagination.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Ellipsis — Middle",
+				Description: "A current page in the middle collapses both sides with ellipses.",
+			},
+			paginationEllipsisMidPreview(),
+			`@pagination.Pagination(pagination.Config{
+    Variant:     pagination.WithEllipsis,
+    CurrentPage: 15,
+    TotalPages:  30,
+    BaseURL:     "/items",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Ellipsis — End",
+				Description: "Near the end, only the leading range collapses.",
+			},
+			paginationEllipsisEndPreview(),
+			`@pagination.Pagination(pagination.Config{
+    Variant:     pagination.WithEllipsis,
+    CurrentPage: 29,
+    TotalPages:  30,
+    BaseURL:     "/items",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Small Page Count",
+				Description: "With 7 or fewer pages, every page number is shown (no ellipsis). Add HTMXTarget + HTMXSwap to swap content in place instead of navigating.",
+			},
+			paginationSmallPreview(),
+			`@pagination.Pagination(pagination.Config{
     Variant:     pagination.WithEllipsis,
     CurrentPage: 5,
     TotalPages:  30,
@@ -100,12 +169,29 @@ func paginationDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Variant", Type: "Variant", Default: "WithEllipsis", Description: `Style: "simple" (prev/next only) or "ellipsis" (page numbers).`},
+			{Name: "CurrentPage", Type: "int", Default: "1", Description: "The active page (1-indexed)."},
+			{Name: "TotalPages", Type: "int", Default: "1", Description: "Total number of pages."},
+			{Name: "BaseURL", Type: "string", Default: `""`, Description: "Base href for page links (page appended as a query/path)."},
+			{Name: "HTMXTarget", Type: "string", Default: `""`, Description: "CSS selector to swap on click (enables in-place HTMX navigation)."},
+			{Name: "HTMXSwap", Type: "string", Default: `""`, Description: "HTMX swap strategy used with HTMXTarget."},
+			{Name: "ID", Type: "string", Default: `""`, Description: "Optional element id on the nav."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// paginationDemoPreview renders the Goshtoso pagination preview
-func paginationDemoPreview() templ.Component {
+// paginationSimplePreview renders the simple prev/next variant.
+func paginationSimplePreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -126,85 +212,205 @@ func paginationDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-3xl mx-auto space-y-12\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Simple Pagination (Prev/Next)</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">A minimal pagination with only previous and next buttons.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"pagination-simple\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{
-			Variant:     pagination.Simple,
-			CurrentPage: 3,
-			TotalPages:  10,
-			BaseURL:     "#",
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{Variant: pagination.Simple, CurrentPage: 3, TotalPages: 10, BaseURL: "#"}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Simple Pagination (First Page)</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Previous button is disabled on the first page.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{
-			Variant:     pagination.Simple,
-			CurrentPage: 1,
-			TotalPages:  10,
-			BaseURL:     "#",
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		return nil
+	})
+}
+
+// paginationFirstPreview renders the simple variant on the first page.
+func paginationFirstPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"pagination-first\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Pagination with Ellipsis (Page 2 of 30)</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Shows page numbers with ellipsis for large page ranges.</p>")
+		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{Variant: pagination.Simple, CurrentPage: 1, TotalPages: 10, BaseURL: "#"}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{
-			Variant:     pagination.WithEllipsis,
-			CurrentPage: 2,
-			TotalPages:  30,
-			BaseURL:     "#",
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Pagination with Ellipsis (Page 15 of 30)</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Current page in the middle shows ellipsis on both sides.</p>")
+		return nil
+	})
+}
+
+// paginationEllipsisBeginPreview renders ellipsis pagination near the start.
+func paginationEllipsisBeginPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"pagination-ellipsis-begin\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{
-			Variant:     pagination.WithEllipsis,
-			CurrentPage: 15,
-			TotalPages:  30,
-			BaseURL:     "#",
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{Variant: pagination.WithEllipsis, CurrentPage: 2, TotalPages: 30, BaseURL: "#"}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Pagination with Ellipsis (Page 29 of 30)</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Near the end, ellipsis only appears before the range.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{
-			Variant:     pagination.WithEllipsis,
-			CurrentPage: 29,
-			TotalPages:  30,
-			BaseURL:     "#",
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		return nil
+	})
+}
+
+// paginationEllipsisMidPreview renders ellipsis pagination in the middle.
+func paginationEllipsisMidPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"pagination-ellipsis-mid\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Small Page Count (No Ellipsis)</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">When total pages are 7 or fewer, all pages are shown.</p>")
+		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{Variant: pagination.WithEllipsis, CurrentPage: 15, TotalPages: 30, BaseURL: "#"}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{
-			Variant:     pagination.WithEllipsis,
-			CurrentPage: 3,
-			TotalPages:  5,
-			BaseURL:     "#",
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div></div>")
+		return nil
+	})
+}
+
+// paginationEllipsisEndPreview renders ellipsis pagination near the end.
+func paginationEllipsisEndPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"pagination-ellipsis-end\" class=\"w-full max-w-2xl mx-auto\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{Variant: pagination.WithEllipsis, CurrentPage: 29, TotalPages: 30, BaseURL: "#"}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// paginationSmallPreview renders a small page count (no ellipsis).
+func paginationSmallPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"pagination-small\" class=\"w-full max-w-2xl mx-auto\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = pagination.Pagination(pagination.Config{Variant: pagination.WithEllipsis, CurrentPage: 3, TotalPages: 5, BaseURL: "#"}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/palette.templ
+++ b/internal/pages/demo/components/palette.templ
@@ -11,26 +11,35 @@ templ PaletteDemoPage() {
 	@demo.Layout("Palette", "palette", paletteDemoContent())
 }
 
-// paletteDemoContent renders the actual content inside the layout
+// paletteDemoContent renders the demo. Both palette variants share one
+// x-data="{ picked, shellPicked }" scope so the standalone "Selected:" readout
+// and the shell trigger both react to picks. Wrapped in #palette-fragment.
 templ paletteDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:       "Palette",
-			Description: "A color palette picker spanning Tailwind's named hues and shades. Bind it to an Alpine model or host it inside a Select shell. On pick it dispatches a bubbling select-close event with the chosen value.",
-		},
-		paletteDemoPreview(),
-		`// Standalone palette bound to an Alpine model
-<div x-data="{ picked: '' }">
+	<div x-data="{ picked: '', shellPicked: '' }">
+		<div id="palette-fragment">
+			@demo.ComponentDemo(
+				demo.ComponentDemoProps{
+					Title:       "Palette",
+					Description: "A color palette picker spanning Tailwind's named hues and shades. Bind it to an Alpine model or host it inside a Select shell; on pick it dispatches a bubbling select-close event with the chosen value.",
+				},
+				paletteStandalonePreview(),
+				`<div x-data="{ picked: '' }">
     @palette.Palette(palette.Config{
         ID:          "demo-palette",
         AlpineModel: "picked",
         ShowHex:     true,
     })
     <p>Selected: <span x-text="picked || '—'"></span></p>
-</div>
+</div>`,
+			)
 
-// Palette hosted inside a Select shell
-<div x-data="{ shellPicked: '' }">
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Inside a Select Shell",
+					Description: "Host the palette inside a Select with Shell: true; the trigger label reflects the picked value via ValueExpr.",
+				},
+				paletteShellPreview(),
+				`<div x-data="{ shellPicked: '' }">
     @selectfield.Select(selectfield.Config{
         ID:        "demo-shell",
         Shell:     true,
@@ -43,41 +52,48 @@ templ paletteDemoContent() {
         })
     }
 </div>`,
-	)
+			)
+		</div>
+		@demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the palette root (swatch buttons + Alpine scope)."},
+			{Name: "AlpineModel", Type: "string", Default: `""`, Description: "x-model expression that receives the picked color class (e.g. \"blue-700\")."},
+			{Name: "Hues", Type: "[]string", Default: "all", Description: "Restrict to specific Tailwind hues (default: the full set)."},
+			{Name: "Shades", Type: "[]string", Default: "all", Description: "Restrict to specific shades (e.g. \"500\", \"700\")."},
+			{Name: "HideNeutral", Type: "bool", Default: "false", Description: "Hide the neutral (gray) row."},
+			{Name: "HideReset", Type: "bool", Default: "false", Description: "Hide the reset/clear control."},
+			{Name: "ShowHex", Type: "bool", Default: "false", Description: "Show the hex value of the hovered/selected swatch."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the palette container."},
+		})
+	</div>
 }
 
-// paletteDemoPreview renders the Goshtoso palette preview
-templ paletteDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8" x-data="{ picked: '', shellPicked: '' }">
-		// Standalone palette bound to a model
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Standalone Palette</h4>
-			<div class="max-w-md rounded-radius border border-outline dark:border-outline-dark">
-				@palette.Palette(palette.Config{
-					ID:          "demo-palette",
-					AlpineModel: "picked",
-					ShowHex:     true,
-				})
-			</div>
-			<p class="mt-3 text-sm text-on-surface-muted dark:text-on-surface-dark-muted">Selected: <span x-text="picked || '—'"></span></p>
+// paletteStandalonePreview renders the standalone palette with a Selected readout.
+templ paletteStandalonePreview() {
+	<div id="palette-standalone" class="w-full max-w-md mx-auto">
+		<div class="rounded-radius border border-outline dark:border-outline-dark">
+			@palette.Palette(palette.Config{
+				ID:          "demo-palette",
+				AlpineModel: "picked",
+				ShowHex:     true,
+			})
 		</div>
+		<p class="mt-3 text-sm text-on-surface-muted dark:text-on-surface-dark-muted">Selected: <span x-text="picked || '—'"></span></p>
+	</div>
+}
 
-		// Inside a Select shell
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Inside a Select shell</h4>
-			<div class="max-w-xs">
-				@selectfield.Select(selectfield.Config{
-					ID:        "demo-shell",
-					Shell:     true,
-					ValueExpr: "shellPicked || 'Pick a color'",
-				}) {
-					@palette.Palette(palette.Config{
-						ID:          "demo-shell-palette",
-						AlpineModel: "shellPicked",
-						ShowHex:     true,
-					})
-				}
-			</div>
-		</div>
+// paletteShellPreview renders the palette hosted inside a Select shell.
+templ paletteShellPreview() {
+	<div id="palette-shell" class="w-full max-w-xs mx-auto">
+		@selectfield.Select(selectfield.Config{
+			ID:        "demo-shell",
+			Shell:     true,
+			ValueExpr: "shellPicked || 'Pick a color'",
+		}) {
+			@palette.Palette(palette.Config{
+				ID:          "demo-shell-palette",
+				AlpineModel: "shellPicked",
+				ShowHex:     true,
+			})
+		}
 	</div>
 }

--- a/internal/pages/demo/components/palette_templ.go
+++ b/internal/pages/demo/components/palette_templ.go
@@ -44,7 +44,9 @@ func PaletteDemoPage() templ.Component {
 	})
 }
 
-// paletteDemoContent renders the actual content inside the layout
+// paletteDemoContent renders the demo. Both palette variants share one
+// x-data="{ picked, shellPicked }" scope so the standalone "Selected:" readout
+// and the shell trigger both react to picks. Wrapped in #palette-fragment.
 func paletteDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -66,24 +68,35 @@ func paletteDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div x-data=\"{ picked: '', shellPicked: '' }\"><div id=\"palette-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Palette",
-				Description: "A color palette picker spanning Tailwind's named hues and shades. Bind it to an Alpine model or host it inside a Select shell. On pick it dispatches a bubbling select-close event with the chosen value.",
+				Description: "A color palette picker spanning Tailwind's named hues and shades. Bind it to an Alpine model or host it inside a Select shell; on pick it dispatches a bubbling select-close event with the chosen value.",
 			},
-			paletteDemoPreview(),
-			`// Standalone palette bound to an Alpine model
-<div x-data="{ picked: '' }">
+			paletteStandalonePreview(),
+			`<div x-data="{ picked: '' }">
     @palette.Palette(palette.Config{
         ID:          "demo-palette",
         AlpineModel: "picked",
         ShowHex:     true,
     })
     <p>Selected: <span x-text="picked || '—'"></span></p>
-</div>
-
-// Palette hosted inside a Select shell
-<div x-data="{ shellPicked: '' }">
+</div>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Inside a Select Shell",
+				Description: "Host the palette inside a Select with Shell: true; the trigger label reflects the picked value via ValueExpr.",
+			},
+			paletteShellPreview(),
+			`<div x-data="{ shellPicked: '' }">
     @selectfield.Select(selectfield.Config{
         ID:        "demo-shell",
         Shell:     true,
@@ -100,12 +113,33 @@ func paletteDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the palette root (swatch buttons + Alpine scope)."},
+			{Name: "AlpineModel", Type: "string", Default: `""`, Description: "x-model expression that receives the picked color class (e.g. \"blue-700\")."},
+			{Name: "Hues", Type: "[]string", Default: "all", Description: "Restrict to specific Tailwind hues (default: the full set)."},
+			{Name: "Shades", Type: "[]string", Default: "all", Description: "Restrict to specific shades (e.g. \"500\", \"700\")."},
+			{Name: "HideNeutral", Type: "bool", Default: "false", Description: "Hide the neutral (gray) row."},
+			{Name: "HideReset", Type: "bool", Default: "false", Description: "Hide the reset/clear control."},
+			{Name: "ShowHex", Type: "bool", Default: "false", Description: "Show the hex value of the hovered/selected swatch."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the palette container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// paletteDemoPreview renders the Goshtoso palette preview
-func paletteDemoPreview() templ.Component {
+// paletteStandalonePreview renders the standalone palette with a Selected readout.
+func paletteStandalonePreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -126,7 +160,7 @@ func paletteDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\" x-data=\"{ picked: '', shellPicked: '' }\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Standalone Palette</h4><div class=\"max-w-md rounded-radius border border-outline dark:border-outline-dark\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div id=\"palette-standalone\" class=\"w-full max-w-md mx-auto\"><div class=\"rounded-radius border border-outline dark:border-outline-dark\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -138,11 +172,41 @@ func paletteDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><p class=\"mt-3 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Selected: <span x-text=\"picked || '—'\"></span></p></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Inside a Select shell</h4><div class=\"max-w-xs\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div><p class=\"mt-3 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Selected: <span x-text=\"picked || '—'\"></span></p></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var4 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		return nil
+	})
+}
+
+// paletteShellPreview renders the palette hosted inside a Select shell.
+func paletteShellPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div id=\"palette-shell\" class=\"w-full max-w-xs mx-auto\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var5 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -168,11 +232,11 @@ func paletteDemoPreview() templ.Component {
 			ID:        "demo-shell",
 			Shell:     true,
 			ValueExpr: "shellPicked || 'Pick a color'",
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var5), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/radio.templ
+++ b/internal/pages/demo/components/radio.templ
@@ -11,206 +11,308 @@ templ RadioDemoPage() {
 	@demo.Layout("Radio", "radio", radioDemoContent())
 }
 
-// radioDemoContent renders the actual content inside the layout
+// radioDemoContent renders the demo. Each radio variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/radio).
+// The variant set stays wrapped in #radio-fragment so the e2e selectors keep working.
 templ radioDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Radio",
-			Description:   "Single-select form input. Supports color variants, sizes, descriptions, bordered containers, segmented pill bars, and exposes first-class HTMX + Alpine.js interaction primitives.",
-		},
-		radioDemoPreview(),
-		`// Default radio
-@radio.Radio(radio.Config{
+	<div id="radio-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Radio",
+				Description: "Single-select form input. Supports color variants, sizes, descriptions, bordered containers, segmented pill bars, and first-class HTMX + Alpine.js interaction primitives.",
+			},
+			radioDefaultPreview(),
+			`@radio.Radio(radio.Config{
     ID: "r-mac", Name: "os", Value: "mac", Label: "Mac", Checked: true,
 })
-
-// Container variant
 @radio.Radio(radio.Config{
+    ID: "r-win", Name: "os", Value: "windows", Label: "Windows",
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Container",
+				Description: "Wraps each option in a bordered container with Container: true.",
+			},
+			radioContainerPreview(),
+			`@radio.Radio(radio.Config{
     ID: "r-c-mac", Name: "os-c", Value: "mac", Label: "Mac",
     Container: true, Checked: true,
-})
+})`,
+		)
 
-// Segmented variant — true segmented control (connected pill bar)
-@radio.RadioBar() {
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Segmented",
+				Description: "A true segmented control (connected pill bar). Set Segmented: true and group inside RadioBar.",
+			},
+			radioSegmentedPreview(),
+			`@radio.RadioBar() {
     @radio.Radio(radio.Config{ID: "r-seg-a", Name: "g", Value: "a", Label: "A", Segmented: true, Checked: true})
     @radio.Radio(radio.Config{ID: "r-seg-b", Name: "g", Value: "b", Label: "B", Segmented: true})
-}
+}`,
+		)
 
-// Alpine: client-side state
-@radio.Radio(radio.Config{
-    ID: "r-a-md", Name: "size-a", Value: "md", Label: "md",
-    Segmented: true,
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Description",
+				Description: "Add helper text under the label via Description (wire DescriptionID for aria-describedby).",
+			},
+			radioDescriptionPreview(),
+			`@radio.Radio(radio.Config{
+    ID: "r-desc-mac", Name: "os-desc", Value: "mac", Label: "Mac",
+    Description:   "For macOS Big Sur and higher.",
+    DescriptionID: "r-desc-mac-desc",
+    Checked:       true,
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Color Variants",
+				Description: "Six semantic colors via Variant: Primary, Secondary, Info, Success, Warning, Danger.",
+			},
+			radioColorPreview(),
+			`@radio.Radio(radio.Config{ID: "r-success", Name: "v", Value: "su", Label: "Success", Variant: radio.Success, Checked: true})
+@radio.Radio(radio.Config{ID: "r-danger", Name: "v2", Value: "d", Label: "Danger", Variant: radio.Danger, Checked: true})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Sizes",
+				Description: "Four box sizes via Size: SizeSM, SizeMD (default), SizeLG, SizeXL.",
+			},
+			radioSizesPreview(),
+			`@radio.Radio(radio.Config{ID: "r-sm", Name: "sz", Value: "sm", Label: "Small", Size: radio.SizeSM, Checked: true})
+@radio.Radio(radio.Config{ID: "r-xl", Name: "sz2", Value: "xl", Label: "XL", Size: radio.SizeXL, Checked: true})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks interaction and dims the control.",
+			},
+			radioDisabledPreview(),
+			`@radio.Radio(radio.Config{ID: "r-d1", Name: "dis", Value: "a", Label: "Disabled unchecked", Disabled: true})
+@radio.Radio(radio.Config{ID: "r-d2", Name: "dis", Value: "b", Label: "Disabled checked", Disabled: true, Checked: true})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Alpine — client state",
+				Description: "Wire AlpineConfig for client-only state. Clicks update local x-data without a server roundtrip.",
+			},
+			radioAlpinePreview(),
+			`@radio.Radio(radio.Config{
+    ID: "r-a-md", Name: "size-a", Value: "md", Label: "md", Segmented: true,
     Alpine: &radio.AlpineConfig{
         BindChecked: "selected === 'md'",
         OnChange:    "selected = 'md'",
     },
-})
+})`,
+		)
 
-// HTMX: server roundtrip on change
-@radio.Radio(radio.Config{
-    ID: "r-h-md", Name: "size-h", Value: "md", Label: "md",
-    Segmented: true,
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "HTMX — server roundtrip",
+				Description: "Wire HTMXConfig for a server roundtrip on change. The response swaps into the target.",
+			},
+			radioHTMXPreview(),
+			`@radio.Radio(radio.Config{
+    ID: "r-h-md", Name: "size-h", Value: "md", Label: "md", Segmented: true,
     HTMX: &radio.HTMXConfig{
         Get:    "/api/components/radio/echo?value=md",
         Target: "#radio-htmx-out",
         Swap:   "innerHTML",
     },
 })`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Hybrid — Alpine state + HTMX persistence",
+				Description: "Set both Alpine and HTMX: a single click updates client state and fires the server roundtrip.",
+			},
+			radioHybridPreview(),
+			`@radio.Radio(radio.Config{
+    ID: "r-hy-md", Name: "size-hy", Value: "md", Label: "md", Segmented: true,
+    Alpine: &radio.AlpineConfig{BindChecked: "selected === 'md'", OnChange: "selected = 'md'"},
+    HTMX:   &radio.HTMXConfig{Get: "/api/components/radio/echo?value=md", Target: "#radio-hybrid-out", Swap: "innerHTML"},
+})`,
+		)
+	</div>
+	// API reference lives outside #radio-fragment so its table rows don't pollute
+	// the radio group selectors the e2e suite relies on.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the radio input (also the label's for target)."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Form field name shared by all radios in a group."},
+		{Name: "Value", Type: "string", Default: `""`, Description: "Form field value submitted when selected."},
+		{Name: "Label", Type: "string", Default: `""`, Description: "Text displayed next to the radio."},
+		{Name: "Checked", Type: "bool", Default: "false", Description: "Initial checked state."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disables interaction and dims the control."},
+		{Name: "Variant", Type: "Variant", Default: "Primary", Description: `Color scheme: "primary", "secondary", "info", "success", "warning", "danger".`},
+		{Name: "Size", Type: "Size", Default: "SizeMD", Description: `Box size: "sm", "md", "lg", "xl".`},
+		{Name: "Description", Type: "string", Default: `""`, Description: "Helper text rendered below the label."},
+		{Name: "DescriptionID", Type: "string", Default: `""`, Description: "ID of the description element for aria-describedby wiring."},
+		{Name: "Container", Type: "bool", Default: "false", Description: "Wraps the radio in a bordered container."},
+		{Name: "Segmented", Type: "bool", Default: "false", Description: "Renders a segmented-control pill (sr-only input); group inside RadioBar."},
+		{Name: "BadgeColor", Type: "string", Default: `""`, Description: "Wraps the label in a semi-solid badge of the given color."},
+		{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "Server interaction on change (Get/Post/Target/Swap/...)."},
+		{Name: "Alpine", Type: "*AlpineConfig", Default: "nil", Description: "Client-side state (Model/OnChange/BindChecked/...)."},
+		{Name: "Attrs", Type: "templ.Attributes", Default: "nil", Description: "Escape hatch applied last to the input; wins on conflict."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes appended to the label root."},
+	})
 }
 
-// radioDemoPreview renders the Goshtoso radio preview sections
-templ radioDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-10">
-		// Default Radio
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Radio</h4>
-			<div class="flex flex-col gap-2" data-testid="radio-default-group">
-				@radio.Radio(radio.Config{ID: "r-d-mac", Name: "os-default", Value: "mac", Label: "Mac", Checked: true})
-				@radio.Radio(radio.Config{ID: "r-d-win", Name: "os-default", Value: "windows", Label: "Windows"})
-				@radio.Radio(radio.Config{ID: "r-d-linux", Name: "os-default", Value: "linux", Label: "Linux"})
-			</div>
+// radioDefaultPreview renders the default exclusive radio group.
+templ radioDefaultPreview() {
+	<div id="radio-default" class="w-full max-w-md mx-auto">
+		<div class="flex flex-col gap-2" data-testid="radio-default-group">
+			@radio.Radio(radio.Config{ID: "r-d-mac", Name: "os-default", Value: "mac", Label: "Mac", Checked: true})
+			@radio.Radio(radio.Config{ID: "r-d-win", Name: "os-default", Value: "windows", Label: "Windows"})
+			@radio.Radio(radio.Config{ID: "r-d-linux", Name: "os-default", Value: "linux", Label: "Linux"})
 		</div>
+	</div>
+}
 
-		// Container Variant
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With Container</h4>
-			<div class="flex flex-wrap gap-2" data-testid="radio-container-group">
-				@radio.Radio(radio.Config{ID: "r-c-mac", Name: "os-container", Value: "mac", Label: "Mac", Container: true, Checked: true})
-				@radio.Radio(radio.Config{ID: "r-c-win", Name: "os-container", Value: "windows", Label: "Windows", Container: true})
-				@radio.Radio(radio.Config{ID: "r-c-linux", Name: "os-container", Value: "linux", Label: "Linux", Container: true})
-			</div>
+// radioContainerPreview renders the bordered-container variant.
+templ radioContainerPreview() {
+	<div id="radio-container" class="w-full max-w-md mx-auto">
+		<div class="flex flex-wrap gap-2" data-testid="radio-container-group">
+			@radio.Radio(radio.Config{ID: "r-c-mac", Name: "os-container", Value: "mac", Label: "Mac", Container: true, Checked: true})
+			@radio.Radio(radio.Config{ID: "r-c-win", Name: "os-container", Value: "windows", Label: "Windows", Container: true})
+			@radio.Radio(radio.Config{ID: "r-c-linux", Name: "os-container", Value: "linux", Label: "Linux", Container: true})
 		</div>
+	</div>
+}
 
-		// Segmented Variant
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Segmented (connected pill bar)</h4>
-			<div data-testid="radio-segmented-group">
-				@radio.RadioBar() {
-					@radio.Radio(radio.Config{ID: "r-seg-mac", Name: "os-seg", Value: "mac", Label: "Mac", Segmented: true, Checked: true})
-					@radio.Radio(radio.Config{ID: "r-seg-win", Name: "os-seg", Value: "windows", Label: "Windows", Segmented: true})
-					@radio.Radio(radio.Config{ID: "r-seg-linux", Name: "os-seg", Value: "linux", Label: "Linux", Segmented: true})
-				}
-			</div>
+// radioSegmentedPreview renders the connected pill-bar segmented variant.
+templ radioSegmentedPreview() {
+	<div id="radio-segmented" class="w-full max-w-md mx-auto">
+		<div data-testid="radio-segmented-group">
+			@radio.RadioBar() {
+				@radio.Radio(radio.Config{ID: "r-seg-mac", Name: "os-seg", Value: "mac", Label: "Mac", Segmented: true, Checked: true})
+				@radio.Radio(radio.Config{ID: "r-seg-win", Name: "os-seg", Value: "windows", Label: "Windows", Segmented: true})
+				@radio.Radio(radio.Config{ID: "r-seg-linux", Name: "os-seg", Value: "linux", Label: "Linux", Segmented: true})
+			}
 		</div>
+	</div>
+}
 
-		// With Description
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With Description</h4>
-			<div class="flex flex-col gap-3">
-				@radio.Radio(radio.Config{
-					ID: "r-desc-mac", Name: "os-desc", Value: "mac", Label: "Mac",
-					Description:   "For macOS Big Sur and higher.",
-					DescriptionID: "r-desc-mac-desc",
-					Checked:       true,
-				})
-				@radio.Radio(radio.Config{
-					ID: "r-desc-win", Name: "os-desc", Value: "windows", Label: "Windows",
-					Description:   "Windows 10 and Windows 11.",
-					DescriptionID: "r-desc-win-desc",
-				})
-			</div>
+// radioDescriptionPreview renders radios with helper descriptions.
+templ radioDescriptionPreview() {
+	<div id="radio-description" class="w-full max-w-md mx-auto">
+		<div class="flex flex-col gap-3">
+			@radio.Radio(radio.Config{
+				ID: "r-desc-mac", Name: "os-desc", Value: "mac", Label: "Mac",
+				Description:   "For macOS Big Sur and higher.",
+				DescriptionID: "r-desc-mac-desc",
+				Checked:       true,
+			})
+			@radio.Radio(radio.Config{
+				ID: "r-desc-win", Name: "os-desc", Value: "windows", Label: "Windows",
+				Description:   "Windows 10 and Windows 11.",
+				DescriptionID: "r-desc-win-desc",
+			})
 		</div>
+	</div>
+}
 
-		// Color Variants
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Color Variants</h4>
-			<div class="flex flex-wrap gap-4" data-testid="radio-color-variants">
-				@radio.Radio(radio.Config{ID: "r-v-primary", Name: "v-primary", Value: "p", Label: "Primary", Variant: radio.Primary, Checked: true})
-				@radio.Radio(radio.Config{ID: "r-v-secondary", Name: "v-secondary", Value: "s", Label: "Secondary", Variant: radio.Secondary, Checked: true})
-				@radio.Radio(radio.Config{ID: "r-v-info", Name: "v-info", Value: "i", Label: "Info", Variant: radio.Info, Checked: true})
-				@radio.Radio(radio.Config{ID: "r-v-success", Name: "v-success", Value: "su", Label: "Success", Variant: radio.Success, Checked: true})
-				@radio.Radio(radio.Config{ID: "r-v-warning", Name: "v-warning", Value: "w", Label: "Warning", Variant: radio.Warning, Checked: true})
-				@radio.Radio(radio.Config{ID: "r-v-danger", Name: "v-danger", Value: "d", Label: "Danger", Variant: radio.Danger, Checked: true})
-			</div>
+// radioColorPreview renders the six semantic color variants.
+templ radioColorPreview() {
+	<div id="radio-colors" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-4" data-testid="radio-color-variants">
+			@radio.Radio(radio.Config{ID: "r-v-primary", Name: "v-primary", Value: "p", Label: "Primary", Variant: radio.Primary, Checked: true})
+			@radio.Radio(radio.Config{ID: "r-v-secondary", Name: "v-secondary", Value: "s", Label: "Secondary", Variant: radio.Secondary, Checked: true})
+			@radio.Radio(radio.Config{ID: "r-v-info", Name: "v-info", Value: "i", Label: "Info", Variant: radio.Info, Checked: true})
+			@radio.Radio(radio.Config{ID: "r-v-success", Name: "v-success", Value: "su", Label: "Success", Variant: radio.Success, Checked: true})
+			@radio.Radio(radio.Config{ID: "r-v-warning", Name: "v-warning", Value: "w", Label: "Warning", Variant: radio.Warning, Checked: true})
+			@radio.Radio(radio.Config{ID: "r-v-danger", Name: "v-danger", Value: "d", Label: "Danger", Variant: radio.Danger, Checked: true})
 		</div>
+	</div>
+}
 
-		// Sizes
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Sizes</h4>
-			<div class="flex items-center gap-4" data-testid="radio-sizes">
-				@radio.Radio(radio.Config{ID: "r-size-sm", Name: "sz-sm", Value: "sm", Label: "Small", Size: radio.SizeSM, Checked: true})
-				@radio.Radio(radio.Config{ID: "r-size-md", Name: "sz-md", Value: "md", Label: "Medium", Size: radio.SizeMD, Checked: true})
-				@radio.Radio(radio.Config{ID: "r-size-lg", Name: "sz-lg", Value: "lg", Label: "Large", Size: radio.SizeLG, Checked: true})
-				@radio.Radio(radio.Config{ID: "r-size-xl", Name: "sz-xl", Value: "xl", Label: "XL", Size: radio.SizeXL, Checked: true})
-			</div>
+// radioSizesPreview renders the four input sizes.
+templ radioSizesPreview() {
+	<div id="radio-sizes" class="w-full max-w-md mx-auto">
+		<div class="flex items-center gap-4" data-testid="radio-sizes">
+			@radio.Radio(radio.Config{ID: "r-size-sm", Name: "sz-sm", Value: "sm", Label: "Small", Size: radio.SizeSM, Checked: true})
+			@radio.Radio(radio.Config{ID: "r-size-md", Name: "sz-md", Value: "md", Label: "Medium", Size: radio.SizeMD, Checked: true})
+			@radio.Radio(radio.Config{ID: "r-size-lg", Name: "sz-lg", Value: "lg", Label: "Large", Size: radio.SizeLG, Checked: true})
+			@radio.Radio(radio.Config{ID: "r-size-xl", Name: "sz-xl", Value: "xl", Label: "XL", Size: radio.SizeXL, Checked: true})
 		</div>
+	</div>
+}
 
-		// Disabled
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Disabled</h4>
-			<div class="flex flex-col gap-2">
-				@radio.Radio(radio.Config{ID: "r-dis-1", Name: "dis", Value: "a", Label: "Disabled unchecked", Disabled: true})
-				@radio.Radio(radio.Config{ID: "r-dis-2", Name: "dis", Value: "b", Label: "Disabled checked", Disabled: true, Checked: true})
-			</div>
+// radioDisabledPreview renders disabled radios.
+templ radioDisabledPreview() {
+	<div id="radio-disabled" class="w-full max-w-md mx-auto">
+		<div class="flex flex-col gap-2">
+			@radio.Radio(radio.Config{ID: "r-dis-1", Name: "dis", Value: "a", Label: "Disabled unchecked", Disabled: true})
+			@radio.Radio(radio.Config{ID: "r-dis-2", Name: "dis", Value: "b", Label: "Disabled checked", Disabled: true, Checked: true})
 		</div>
+	</div>
+}
 
-		// Interaction Primitives Showcase
-		<div class="pt-6 border-t border-outline dark:border-outline-dark">
-			<h3 class="text-base font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-1">Interaction primitives</h3>
-			<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-6">
-				Radio exposes both Alpine.js and HTMX primitives via typed Config fields. Use Alpine for client-only
-				state, HTMX for server-driven side effects, or combine both for hybrid flows.
-			</p>
+// radioAlpinePreview renders the Alpine-only client-state showcase.
+templ radioAlpinePreview() {
+	<div id="radio-alpine" class="w-full max-w-md mx-auto" x-data="{ selected: 'md' }">
+		<div class="mb-3" data-testid="radio-alpine-group">
+			@radio.RadioBar() {
+				@radio.Radio(radio.Config{ID: "r-a-sm", Name: "size-a", Value: "sm", Label: "sm", Segmented: true,
+					Alpine: &radio.AlpineConfig{BindChecked: "selected === 'sm'", OnChange: "selected = 'sm'"}})
+				@radio.Radio(radio.Config{ID: "r-a-md", Name: "size-a", Value: "md", Label: "md", Segmented: true,
+					Alpine: &radio.AlpineConfig{BindChecked: "selected === 'md'", OnChange: "selected = 'md'"}})
+				@radio.Radio(radio.Config{ID: "r-a-lg", Name: "size-a", Value: "lg", Label: "lg", Segmented: true,
+					Alpine: &radio.AlpineConfig{BindChecked: "selected === 'lg'", OnChange: "selected = 'lg'"}})
+			}
+		</div>
+		<div class="text-sm text-on-surface dark:text-on-surface-dark" data-testid="radio-alpine-out">
+			Selected: <span x-text="selected" class="font-mono font-semibold"></span>
+		</div>
+	</div>
+}
 
-			// Alpine-only
-			<div class="mb-8" x-data="{ selected: 'md' }">
-				<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Alpine only — client state</h4>
-				<div class="mb-3" data-testid="radio-alpine-group">
-					@radio.RadioBar() {
-						@radio.Radio(radio.Config{ID: "r-a-sm", Name: "size-a", Value: "sm", Label: "sm", Segmented: true,
-							Alpine: &radio.AlpineConfig{BindChecked: "selected === 'sm'", OnChange: "selected = 'sm'"}})
-						@radio.Radio(radio.Config{ID: "r-a-md", Name: "size-a", Value: "md", Label: "md", Segmented: true,
-							Alpine: &radio.AlpineConfig{BindChecked: "selected === 'md'", OnChange: "selected = 'md'"}})
-						@radio.Radio(radio.Config{ID: "r-a-lg", Name: "size-a", Value: "lg", Label: "lg", Segmented: true,
-							Alpine: &radio.AlpineConfig{BindChecked: "selected === 'lg'", OnChange: "selected = 'lg'"}})
-					}
-				</div>
-				<div class="text-sm text-on-surface dark:text-on-surface-dark" data-testid="radio-alpine-out">
-					Selected: <span x-text="selected" class="font-mono font-semibold"></span>
-				</div>
-			</div>
+// radioHTMXPreview renders the HTMX-only server-roundtrip showcase.
+templ radioHTMXPreview() {
+	<div id="radio-htmx" class="w-full max-w-md mx-auto">
+		<div class="mb-3" data-testid="radio-htmx-group">
+			@radio.RadioBar() {
+				@radio.Radio(radio.Config{ID: "r-h-sm", Name: "size-h", Value: "sm", Label: "sm", Segmented: true,
+					HTMX: &radio.HTMXConfig{Get: "/api/components/radio/echo?value=sm", Target: "#radio-htmx-out", Swap: "innerHTML"}})
+				@radio.Radio(radio.Config{ID: "r-h-md", Name: "size-h", Value: "md", Label: "md", Segmented: true,
+					HTMX: &radio.HTMXConfig{Get: "/api/components/radio/echo?value=md", Target: "#radio-htmx-out", Swap: "innerHTML"}})
+				@radio.Radio(radio.Config{ID: "r-h-lg", Name: "size-h", Value: "lg", Label: "lg", Segmented: true,
+					HTMX: &radio.HTMXConfig{Get: "/api/components/radio/echo?value=lg", Target: "#radio-htmx-out", Swap: "innerHTML"}})
+			}
+		</div>
+		<div id="radio-htmx-out" class="text-sm text-on-surface dark:text-on-surface-dark" data-testid="radio-htmx-out">
+			<span class="text-on-surface-muted dark:text-on-surface-dark-muted">No selection yet.</span>
+		</div>
+	</div>
+}
 
-			// HTMX-only
-			<div class="mb-8">
-				<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">HTMX only — server roundtrip on change</h4>
-				<div class="mb-3" data-testid="radio-htmx-group">
-					@radio.RadioBar() {
-						@radio.Radio(radio.Config{ID: "r-h-sm", Name: "size-h", Value: "sm", Label: "sm", Segmented: true,
-							HTMX: &radio.HTMXConfig{Get: "/api/components/radio/echo?value=sm", Target: "#radio-htmx-out", Swap: "innerHTML"}})
-						@radio.Radio(radio.Config{ID: "r-h-md", Name: "size-h", Value: "md", Label: "md", Segmented: true,
-							HTMX: &radio.HTMXConfig{Get: "/api/components/radio/echo?value=md", Target: "#radio-htmx-out", Swap: "innerHTML"}})
-						@radio.Radio(radio.Config{ID: "r-h-lg", Name: "size-h", Value: "lg", Label: "lg", Segmented: true,
-							HTMX: &radio.HTMXConfig{Get: "/api/components/radio/echo?value=lg", Target: "#radio-htmx-out", Swap: "innerHTML"}})
-					}
-				</div>
-				<div id="radio-htmx-out" class="text-sm text-on-surface dark:text-on-surface-dark" data-testid="radio-htmx-out">
-					<span class="text-on-surface-muted dark:text-on-surface-dark-muted">No selection yet.</span>
-				</div>
-			</div>
-
-			// Hybrid
-			<div x-data="{ selected: 'md' }">
-				<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Hybrid — Alpine state + HTMX persistence</h4>
-				<div class="mb-3" data-testid="radio-hybrid-group">
-					@radio.RadioBar() {
-						@radio.Radio(radio.Config{ID: "r-hy-sm", Name: "size-hy", Value: "sm", Label: "sm", Segmented: true,
-							Alpine: &radio.AlpineConfig{BindChecked: "selected === 'sm'", OnChange: "selected = 'sm'"},
-							HTMX:   &radio.HTMXConfig{Get: "/api/components/radio/echo?value=sm", Target: "#radio-hybrid-out", Swap: "innerHTML"}})
-						@radio.Radio(radio.Config{ID: "r-hy-md", Name: "size-hy", Value: "md", Label: "md", Segmented: true,
-							Alpine: &radio.AlpineConfig{BindChecked: "selected === 'md'", OnChange: "selected = 'md'"},
-							HTMX:   &radio.HTMXConfig{Get: "/api/components/radio/echo?value=md", Target: "#radio-hybrid-out", Swap: "innerHTML"}})
-						@radio.Radio(radio.Config{ID: "r-hy-lg", Name: "size-hy", Value: "lg", Label: "lg", Segmented: true,
-							Alpine: &radio.AlpineConfig{BindChecked: "selected === 'lg'", OnChange: "selected = 'lg'"},
-							HTMX:   &radio.HTMXConfig{Get: "/api/components/radio/echo?value=lg", Target: "#radio-hybrid-out", Swap: "innerHTML"}})
-					}
-				</div>
-				<div class="text-sm text-on-surface dark:text-on-surface-dark space-y-1">
-					<div>Alpine: <span x-text="selected" class="font-mono font-semibold" data-testid="radio-hybrid-alpine-out"></span></div>
-					<div id="radio-hybrid-out" data-testid="radio-hybrid-htmx-out">
-						<span class="text-on-surface-muted dark:text-on-surface-dark-muted">Server: not called yet.</span>
-					</div>
-				</div>
+// radioHybridPreview renders the hybrid Alpine-state + HTMX-persistence showcase.
+templ radioHybridPreview() {
+	<div id="radio-hybrid" class="w-full max-w-md mx-auto" x-data="{ selected: 'md' }">
+		<div class="mb-3" data-testid="radio-hybrid-group">
+			@radio.RadioBar() {
+				@radio.Radio(radio.Config{ID: "r-hy-sm", Name: "size-hy", Value: "sm", Label: "sm", Segmented: true,
+					Alpine: &radio.AlpineConfig{BindChecked: "selected === 'sm'", OnChange: "selected = 'sm'"},
+					HTMX:   &radio.HTMXConfig{Get: "/api/components/radio/echo?value=sm", Target: "#radio-hybrid-out", Swap: "innerHTML"}})
+				@radio.Radio(radio.Config{ID: "r-hy-md", Name: "size-hy", Value: "md", Label: "md", Segmented: true,
+					Alpine: &radio.AlpineConfig{BindChecked: "selected === 'md'", OnChange: "selected = 'md'"},
+					HTMX:   &radio.HTMXConfig{Get: "/api/components/radio/echo?value=md", Target: "#radio-hybrid-out", Swap: "innerHTML"}})
+				@radio.Radio(radio.Config{ID: "r-hy-lg", Name: "size-hy", Value: "lg", Label: "lg", Segmented: true,
+					Alpine: &radio.AlpineConfig{BindChecked: "selected === 'lg'", OnChange: "selected = 'lg'"},
+					HTMX:   &radio.HTMXConfig{Get: "/api/components/radio/echo?value=lg", Target: "#radio-hybrid-out", Swap: "innerHTML"}})
+			}
+		</div>
+		<div class="text-sm text-on-surface dark:text-on-surface-dark space-y-1">
+			<div>Alpine: <span x-text="selected" class="font-mono font-semibold" data-testid="radio-hybrid-alpine-out"></span></div>
+			<div id="radio-hybrid-out" data-testid="radio-hybrid-htmx-out">
+				<span class="text-on-surface-muted dark:text-on-surface-dark-muted">Server: not called yet.</span>
 			</div>
 		</div>
 	</div>

--- a/internal/pages/demo/components/radio_templ.go
+++ b/internal/pages/demo/components/radio_templ.go
@@ -44,7 +44,9 @@ func RadioDemoPage() templ.Component {
 	})
 }
 
-// radioDemoContent renders the actual content inside the layout
+// radioDemoContent renders the demo. Each radio variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/radio).
+// The variant set stays wrapped in #radio-fragment so the e2e selectors keep working.
 func radioDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -66,43 +68,131 @@ func radioDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"radio-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Radio",
-				Description: "Single-select form input. Supports color variants, sizes, descriptions, bordered containers, segmented pill bars, and exposes first-class HTMX + Alpine.js interaction primitives.",
+				Description: "Single-select form input. Supports color variants, sizes, descriptions, bordered containers, segmented pill bars, and first-class HTMX + Alpine.js interaction primitives.",
 			},
-			radioDemoPreview(),
-			`// Default radio
-@radio.Radio(radio.Config{
+			radioDefaultPreview(),
+			`@radio.Radio(radio.Config{
     ID: "r-mac", Name: "os", Value: "mac", Label: "Mac", Checked: true,
 })
-
-// Container variant
 @radio.Radio(radio.Config{
+    ID: "r-win", Name: "os", Value: "windows", Label: "Windows",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Container",
+				Description: "Wraps each option in a bordered container with Container: true.",
+			},
+			radioContainerPreview(),
+			`@radio.Radio(radio.Config{
     ID: "r-c-mac", Name: "os-c", Value: "mac", Label: "Mac",
     Container: true, Checked: true,
-})
-
-// Segmented variant — true segmented control (connected pill bar)
-@radio.RadioBar() {
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Segmented",
+				Description: "A true segmented control (connected pill bar). Set Segmented: true and group inside RadioBar.",
+			},
+			radioSegmentedPreview(),
+			`@radio.RadioBar() {
     @radio.Radio(radio.Config{ID: "r-seg-a", Name: "g", Value: "a", Label: "A", Segmented: true, Checked: true})
     @radio.Radio(radio.Config{ID: "r-seg-b", Name: "g", Value: "b", Label: "B", Segmented: true})
-}
-
-// Alpine: client-side state
-@radio.Radio(radio.Config{
-    ID: "r-a-md", Name: "size-a", Value: "md", Label: "md",
-    Segmented: true,
+}`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Description",
+				Description: "Add helper text under the label via Description (wire DescriptionID for aria-describedby).",
+			},
+			radioDescriptionPreview(),
+			`@radio.Radio(radio.Config{
+    ID: "r-desc-mac", Name: "os-desc", Value: "mac", Label: "Mac",
+    Description:   "For macOS Big Sur and higher.",
+    DescriptionID: "r-desc-mac-desc",
+    Checked:       true,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Color Variants",
+				Description: "Six semantic colors via Variant: Primary, Secondary, Info, Success, Warning, Danger.",
+			},
+			radioColorPreview(),
+			`@radio.Radio(radio.Config{ID: "r-success", Name: "v", Value: "su", Label: "Success", Variant: radio.Success, Checked: true})
+@radio.Radio(radio.Config{ID: "r-danger", Name: "v2", Value: "d", Label: "Danger", Variant: radio.Danger, Checked: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Sizes",
+				Description: "Four box sizes via Size: SizeSM, SizeMD (default), SizeLG, SizeXL.",
+			},
+			radioSizesPreview(),
+			`@radio.Radio(radio.Config{ID: "r-sm", Name: "sz", Value: "sm", Label: "Small", Size: radio.SizeSM, Checked: true})
+@radio.Radio(radio.Config{ID: "r-xl", Name: "sz2", Value: "xl", Label: "XL", Size: radio.SizeXL, Checked: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks interaction and dims the control.",
+			},
+			radioDisabledPreview(),
+			`@radio.Radio(radio.Config{ID: "r-d1", Name: "dis", Value: "a", Label: "Disabled unchecked", Disabled: true})
+@radio.Radio(radio.Config{ID: "r-d2", Name: "dis", Value: "b", Label: "Disabled checked", Disabled: true, Checked: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Alpine — client state",
+				Description: "Wire AlpineConfig for client-only state. Clicks update local x-data without a server roundtrip.",
+			},
+			radioAlpinePreview(),
+			`@radio.Radio(radio.Config{
+    ID: "r-a-md", Name: "size-a", Value: "md", Label: "md", Segmented: true,
     Alpine: &radio.AlpineConfig{
         BindChecked: "selected === 'md'",
         OnChange:    "selected = 'md'",
     },
-})
-
-// HTMX: server roundtrip on change
-@radio.Radio(radio.Config{
-    ID: "r-h-md", Name: "size-h", Value: "md", Label: "md",
-    Segmented: true,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "HTMX — server roundtrip",
+				Description: "Wire HTMXConfig for a server roundtrip on change. The response swaps into the target.",
+			},
+			radioHTMXPreview(),
+			`@radio.Radio(radio.Config{
+    ID: "r-h-md", Name: "size-h", Value: "md", Label: "md", Segmented: true,
     HTMX: &radio.HTMXConfig{
         Get:    "/api/components/radio/echo?value=md",
         Target: "#radio-htmx-out",
@@ -113,12 +203,53 @@ func radioDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Hybrid — Alpine state + HTMX persistence",
+				Description: "Set both Alpine and HTMX: a single click updates client state and fires the server roundtrip.",
+			},
+			radioHybridPreview(),
+			`@radio.Radio(radio.Config{
+    ID: "r-hy-md", Name: "size-hy", Value: "md", Label: "md", Segmented: true,
+    Alpine: &radio.AlpineConfig{BindChecked: "selected === 'md'", OnChange: "selected = 'md'"},
+    HTMX:   &radio.HTMXConfig{Get: "/api/components/radio/echo?value=md", Target: "#radio-hybrid-out", Swap: "innerHTML"},
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the radio input (also the label's for target)."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Form field name shared by all radios in a group."},
+			{Name: "Value", Type: "string", Default: `""`, Description: "Form field value submitted when selected."},
+			{Name: "Label", Type: "string", Default: `""`, Description: "Text displayed next to the radio."},
+			{Name: "Checked", Type: "bool", Default: "false", Description: "Initial checked state."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disables interaction and dims the control."},
+			{Name: "Variant", Type: "Variant", Default: "Primary", Description: `Color scheme: "primary", "secondary", "info", "success", "warning", "danger".`},
+			{Name: "Size", Type: "Size", Default: "SizeMD", Description: `Box size: "sm", "md", "lg", "xl".`},
+			{Name: "Description", Type: "string", Default: `""`, Description: "Helper text rendered below the label."},
+			{Name: "DescriptionID", Type: "string", Default: `""`, Description: "ID of the description element for aria-describedby wiring."},
+			{Name: "Container", Type: "bool", Default: "false", Description: "Wraps the radio in a bordered container."},
+			{Name: "Segmented", Type: "bool", Default: "false", Description: "Renders a segmented-control pill (sr-only input); group inside RadioBar."},
+			{Name: "BadgeColor", Type: "string", Default: `""`, Description: "Wraps the label in a semi-solid badge of the given color."},
+			{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "Server interaction on change (Get/Post/Target/Swap/...)."},
+			{Name: "Alpine", Type: "*AlpineConfig", Default: "nil", Description: "Client-side state (Model/OnChange/BindChecked/...)."},
+			{Name: "Attrs", Type: "templ.Attributes", Default: "nil", Description: "Escape hatch applied last to the input; wins on conflict."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes appended to the label root."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// radioDemoPreview renders the Goshtoso radio preview sections
-func radioDemoPreview() templ.Component {
+// radioDefaultPreview renders the default exclusive radio group.
+func radioDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -139,7 +270,7 @@ func radioDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-10\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Radio</h4><div class=\"flex flex-col gap-2\" data-testid=\"radio-default-group\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"radio-default\" class=\"w-full max-w-md mx-auto\"><div class=\"flex flex-col gap-2\" data-testid=\"radio-default-group\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -155,7 +286,37 @@ func radioDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With Container</h4><div class=\"flex flex-wrap gap-2\" data-testid=\"radio-container-group\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// radioContainerPreview renders the bordered-container variant.
+func radioContainerPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"radio-container\" class=\"w-full max-w-md mx-auto\"><div class=\"flex flex-wrap gap-2\" data-testid=\"radio-container-group\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -171,11 +332,41 @@ func radioDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Segmented (connected pill bar)</h4><div data-testid=\"radio-segmented-group\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var4 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		return nil
+	})
+}
+
+// radioSegmentedPreview renders the connected pill-bar segmented variant.
+func radioSegmentedPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"radio-segmented\" class=\"w-full max-w-md mx-auto\"><div data-testid=\"radio-segmented-group\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var6 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -191,7 +382,7 @@ func radioDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -199,7 +390,7 @@ func radioDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -209,11 +400,41 @@ func radioDemoPreview() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = radio.RadioBar().Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = radio.RadioBar().Render(templ.WithChildren(ctx, templ_7745c5c3_Var6), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With Description</h4><div class=\"flex flex-col gap-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// radioDescriptionPreview renders radios with helper descriptions.
+func radioDescriptionPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"radio-description\" class=\"w-full max-w-md mx-auto\"><div class=\"flex flex-col gap-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -234,7 +455,37 @@ func radioDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Color Variants</h4><div class=\"flex flex-wrap gap-4\" data-testid=\"radio-color-variants\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// radioColorPreview renders the six semantic color variants.
+func radioColorPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"radio-colors\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-4\" data-testid=\"radio-color-variants\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -262,7 +513,37 @@ func radioDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Sizes</h4><div class=\"flex items-center gap-4\" data-testid=\"radio-sizes\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// radioSizesPreview renders the four input sizes.
+func radioSizesPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"radio-sizes\" class=\"w-full max-w-md mx-auto\"><div class=\"flex items-center gap-4\" data-testid=\"radio-sizes\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -282,7 +563,37 @@ func radioDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Disabled</h4><div class=\"flex flex-col gap-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// radioDisabledPreview renders disabled radios.
+func radioDisabledPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"radio-disabled\" class=\"w-full max-w-md mx-auto\"><div class=\"flex flex-col gap-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -294,11 +605,41 @@ func radioDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div><div class=\"pt-6 border-t border-outline dark:border-outline-dark\"><h3 class=\"text-base font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-1\">Interaction primitives</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-6\">Radio exposes both Alpine.js and HTMX primitives via typed Config fields. Use Alpine for client-only state, HTMX for server-driven side effects, or combine both for hybrid flows.</p><div class=\"mb-8\" x-data=\"{ selected: 'md' }\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Alpine only — client state</h4><div class=\"mb-3\" data-testid=\"radio-alpine-group\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var5 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		return nil
+	})
+}
+
+// radioAlpinePreview renders the Alpine-only client-state showcase.
+func radioAlpinePreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div id=\"radio-alpine\" class=\"w-full max-w-md mx-auto\" x-data=\"{ selected: 'md' }\"><div class=\"mb-3\" data-testid=\"radio-alpine-group\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var12 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -315,7 +656,7 @@ func radioDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -324,7 +665,7 @@ func radioDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -335,15 +676,45 @@ func radioDemoPreview() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = radio.RadioBar().Render(templ.WithChildren(ctx, templ_7745c5c3_Var5), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = radio.RadioBar().Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div><div class=\"text-sm text-on-surface dark:text-on-surface-dark\" data-testid=\"radio-alpine-out\">Selected: <span x-text=\"selected\" class=\"font-mono font-semibold\"></span></div></div><div class=\"mb-8\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">HTMX only — server roundtrip on change</h4><div class=\"mb-3\" data-testid=\"radio-htmx-group\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</div><div class=\"text-sm text-on-surface dark:text-on-surface-dark\" data-testid=\"radio-alpine-out\">Selected: <span x-text=\"selected\" class=\"font-mono font-semibold\"></span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var6 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		return nil
+	})
+}
+
+// radioHTMXPreview renders the HTMX-only server-roundtrip showcase.
+func radioHTMXPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div id=\"radio-htmx\" class=\"w-full max-w-md mx-auto\"><div class=\"mb-3\" data-testid=\"radio-htmx-group\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var14 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -360,7 +731,7 @@ func radioDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -369,7 +740,7 @@ func radioDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -380,15 +751,45 @@ func radioDemoPreview() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = radio.RadioBar().Render(templ.WithChildren(ctx, templ_7745c5c3_Var6), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = radio.RadioBar().Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div><div id=\"radio-htmx-out\" class=\"text-sm text-on-surface dark:text-on-surface-dark\" data-testid=\"radio-htmx-out\"><span class=\"text-on-surface-muted dark:text-on-surface-dark-muted\">No selection yet.</span></div></div><div x-data=\"{ selected: 'md' }\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Hybrid — Alpine state + HTMX persistence</h4><div class=\"mb-3\" data-testid=\"radio-hybrid-group\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</div><div id=\"radio-htmx-out\" class=\"text-sm text-on-surface dark:text-on-surface-dark\" data-testid=\"radio-htmx-out\"><span class=\"text-on-surface-muted dark:text-on-surface-dark-muted\">No selection yet.</span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		return nil
+	})
+}
+
+// radioHybridPreview renders the hybrid Alpine-state + HTMX-persistence showcase.
+func radioHybridPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div id=\"radio-hybrid\" class=\"w-full max-w-md mx-auto\" x-data=\"{ selected: 'md' }\"><div class=\"mb-3\" data-testid=\"radio-hybrid-group\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var16 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -406,7 +807,7 @@ func radioDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -416,7 +817,7 @@ func radioDemoPreview() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -428,11 +829,11 @@ func radioDemoPreview() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = radio.RadioBar().Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = radio.RadioBar().Render(templ.WithChildren(ctx, templ_7745c5c3_Var16), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div><div class=\"text-sm text-on-surface dark:text-on-surface-dark space-y-1\"><div>Alpine: <span x-text=\"selected\" class=\"font-mono font-semibold\" data-testid=\"radio-hybrid-alpine-out\"></span></div><div id=\"radio-hybrid-out\" data-testid=\"radio-hybrid-htmx-out\"><span class=\"text-on-surface-muted dark:text-on-surface-dark-muted\">Server: not called yet.</span></div></div></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div><div class=\"text-sm text-on-surface dark:text-on-surface-dark space-y-1\"><div>Alpine: <span x-text=\"selected\" class=\"font-mono font-semibold\" data-testid=\"radio-hybrid-alpine-out\"></span></div><div id=\"radio-hybrid-out\" data-testid=\"radio-hybrid-htmx-out\"><span class=\"text-on-surface-muted dark:text-on-surface-dark-muted\">Server: not called yet.</span></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/select.templ
+++ b/internal/pages/demo/components/select.templ
@@ -10,16 +10,18 @@ templ SelectDemoPage() {
 	@demo.Layout("Select", "select", selectDemoContent())
 }
 
-// selectDemoContent renders the actual content inside the layout
+// selectDemoContent renders the demo. Each select variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/select). Wrapped in #select-fragment.
 templ selectDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Select",
-			Description:   "A native select dropdown with label, validation states, and support for Alpine.js binding.",
-		},
-		selectDemoPreview(),
-		`// Default Select
-@selectfield.Select(selectfield.Config{
+	<div id="select-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Select",
+				Description: "A select dropdown with label, validation states, large lists, Alpine.js binding for dependent selects, and disabled/readonly modes.",
+			},
+			selectDefaultPreview(),
+			`@selectfield.Select(selectfield.Config{
     ID:    "os",
     Name:  "os",
     Label: "Operating System",
@@ -28,24 +30,32 @@ templ selectDemoContent() {
         {Value: "windows", Label: "Windows"},
         {Value: "linux", Label: "Linux"},
     },
-})
+})`,
+		)
 
-// Select with Error State
-@selectfield.Select(selectfield.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Error State",
+				Description: "State: selectfield.StateError recolors the field and shows HelperText as an error.",
+			},
+			selectErrorPreview(),
+			`@selectfield.Select(selectfield.Config{
     ID:         "os-error",
     Name:       "os",
     Label:      "Operating System",
     State:      selectfield.StateError,
     HelperText: "Error: Please select an operating system",
-    Options: []selectfield.Option{
-        {Value: "mac", Label: "Mac"},
-        {Value: "windows", Label: "Windows"},
-        {Value: "linux", Label: "Linux"},
-    },
-})
+    Options:    options,
+})`,
+		)
 
-// Select with Success State
-@selectfield.Select(selectfield.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Success State",
+				Description: "State: selectfield.StateSuccess applies the success styling. Mark an Option Selected for the initial value.",
+			},
+			selectSuccessPreview(),
+			`@selectfield.Select(selectfield.Config{
     ID:    "os-success",
     Name:  "os",
     Label: "Operating System",
@@ -53,46 +63,108 @@ templ selectDemoContent() {
     Options: []selectfield.Option{
         {Value: "mac", Label: "Mac", Selected: true},
         {Value: "windows", Label: "Windows"},
-        {Value: "linux", Label: "Linux"},
     },
-})
+})`,
+		)
 
-// Disabled Select
-@selectfield.Select(selectfield.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Large List",
+				Description: "Selects handle long option lists (e.g. a country picker) with native scrolling.",
+			},
+			selectCountryPreview(),
+			`@selectfield.Select(selectfield.Config{
+    ID:           "country",
+    Name:         "country",
+    Label:        "Country",
+    Autocomplete: "country",
+    Options:      countryOptions(),
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Dependent Selects (Alpine.js)",
+				Description: "Bind AlpineModel to share state; AlpineBindDisabled keeps the second select disabled until the first has a value.",
+			},
+			selectDependentPreview(),
+			`<div x-data="{ firstValue: '', secondValue: '' }">
+    @selectfield.Select(selectfield.Config{ID: "modelName", AlpineModel: "firstValue", Options: models})
+    @selectfield.Select(selectfield.Config{ID: "year", AlpineModel: "secondValue", AlpineBindDisabled: "!firstValue", Options: years})
+</div>`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks interaction.",
+			},
+			selectDisabledPreview(),
+			`@selectfield.Select(selectfield.Config{
     ID:       "os-disabled",
     Name:     "os",
     Label:    "Operating System",
     Disabled: true,
-    Options: []selectfield.Option{
-        {Value: "mac", Label: "Mac"},
-    },
+    Options:  options,
 })`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Readonly",
+				Description: "Readonly: true keeps the selected value submittable but prevents the user from changing it.",
+			},
+			selectReadonlyPreview(),
+			`@selectfield.Select(selectfield.Config{
+    ID:       "os-readonly",
+    Name:     "os-readonly",
+    Label:    "Operating System",
+    Readonly: true,
+    Options:  options,
+})`,
+		)
+	</div>
+	// API reference lives outside #select-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id (seeds the trigger id <id>-trigger and option ids)."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+		{Name: "Label", Type: "string", Default: `""`, Description: "Label above the select."},
+		{Name: "Placeholder", Type: "string", Default: `""`, Description: "Placeholder option shown when nothing is selected."},
+		{Name: "Options", Type: "[]Option", Default: "nil", Description: "Options (Value, Label, Selected)."},
+		{Name: "State", Type: "State", Default: "StateDefault", Description: `Validation state: "" (default), "error", "success".`},
+		{Name: "HelperText", Type: "string", Default: `""`, Description: "Text below the field, recolored by State."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable the select."},
+		{Name: "Readonly", Type: "bool", Default: "false", Description: "Non-editable but submittable."},
+		{Name: "Autocomplete", Type: "string", Default: `""`, Description: "HTML autocomplete attribute."},
+		{Name: "AlpineModel", Type: "string", Default: `""`, Description: "x-model expression bound to the select value."},
+		{Name: "AlpineBindDisabled", Type: "string", Default: `""`, Description: "x-bind:disabled expression."},
+		{Name: "Attrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the select."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+	})
 }
 
-// selectDemoPreview renders the Goshtoso select preview
-templ selectDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Default Select
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Select</h4>
-			@selectfield.Select(selectfield.Config{
-				ID:    "os",
-				Name:  "os",
-				Label: "Operating System",
-				Options: []selectfield.Option{
-					{Value: "mac", Label: "Mac"},
-					{Value: "windows", Label: "Windows"},
-					{Value: "linux", Label: "Linux"},
-				},
-			})
-		</div>
+// selectDefaultPreview renders the default select.
+templ selectDefaultPreview() {
+	<div id="select-default" class="w-full max-w-xs mx-auto">
+		@selectfield.Select(selectfield.Config{
+			ID:    "os",
+			Name:  "os",
+			Label: "Operating System",
+			Options: []selectfield.Option{
+				{Value: "mac", Label: "Mac"},
+				{Value: "windows", Label: "Windows"},
+				{Value: "linux", Label: "Linux"},
+			},
+		})
+	</div>
 
-		// Select with Error State
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Error State</h4>
-			@selectfield.Select(selectfield.Config{
-				ID:         "os-error",
+}
+
+// selectErrorPreview renders the error-state select.
+templ selectErrorPreview() {
+	<div id="select-error" class="w-full max-w-xs mx-auto">
+		@selectfield.Select(selectfield.Config{
+			ID:         "os-error",
 				Name:       "os-error",
 				Label:      "Operating System",
 				State:      selectfield.StateError,
@@ -105,11 +177,13 @@ templ selectDemoPreview() {
 			})
 		</div>
 
-		// Select with Success State
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Success State</h4>
-			@selectfield.Select(selectfield.Config{
-				ID:    "os-success",
+}
+
+// selectSuccessPreview renders the success-state select.
+templ selectSuccessPreview() {
+	<div id="select-success" class="w-full max-w-xs mx-auto">
+		@selectfield.Select(selectfield.Config{
+			ID:    "os-success",
 				Name:  "os-success",
 				Label: "Operating System",
 				State: selectfield.StateSuccess,
@@ -121,11 +195,13 @@ templ selectDemoPreview() {
 			})
 		</div>
 
-		// Country Select (large list)
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Country Select</h4>
-			@selectfield.Select(selectfield.Config{
-				ID:           "country",
+}
+
+// selectCountryPreview renders a select with a large option list.
+templ selectCountryPreview() {
+	<div id="select-country" class="w-full max-w-xs mx-auto">
+		@selectfield.Select(selectfield.Config{
+			ID:           "country",
 				Name:         "country",
 				Label:        "Country",
 				Autocomplete: "country",
@@ -133,10 +209,12 @@ templ selectDemoPreview() {
 			})
 		</div>
 
-		// Dependent Selects with Alpine.js
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Dependent Selects</h4>
-			<div x-data="{ firstValue: '', secondValue: '' }" class="flex w-full flex-col gap-4">
+}
+
+// selectDependentPreview renders the Alpine-bound dependent selects.
+templ selectDependentPreview() {
+	<div id="select-dependent" class="w-full max-w-xs mx-auto">
+		<div x-data="{ firstValue: '', secondValue: '' }" class="flex w-full flex-col gap-4">
 				@selectfield.Select(selectfield.Config{
 					ID:          "modelName",
 					Name:        "modelName",
@@ -169,11 +247,13 @@ templ selectDemoPreview() {
 			</div>
 		</div>
 
-		// Disabled Select
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Disabled</h4>
-			@selectfield.Select(selectfield.Config{
-				ID:       "os-disabled",
+}
+
+// selectDisabledPreview renders the disabled select.
+templ selectDisabledPreview() {
+	<div id="select-disabled" class="w-full max-w-xs mx-auto">
+		@selectfield.Select(selectfield.Config{
+			ID:       "os-disabled",
 				Name:     "os-disabled",
 				Label:    "Operating System",
 				Disabled: true,
@@ -185,10 +265,12 @@ templ selectDemoPreview() {
 			})
 		</div>
 
-		// Readonly Select
-		<div class="max-w-xs">
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Readonly</h4>
-			<form id="readonlySelectForm" method="get" action="javascript:void(0)">
+}
+
+// selectReadonlyPreview renders the readonly select inside a form.
+templ selectReadonlyPreview() {
+	<div id="select-readonly" class="w-full max-w-xs mx-auto">
+		<form id="readonlySelectForm" method="get" action="javascript:void(0)">
 				@selectfield.Select(selectfield.Config{
 					ID:       "os-readonly",
 					Name:     "os-readonly",
@@ -202,7 +284,6 @@ templ selectDemoPreview() {
 				})
 			</form>
 		</div>
-	</div>
 }
 
 func countryOptions() []selectfield.Option {

--- a/internal/pages/demo/components/select_templ.go
+++ b/internal/pages/demo/components/select_templ.go
@@ -43,7 +43,9 @@ func SelectDemoPage() templ.Component {
 	})
 }
 
-// selectDemoContent renders the actual content inside the layout
+// selectDemoContent renders the demo. Each select variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/select). Wrapped in #select-fragment.
 func selectDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,14 +67,17 @@ func selectDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"select-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Select",
-				Description: "A native select dropdown with label, validation states, and support for Alpine.js binding.",
+				Description: "A select dropdown with label, validation states, large lists, Alpine.js binding for dependent selects, and disabled/readonly modes.",
 			},
-			selectDemoPreview(),
-			`// Default Select
-@selectfield.Select(selectfield.Config{
+			selectDefaultPreview(),
+			`@selectfield.Select(selectfield.Config{
     ID:    "os",
     Name:  "os",
     Label: "Operating System",
@@ -81,24 +86,36 @@ func selectDemoContent() templ.Component {
         {Value: "windows", Label: "Windows"},
         {Value: "linux", Label: "Linux"},
     },
-})
-
-// Select with Error State
-@selectfield.Select(selectfield.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Error State",
+				Description: "State: selectfield.StateError recolors the field and shows HelperText as an error.",
+			},
+			selectErrorPreview(),
+			`@selectfield.Select(selectfield.Config{
     ID:         "os-error",
     Name:       "os",
     Label:      "Operating System",
     State:      selectfield.StateError,
     HelperText: "Error: Please select an operating system",
-    Options: []selectfield.Option{
-        {Value: "mac", Label: "Mac"},
-        {Value: "windows", Label: "Windows"},
-        {Value: "linux", Label: "Linux"},
-    },
-})
-
-// Select with Success State
-@selectfield.Select(selectfield.Config{
+    Options:    options,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Success State",
+				Description: "State: selectfield.StateSuccess applies the success styling. Mark an Option Selected for the initial value.",
+			},
+			selectSuccessPreview(),
+			`@selectfield.Select(selectfield.Config{
     ID:    "os-success",
     Name:  "os",
     Label: "Operating System",
@@ -106,21 +123,97 @@ func selectDemoContent() templ.Component {
     Options: []selectfield.Option{
         {Value: "mac", Label: "Mac", Selected: true},
         {Value: "windows", Label: "Windows"},
-        {Value: "linux", Label: "Linux"},
     },
-})
-
-// Disabled Select
-@selectfield.Select(selectfield.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Large List",
+				Description: "Selects handle long option lists (e.g. a country picker) with native scrolling.",
+			},
+			selectCountryPreview(),
+			`@selectfield.Select(selectfield.Config{
+    ID:           "country",
+    Name:         "country",
+    Label:        "Country",
+    Autocomplete: "country",
+    Options:      countryOptions(),
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Dependent Selects (Alpine.js)",
+				Description: "Bind AlpineModel to share state; AlpineBindDisabled keeps the second select disabled until the first has a value.",
+			},
+			selectDependentPreview(),
+			`<div x-data="{ firstValue: '', secondValue: '' }">
+    @selectfield.Select(selectfield.Config{ID: "modelName", AlpineModel: "firstValue", Options: models})
+    @selectfield.Select(selectfield.Config{ID: "year", AlpineModel: "secondValue", AlpineBindDisabled: "!firstValue", Options: years})
+</div>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks interaction.",
+			},
+			selectDisabledPreview(),
+			`@selectfield.Select(selectfield.Config{
     ID:       "os-disabled",
     Name:     "os",
     Label:    "Operating System",
     Disabled: true,
-    Options: []selectfield.Option{
-        {Value: "mac", Label: "Mac"},
-    },
+    Options:  options,
 })`,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Readonly",
+				Description: "Readonly: true keeps the selected value submittable but prevents the user from changing it.",
+			},
+			selectReadonlyPreview(),
+			`@selectfield.Select(selectfield.Config{
+    ID:       "os-readonly",
+    Name:     "os-readonly",
+    Label:    "Operating System",
+    Readonly: true,
+    Options:  options,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id (seeds the trigger id <id>-trigger and option ids)."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+			{Name: "Label", Type: "string", Default: `""`, Description: "Label above the select."},
+			{Name: "Placeholder", Type: "string", Default: `""`, Description: "Placeholder option shown when nothing is selected."},
+			{Name: "Options", Type: "[]Option", Default: "nil", Description: "Options (Value, Label, Selected)."},
+			{Name: "State", Type: "State", Default: "StateDefault", Description: `Validation state: "" (default), "error", "success".`},
+			{Name: "HelperText", Type: "string", Default: `""`, Description: "Text below the field, recolored by State."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable the select."},
+			{Name: "Readonly", Type: "bool", Default: "false", Description: "Non-editable but submittable."},
+			{Name: "Autocomplete", Type: "string", Default: `""`, Description: "HTML autocomplete attribute."},
+			{Name: "AlpineModel", Type: "string", Default: `""`, Description: "x-model expression bound to the select value."},
+			{Name: "AlpineBindDisabled", Type: "string", Default: `""`, Description: "x-bind:disabled expression."},
+			{Name: "Attrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the select."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -128,8 +221,8 @@ func selectDemoContent() templ.Component {
 	})
 }
 
-// selectDemoPreview renders the Goshtoso select preview
-func selectDemoPreview() templ.Component {
+// selectDefaultPreview renders the default select.
+func selectDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -150,7 +243,7 @@ func selectDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Select</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"select-default\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -167,7 +260,37 @@ func selectDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Error State</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// selectErrorPreview renders the error-state select.
+func selectErrorPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"select-error\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -186,7 +309,37 @@ func selectDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Success State</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// selectSuccessPreview renders the success-state select.
+func selectSuccessPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"select-success\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -204,7 +357,37 @@ func selectDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Country Select</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// selectCountryPreview renders a select with a large option list.
+func selectCountryPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"select-country\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -218,7 +401,37 @@ func selectDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Dependent Selects</h4><div x-data=\"{ firstValue: '', secondValue: '' }\" class=\"flex w-full flex-col gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// selectDependentPreview renders the Alpine-bound dependent selects.
+func selectDependentPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"select-dependent\" class=\"w-full max-w-xs mx-auto\"><div x-data=\"{ firstValue: '', secondValue: '' }\" class=\"flex w-full flex-col gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -257,7 +470,37 @@ func selectDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Disabled</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// selectDisabledPreview renders the disabled select.
+func selectDisabledPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"select-disabled\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -275,7 +518,37 @@ func selectDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div><div class=\"max-w-xs\"><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Readonly</h4><form id=\"readonlySelectForm\" method=\"get\" action=\"javascript:void(0)\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// selectReadonlyPreview renders the readonly select inside a form.
+func selectReadonlyPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"select-readonly\" class=\"w-full max-w-xs mx-auto\"><form id=\"readonlySelectForm\" method=\"get\" action=\"javascript:void(0)\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -293,7 +566,7 @@ func selectDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</form></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</form></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/sidebar.templ
+++ b/internal/pages/demo/components/sidebar.templ
@@ -10,167 +10,206 @@ templ SidebarDemoPage() {
 	@demo.Layout("Sidebar", "sidebar", sidebarDemoContent())
 }
 
-// sidebarDemoContent renders all sidebar variant demos
+// sidebarDemoContent renders the demo. Each sidebar variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/sidebar). Wrapped in #sidebar-fragment.
 templ sidebarDemoContent() {
-	<div class="space-y-12">
-		<div>
-			<h1 class="text-3xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong">Sidebar</h1>
-			<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted">Tailwind CSS and Alpine JS Sidebar</p>
-			<p class="mt-2 text-on-surface dark:text-on-surface-dark">Sidebars help users find what they need by organizing navigation into clearly labelled sections. They support flat lists, grouped sections, nested sub-items, collapsible menus, and overlay modes.</p>
-		</div>
+	<div id="sidebar-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Sidebar",
+				Description: "Organize navigation into labelled sections. Flat item lists, grouped sections, nested sub-items, collapsible Alpine sections, and an overlay mode with a hamburger trigger.",
+			},
+			sidebarSimplePreview(),
+			`@sidebar.Sidebar(sidebar.Config{
+    LogoText:   "MyApp",
+    ShowSearch: true,
+    Items: []sidebar.Item{
+        {ID: "dashboard", Label: "Dashboard", Href: "#", Icon: dashboardIcon()},
+        {ID: "profile", Label: "Profile", Href: "#", Icon: profileIcon(), Active: true},
+        {ID: "inbox", Label: "Inbox", Href: "#", Icon: inboxIcon(), Badge: "3"},
+    },
+})`,
+		)
 
-		@simpleSidebarDemo()
-		@sectionsSidebarDemo()
-		@subItemsSidebarDemo()
-		@collapsibleSidebarDemo()
-		@overlaySidebarDemo()
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Sections",
+				Description: "Use Sections (each with a Title and Items) to group links logically.",
+			},
+			sidebarSectionsPreview(),
+			`@sidebar.Sidebar(sidebar.Config{
+    LogoText: "Docs",
+    Sections: []sidebar.Section{
+        {Title: "Getting Started", Items: gettingStartedItems},
+        {Title: "Components", Items: componentItems},
+    },
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Sub-Items",
+				Description: "An Item can carry nested Items (with their own Badge) for API-reference-style navigation.",
+			},
+			sidebarSubItemsPreview(),
+			`{ID: "ep-users", Label: "Users", Href: "#", Icon: usersIcon(), Items: []sidebar.Item{
+    {ID: "ep-create-user", Label: "Create User", Href: "#", Badge: "POST"},
+    {ID: "ep-get-user", Label: "Get User", Href: "#", Badge: "GET"},
+}}`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Collapsible Sections",
+				Description: "Compose collapsible groups with Alpine (x-data + x-collapse) when you need section headers that expand and collapse on click.",
+			},
+			sidebarCollapsiblePreview(),
+			`<div x-data="{ sections: { general: true, content: false } }">
+    <button x-on:click="sections.general = !sections.general">General</button>
+    <div x-show="sections.general" x-collapse> ...items... </div>
+</div>`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Overlay Sidebar",
+				Description: "Render the sidebar in an off-canvas panel with a backdrop, toggled by a hamburger button via Alpine (x-data=\"{ showSidebar: false }\").",
+			},
+			sidebarOverlayPreview(),
+			`<div x-data="{ showSidebar: false }">
+    <button x-on:click="showSidebar = true" aria-label="Open sidebar">☰</button>
+    <div x-show="showSidebar" class="absolute inset-y-0 left-0 z-40 w-60" x-cloak>
+        @sidebar.Sidebar(cfg)
+    </div>
+</div>`,
+		)
 	</div>
+	// API reference lives outside #sidebar-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Items", Type: "[]Item", Default: "nil", Description: "Flat item list. Item: ID, Label, Href, Icon, Active, Disabled, Badge, nested Items."},
+		{Name: "Sections", Type: "[]Section", Default: "nil", Description: "Grouped sections, each with a Title and Items (use instead of, or with, Items)."},
+		{Name: "SectionsTitle", Type: "string", Default: `""`, Description: "Optional heading above the sections."},
+		{Name: "Logo", Type: "templ.Component", Default: "nil", Description: "Custom logo content (overrides LogoText)."},
+		{Name: "LogoText", Type: "string", Default: `""`, Description: "Text logo shown at the top."},
+		{Name: "LogoHref", Type: "string", Default: `""`, Description: "Link target for the logo."},
+		{Name: "ShowSearch", Type: "bool", Default: "false", Description: "Render a search input below the logo."},
+		{Name: "SearchPlaceholder", Type: "string", Default: `""`, Description: "Placeholder for the search input."},
+		{Name: "SearchSlot", Type: "templ.Component", Default: "nil", Description: "Custom search-area content."},
+		{Name: "FooterSlot", Type: "templ.Component", Default: "nil", Description: "Content pinned to the bottom of the sidebar."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
+	})
 }
 
 // --- Variant 1: Simple Sidebar ---
 
-templ simpleSidebarDemo() {
-	<div class="not-prose">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2">Simple Sidebar</h3>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">A sidebar with a logo, search input, and icon navigation links. Profile is marked as active.</p>
-		<div class="border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
-			<div class="flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark">
-				<span class="size-3 rounded-full bg-red-400"></span>
-				<span class="size-3 rounded-full bg-yellow-400"></span>
-				<span class="size-3 rounded-full bg-green-400"></span>
+templ sidebarSimplePreview() {
+	<div id="sidebar-simple" class="w-full">
+		<div class="flex h-[400px] border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
+			<div class="w-60 shrink-0">
+				@sidebar.Sidebar(sidebar.Config{
+					LogoText:          "MyApp",
+					ShowSearch:        true,
+					SearchPlaceholder: "Search...",
+					Items: []sidebar.Item{
+						{ID: "dashboard", Label: "Dashboard", Href: "#", Icon: dashboardIcon()},
+						{ID: "profile", Label: "Profile", Href: "#", Icon: profileIcon(), Active: true},
+						{ID: "inbox", Label: "Inbox", Href: "#", Icon: inboxIcon(), Badge: "3"},
+						{ID: "notifications", Label: "Notifications", Href: "#", Icon: bellIcon()},
+						{ID: "settings", Label: "Settings", Href: "#", Icon: settingsIcon()},
+					},
+				})
 			</div>
-			<div class="flex h-[400px]">
-				<div class="w-60 shrink-0">
-					@sidebar.Sidebar(sidebar.Config{
-						LogoText:          "MyApp",
-						ShowSearch:        true,
-						SearchPlaceholder: "Search...",
-						Items: []sidebar.Item{
-							{ID: "dashboard", Label: "Dashboard", Href: "#", Icon: dashboardIcon()},
-							{ID: "profile", Label: "Profile", Href: "#", Icon: profileIcon(), Active: true},
-							{ID: "inbox", Label: "Inbox", Href: "#", Icon: inboxIcon(), Badge: "3"},
-							{ID: "notifications", Label: "Notifications", Href: "#", Icon: bellIcon()},
-							{ID: "settings", Label: "Settings", Href: "#", Icon: settingsIcon()},
-						},
-					})
-				</div>
-				@contentPlaceholder()
-			</div>
+			@contentPlaceholder()
 		</div>
 	</div>
 }
 
 // --- Variant 2: Sidebar with Sections ---
 
-templ sectionsSidebarDemo() {
-	<div class="not-prose">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2">Sidebar with Sections</h3>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Grouped navigation with section titles for logical organization of links.</p>
-		<div class="border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
-			<div class="flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark">
-				<span class="size-3 rounded-full bg-red-400"></span>
-				<span class="size-3 rounded-full bg-yellow-400"></span>
-				<span class="size-3 rounded-full bg-green-400"></span>
-			</div>
-			<div class="flex h-[400px]">
-				<div class="w-60 shrink-0">
-					@sidebar.Sidebar(sidebar.Config{
-						LogoText: "Docs",
-						Sections: []sidebar.Section{
-							{
-								Title: "Getting Started",
-								Items: []sidebar.Item{
-									{ID: "overview", Label: "Overview", Href: "#", Icon: bookIcon(), Active: true},
-									{ID: "installation", Label: "Installation", Href: "#", Icon: downloadIcon()},
-								},
-							},
-							{
-								Title: "Components",
-								Items: []sidebar.Item{
-									{ID: "buttons", Label: "Buttons", Href: "#", Icon: componentsIcon()},
-									{ID: "forms", Label: "Forms", Href: "#", Icon: formsIcon()},
-									{ID: "table", Label: "Table", Href: "#", Icon: tableIcon()},
-									{ID: "modal", Label: "Modal", Href: "#", Icon: modalIcon()},
-								},
-							},
-							{
-								Title: "Settings",
-								Items: []sidebar.Item{
-									{ID: "profile", Label: "Profile", Href: "#", Icon: profileIcon()},
-									{ID: "account", Label: "Account", Href: "#", Icon: accountIcon()},
-								},
+templ sidebarSectionsPreview() {
+	<div id="sidebar-sections" class="w-full">
+		<div class="flex h-[400px] border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
+			<div class="w-60 shrink-0">
+				@sidebar.Sidebar(sidebar.Config{
+					LogoText: "Docs",
+					Sections: []sidebar.Section{
+						{
+							Title: "Getting Started",
+							Items: []sidebar.Item{
+								{ID: "overview", Label: "Overview", Href: "#", Icon: bookIcon(), Active: true},
+								{ID: "installation", Label: "Installation", Href: "#", Icon: downloadIcon()},
 							},
 						},
-					})
-				</div>
-				@contentPlaceholder()
+						{
+							Title: "Components",
+							Items: []sidebar.Item{
+								{ID: "buttons", Label: "Buttons", Href: "#", Icon: componentsIcon()},
+								{ID: "forms", Label: "Forms", Href: "#", Icon: formsIcon()},
+								{ID: "table", Label: "Table", Href: "#", Icon: tableIcon()},
+								{ID: "modal", Label: "Modal", Href: "#", Icon: modalIcon()},
+							},
+						},
+						{
+							Title: "Settings",
+							Items: []sidebar.Item{
+								{ID: "profile", Label: "Profile", Href: "#", Icon: profileIcon()},
+								{ID: "account", Label: "Account", Href: "#", Icon: accountIcon()},
+							},
+						},
+					},
+				})
 			</div>
+			@contentPlaceholder()
 		</div>
 	</div>
 }
 
 // --- Variant 3: Sidebar with Sub-Items ---
 
-templ subItemsSidebarDemo() {
-	<div class="not-prose">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2">Sidebar with Sub-Items</h3>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Documentation-style sidebar with parent items and nested child links, similar to API reference navigation.</p>
-		<div class="border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
-			<div class="flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark">
-				<span class="size-3 rounded-full bg-red-400"></span>
-				<span class="size-3 rounded-full bg-yellow-400"></span>
-				<span class="size-3 rounded-full bg-green-400"></span>
-			</div>
-			<div class="flex h-[450px]">
-				<div class="w-64 shrink-0">
-					@sidebar.Sidebar(sidebar.Config{
-						LogoText: "API Docs",
-						Sections: []sidebar.Section{
-							{
-								Title: "Get Started",
-								Items: []sidebar.Item{
-									{ID: "gs-overview", Label: "Overview", Href: "#", Icon: bookIcon(), Active: true},
-									{ID: "gs-auth", Label: "Authentication", Href: "#", Icon: lockIcon()},
-									{ID: "gs-rate", Label: "Rate Limiting", Href: "#", Icon: clockIcon()},
-								},
-							},
-							{
-								Title: "Endpoints",
-								Items: []sidebar.Item{
-									{ID: "ep-users", Label: "Users", Href: "#", Icon: usersIcon(), Items: []sidebar.Item{
-										{ID: "ep-create-user", Label: "Create User", Href: "#", Badge: "POST"},
-										{ID: "ep-get-user", Label: "Get User", Href: "#", Badge: "GET"},
-										{ID: "ep-update-user", Label: "Update User", Href: "#", Badge: "PUT"},
-										{ID: "ep-delete-user", Label: "Delete User", Href: "#", Badge: "DEL"},
-									}},
-									{ID: "ep-products", Label: "Products", Href: "#", Icon: boxIcon(), Items: []sidebar.Item{
-										{ID: "ep-list-products", Label: "List Products", Href: "#", Badge: "GET"},
-										{ID: "ep-create-product", Label: "Create Product", Href: "#", Badge: "POST"},
-									}},
-								},
+templ sidebarSubItemsPreview() {
+	<div id="sidebar-sub-items" class="w-full">
+		<div class="flex h-[450px] border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
+			<div class="w-64 shrink-0">
+				@sidebar.Sidebar(sidebar.Config{
+					LogoText: "API Docs",
+					Sections: []sidebar.Section{
+						{
+							Title: "Get Started",
+							Items: []sidebar.Item{
+								{ID: "gs-overview", Label: "Overview", Href: "#", Icon: bookIcon(), Active: true},
+								{ID: "gs-auth", Label: "Authentication", Href: "#", Icon: lockIcon()},
+								{ID: "gs-rate", Label: "Rate Limiting", Href: "#", Icon: clockIcon()},
 							},
 						},
-					})
-				</div>
-				@contentPlaceholder()
+						{
+							Title: "Endpoints",
+							Items: []sidebar.Item{
+								{ID: "ep-users", Label: "Users", Href: "#", Icon: usersIcon(), Items: []sidebar.Item{
+									{ID: "ep-create-user", Label: "Create User", Href: "#", Badge: "POST"},
+									{ID: "ep-get-user", Label: "Get User", Href: "#", Badge: "GET"},
+									{ID: "ep-update-user", Label: "Update User", Href: "#", Badge: "PUT"},
+									{ID: "ep-delete-user", Label: "Delete User", Href: "#", Badge: "DEL"},
+								}},
+								{ID: "ep-products", Label: "Products", Href: "#", Icon: boxIcon(), Items: []sidebar.Item{
+									{ID: "ep-list-products", Label: "List Products", Href: "#", Badge: "GET"},
+									{ID: "ep-create-product", Label: "Create Product", Href: "#", Badge: "POST"},
+								}},
+							},
+						},
+					},
+				})
 			</div>
+			@contentPlaceholder()
 		</div>
 	</div>
 }
 
 // --- Variant 4: Collapsible Sidebar ---
 
-templ collapsibleSidebarDemo() {
-	<div class="not-prose">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2">Collapsible Sections</h3>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Each section can be collapsed or expanded using Alpine.js. Click the section headers to toggle visibility.</p>
-		<div class="border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
-			<div class="flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark">
-				<span class="size-3 rounded-full bg-red-400"></span>
-				<span class="size-3 rounded-full bg-yellow-400"></span>
-				<span class="size-3 rounded-full bg-green-400"></span>
-			</div>
-			<div class="flex h-[450px]">
+templ sidebarCollapsiblePreview() {
+	<div id="sidebar-collapsible" class="w-full">
+		<div class="flex h-[450px] border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
 				<div class="w-60 shrink-0">
 					<nav class="h-full w-full border-r border-outline bg-surface dark:border-outline-dark dark:bg-surface-dark flex flex-col" aria-label="sidebar navigation">
 						<div class="shrink-0 border-b border-outline dark:border-outline-dark p-4">
@@ -260,7 +299,6 @@ templ collapsibleSidebarDemo() {
 					</nav>
 				</div>
 				@contentPlaceholder()
-			</div>
 		</div>
 	</div>
 }
@@ -279,17 +317,9 @@ templ collapsibleItem(label string, active bool) {
 
 // --- Variant 5: Overlay Sidebar ---
 
-templ overlaySidebarDemo() {
-	<div class="not-prose">
-		<h3 class="text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2">Overlay Sidebar</h3>
-		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">A sidebar that opens as an overlay with a dark backdrop, triggered by a hamburger button. Uses Alpine.js for toggle state.</p>
-		<div class="border border-outline dark:border-outline-dark rounded-radius overflow-hidden">
-			<div class="flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark">
-				<span class="size-3 rounded-full bg-red-400"></span>
-				<span class="size-3 rounded-full bg-yellow-400"></span>
-				<span class="size-3 rounded-full bg-green-400"></span>
-			</div>
-			<div class="relative h-[400px] bg-surface dark:bg-surface-dark overflow-hidden" x-data="{ showSidebar: false }">
+templ sidebarOverlayPreview() {
+	<div id="sidebar-overlay" class="w-full">
+		<div class="relative h-[400px] bg-surface dark:bg-surface-dark overflow-hidden border border-outline dark:border-outline-dark rounded-radius" x-data="{ showSidebar: false }">
 				<!-- Top bar with hamburger -->
 				<div class="flex items-center gap-3 border-b border-outline dark:border-outline-dark px-4 py-3">
 					<button
@@ -361,7 +391,6 @@ templ overlaySidebarDemo() {
 				</div>
 			</div>
 		</div>
-	</div>
 }
 
 // --- Shared content placeholders ---

--- a/internal/pages/demo/components/sidebar_templ.go
+++ b/internal/pages/demo/components/sidebar_templ.go
@@ -43,7 +43,9 @@ func SidebarDemoPage() templ.Component {
 	})
 }
 
-// sidebarDemoContent renders all sidebar variant demos
+// sidebarDemoContent renders the demo. Each sidebar variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/sidebar). Wrapped in #sidebar-fragment.
 func sidebarDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,31 +67,107 @@ func sidebarDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-12\"><div><h1 class=\"text-3xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">Sidebar</h1><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Tailwind CSS and Alpine JS Sidebar</p><p class=\"mt-2 text-on-surface dark:text-on-surface-dark\">Sidebars help users find what they need by organizing navigation into clearly labelled sections. They support flat lists, grouped sections, nested sub-items, collapsible menus, and overlay modes.</p></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"sidebar-fragment\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = simpleSidebarDemo().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Sidebar",
+				Description: "Organize navigation into labelled sections. Flat item lists, grouped sections, nested sub-items, collapsible Alpine sections, and an overlay mode with a hamburger trigger.",
+			},
+			sidebarSimplePreview(),
+			`@sidebar.Sidebar(sidebar.Config{
+    LogoText:   "MyApp",
+    ShowSearch: true,
+    Items: []sidebar.Item{
+        {ID: "dashboard", Label: "Dashboard", Href: "#", Icon: dashboardIcon()},
+        {ID: "profile", Label: "Profile", Href: "#", Icon: profileIcon(), Active: true},
+        {ID: "inbox", Label: "Inbox", Href: "#", Icon: inboxIcon(), Badge: "3"},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = sectionsSidebarDemo().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Sections",
+				Description: "Use Sections (each with a Title and Items) to group links logically.",
+			},
+			sidebarSectionsPreview(),
+			`@sidebar.Sidebar(sidebar.Config{
+    LogoText: "Docs",
+    Sections: []sidebar.Section{
+        {Title: "Getting Started", Items: gettingStartedItems},
+        {Title: "Components", Items: componentItems},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = subItemsSidebarDemo().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Sub-Items",
+				Description: "An Item can carry nested Items (with their own Badge) for API-reference-style navigation.",
+			},
+			sidebarSubItemsPreview(),
+			`{ID: "ep-users", Label: "Users", Href: "#", Icon: usersIcon(), Items: []sidebar.Item{
+    {ID: "ep-create-user", Label: "Create User", Href: "#", Badge: "POST"},
+    {ID: "ep-get-user", Label: "Get User", Href: "#", Badge: "GET"},
+}}`,
+		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = collapsibleSidebarDemo().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Collapsible Sections",
+				Description: "Compose collapsible groups with Alpine (x-data + x-collapse) when you need section headers that expand and collapse on click.",
+			},
+			sidebarCollapsiblePreview(),
+			`<div x-data="{ sections: { general: true, content: false } }">
+    <button x-on:click="sections.general = !sections.general">General</button>
+    <div x-show="sections.general" x-collapse> ...items... </div>
+</div>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = overlaySidebarDemo().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Overlay Sidebar",
+				Description: "Render the sidebar in an off-canvas panel with a backdrop, toggled by a hamburger button via Alpine (x-data=\"{ showSidebar: false }\").",
+			},
+			sidebarOverlayPreview(),
+			`<div x-data="{ showSidebar: false }">
+    <button x-on:click="showSidebar = true" aria-label="Open sidebar">☰</button>
+    <div x-show="showSidebar" class="absolute inset-y-0 left-0 z-40 w-60" x-cloak>
+        @sidebar.Sidebar(cfg)
+    </div>
+</div>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Items", Type: "[]Item", Default: "nil", Description: "Flat item list. Item: ID, Label, Href, Icon, Active, Disabled, Badge, nested Items."},
+			{Name: "Sections", Type: "[]Section", Default: "nil", Description: "Grouped sections, each with a Title and Items (use instead of, or with, Items)."},
+			{Name: "SectionsTitle", Type: "string", Default: `""`, Description: "Optional heading above the sections."},
+			{Name: "Logo", Type: "templ.Component", Default: "nil", Description: "Custom logo content (overrides LogoText)."},
+			{Name: "LogoText", Type: "string", Default: `""`, Description: "Text logo shown at the top."},
+			{Name: "LogoHref", Type: "string", Default: `""`, Description: "Link target for the logo."},
+			{Name: "ShowSearch", Type: "bool", Default: "false", Description: "Render a search input below the logo."},
+			{Name: "SearchPlaceholder", Type: "string", Default: `""`, Description: "Placeholder for the search input."},
+			{Name: "SearchSlot", Type: "templ.Component", Default: "nil", Description: "Custom search-area content."},
+			{Name: "FooterSlot", Type: "templ.Component", Default: "nil", Description: "Content pinned to the bottom of the sidebar."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -98,7 +176,7 @@ func sidebarDemoContent() templ.Component {
 }
 
 // --- Variant 1: Simple Sidebar ---
-func simpleSidebarDemo() templ.Component {
+func sidebarSimplePreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -119,7 +197,7 @@ func simpleSidebarDemo() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"not-prose\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">Simple Sidebar</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">A sidebar with a logo, search input, and icon navigation links. Profile is marked as active.</p><div class=\"border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark\"><span class=\"size-3 rounded-full bg-red-400\"></span> <span class=\"size-3 rounded-full bg-yellow-400\"></span> <span class=\"size-3 rounded-full bg-green-400\"></span></div><div class=\"flex h-[400px]\"><div class=\"w-60 shrink-0\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"sidebar-simple\" class=\"w-full\"><div class=\"flex h-[400px] border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"w-60 shrink-0\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -146,7 +224,7 @@ func simpleSidebarDemo() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -155,7 +233,7 @@ func simpleSidebarDemo() templ.Component {
 }
 
 // --- Variant 2: Sidebar with Sections ---
-func sectionsSidebarDemo() templ.Component {
+func sidebarSectionsPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -176,7 +254,7 @@ func sectionsSidebarDemo() templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div class=\"not-prose\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">Sidebar with Sections</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Grouped navigation with section titles for logical organization of links.</p><div class=\"border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark\"><span class=\"size-3 rounded-full bg-red-400\"></span> <span class=\"size-3 rounded-full bg-yellow-400\"></span> <span class=\"size-3 rounded-full bg-green-400\"></span></div><div class=\"flex h-[400px]\"><div class=\"w-60 shrink-0\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div id=\"sidebar-sections\" class=\"w-full\"><div class=\"flex h-[400px] border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"w-60 shrink-0\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -219,7 +297,7 @@ func sectionsSidebarDemo() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -228,7 +306,7 @@ func sectionsSidebarDemo() templ.Component {
 }
 
 // --- Variant 3: Sidebar with Sub-Items ---
-func subItemsSidebarDemo() templ.Component {
+func sidebarSubItemsPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -249,7 +327,7 @@ func subItemsSidebarDemo() templ.Component {
 			templ_7745c5c3_Var5 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"not-prose\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">Sidebar with Sub-Items</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Documentation-style sidebar with parent items and nested child links, similar to API reference navigation.</p><div class=\"border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark\"><span class=\"size-3 rounded-full bg-red-400\"></span> <span class=\"size-3 rounded-full bg-yellow-400\"></span> <span class=\"size-3 rounded-full bg-green-400\"></span></div><div class=\"flex h-[450px]\"><div class=\"w-64 shrink-0\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"sidebar-sub-items\" class=\"w-full\"><div class=\"flex h-[450px] border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"w-64 shrink-0\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -292,7 +370,7 @@ func subItemsSidebarDemo() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -301,7 +379,7 @@ func subItemsSidebarDemo() templ.Component {
 }
 
 // --- Variant 4: Collapsible Sidebar ---
-func collapsibleSidebarDemo() templ.Component {
+func sidebarCollapsiblePreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -322,7 +400,7 @@ func collapsibleSidebarDemo() templ.Component {
 			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div class=\"not-prose\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">Collapsible Sections</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Each section can be collapsed or expanded using Alpine.js. Click the section headers to toggle visibility.</p><div class=\"border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark\"><span class=\"size-3 rounded-full bg-red-400\"></span> <span class=\"size-3 rounded-full bg-yellow-400\"></span> <span class=\"size-3 rounded-full bg-green-400\"></span></div><div class=\"flex h-[450px]\"><div class=\"w-60 shrink-0\"><nav class=\"h-full w-full border-r border-outline bg-surface dark:border-outline-dark dark:bg-surface-dark flex flex-col\" aria-label=\"sidebar navigation\"><div class=\"shrink-0 border-b border-outline dark:border-outline-dark p-4\"><a href=\"#\" class=\"flex items-center gap-2 text-xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\"><span>Dashboard</span></a></div><div class=\"flex-1 overflow-y-auto sidebar-scroll p-4\" x-data=\"{ sections: { general: true, content: false, system: false } }\"><div class=\"flex flex-col gap-4\"><!-- General section (open by default) --><div><button x-on:click=\"sections.general = !sections.general\" class=\"flex w-full items-center justify-between rounded-radius px-2 py-1.5 text-xs font-semibold uppercase tracking-wider text-on-surface-muted hover:text-on-surface-muted dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-muted\"><span>General</span> <svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" class=\"size-4 transition-transform duration-200\" x-bind:class=\"sections.general ? 'rotate-180' : ''\"><path fill-rule=\"evenodd\" d=\"M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z\" clip-rule=\"evenodd\"></path></svg></button><div x-show=\"sections.general\" x-collapse><div class=\"mt-1 flex flex-col gap-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div id=\"sidebar-collapsible\" class=\"w-full\"><div class=\"flex h-[450px] border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"w-60 shrink-0\"><nav class=\"h-full w-full border-r border-outline bg-surface dark:border-outline-dark dark:bg-surface-dark flex flex-col\" aria-label=\"sidebar navigation\"><div class=\"shrink-0 border-b border-outline dark:border-outline-dark p-4\"><a href=\"#\" class=\"flex items-center gap-2 text-xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\"><span>Dashboard</span></a></div><div class=\"flex-1 overflow-y-auto sidebar-scroll p-4\" x-data=\"{ sections: { general: true, content: false, system: false } }\"><div class=\"flex flex-col gap-4\"><!-- General section (open by default) --><div><button x-on:click=\"sections.general = !sections.general\" class=\"flex w-full items-center justify-between rounded-radius px-2 py-1.5 text-xs font-semibold uppercase tracking-wider text-on-surface-muted hover:text-on-surface-muted dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-muted\"><span>General</span> <svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" class=\"size-4 transition-transform duration-200\" x-bind:class=\"sections.general ? 'rotate-180' : ''\"><path fill-rule=\"evenodd\" d=\"M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z\" clip-rule=\"evenodd\"></path></svg></button><div x-show=\"sections.general\" x-collapse><div class=\"mt-1 flex flex-col gap-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -378,7 +456,7 @@ func collapsibleSidebarDemo() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -415,7 +493,7 @@ func collapsibleItem(label string, active bool) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/pages/demo/components/sidebar.templ`, Line: 271, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/pages/demo/components/sidebar.templ`, Line: 309, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -433,7 +511,7 @@ func collapsibleItem(label string, active bool) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/pages/demo/components/sidebar.templ`, Line: 275, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/pages/demo/components/sidebar.templ`, Line: 313, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -449,7 +527,7 @@ func collapsibleItem(label string, active bool) templ.Component {
 }
 
 // --- Variant 5: Overlay Sidebar ---
-func overlaySidebarDemo() templ.Component {
+func sidebarOverlayPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -470,7 +548,7 @@ func overlaySidebarDemo() templ.Component {
 			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div class=\"not-prose\"><h3 class=\"text-lg font-semibold text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">Overlay Sidebar</h3><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">A sidebar that opens as an overlay with a dark backdrop, triggered by a hamburger button. Uses Alpine.js for toggle state.</p><div class=\"border border-outline dark:border-outline-dark rounded-radius overflow-hidden\"><div class=\"flex items-center gap-1.5 bg-surface-alt dark:bg-surface-dark-alt px-3 py-2 border-b border-outline dark:border-outline-dark\"><span class=\"size-3 rounded-full bg-red-400\"></span> <span class=\"size-3 rounded-full bg-yellow-400\"></span> <span class=\"size-3 rounded-full bg-green-400\"></span></div><div class=\"relative h-[400px] bg-surface dark:bg-surface-dark overflow-hidden\" x-data=\"{ showSidebar: false }\"><!-- Top bar with hamburger --><div class=\"flex items-center gap-3 border-b border-outline dark:border-outline-dark px-4 py-3\"><button x-on:click=\"showSidebar = true\" class=\"rounded-radius p-1.5 text-on-surface hover:bg-primary/5 dark:text-on-surface-dark dark:hover:bg-primary-dark/5\" aria-label=\"Open sidebar\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" class=\"size-5\"><path fill-rule=\"evenodd\" d=\"M2 4.75A.75.75 0 0 1 2.75 4h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 4.75ZM2 10a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 10Zm0 5.25a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Z\" clip-rule=\"evenodd\"></path></svg></button> <span class=\"text-sm font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Click the hamburger to open</span></div><!-- Content area --><div class=\"p-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div id=\"sidebar-overlay\" class=\"w-full\"><div class=\"relative h-[400px] bg-surface dark:bg-surface-dark overflow-hidden border border-outline dark:border-outline-dark rounded-radius\" x-data=\"{ showSidebar: false }\"><!-- Top bar with hamburger --><div class=\"flex items-center gap-3 border-b border-outline dark:border-outline-dark px-4 py-3\"><button x-on:click=\"showSidebar = true\" class=\"rounded-radius p-1.5 text-on-surface hover:bg-primary/5 dark:text-on-surface-dark dark:hover:bg-primary-dark/5\" aria-label=\"Open sidebar\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" class=\"size-5\"><path fill-rule=\"evenodd\" d=\"M2 4.75A.75.75 0 0 1 2.75 4h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 4.75ZM2 10a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75A.75.75 0 0 1 2 10Zm0 5.25a.75.75 0 0 1 .75-.75h14.5a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1-.75-.75Z\" clip-rule=\"evenodd\"></path></svg></button> <span class=\"text-sm font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Click the hamburger to open</span></div><!-- Content area --><div class=\"p-6\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -496,7 +574,7 @@ func overlaySidebarDemo() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<!-- Close button inside sidebar --><button x-on:click=\"showSidebar = false\" class=\"absolute top-4 right-2 rounded-radius p-1 text-on-surface-muted hover:text-on-surface dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark\" aria-label=\"Close sidebar\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" class=\"size-4\"><path d=\"M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z\"></path></svg></button></div></div></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<!-- Close button inside sidebar --><button x-on:click=\"showSidebar = false\" class=\"absolute top-4 right-2 rounded-radius p-1 text-on-surface-muted hover:text-on-surface dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark\" aria-label=\"Close sidebar\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" class=\"size-4\"><path d=\"M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z\"></path></svg></button></div></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/spinner.templ
+++ b/internal/pages/demo/components/spinner.templ
@@ -10,63 +10,79 @@ templ SpinnerDemoPage() {
 	@demo.Layout("Spinner", "spinner", spinnerDemoContent())
 }
 
-// spinnerDemoContent renders the actual content inside the layout
+// spinnerDemoContent renders the demo. Each spinner variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/spinner). Wrapped in #spinner-fragment.
 templ spinnerDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Spinner",
-			Description:   "A spinner indicates loading state with an animated circular indicator. Available in multiple color variants and sizes.",
-		},
-		spinnerDemoPreview(),
-		`// Default Spinner
-@spinner.Spinner(spinner.Config{})
+	<div id="spinner-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Spinner",
+				Description: "An animated circular loading indicator in six semantic colors and four sizes.",
+			},
+			spinnerDefaultPreview(),
+			`@spinner.Spinner(spinner.Config{})`,
+		)
 
-// Primary Spinner
-@spinner.Spinner(spinner.Config{
-    Variant: spinner.Primary,
-})
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Color Variants",
+				Description: "Set Variant: Primary, Secondary, Info, Success, Warning, or Danger.",
+			},
+			spinnerVariantsPreview(),
+			`@spinner.Spinner(spinner.Config{Variant: spinner.Primary})
+@spinner.Spinner(spinner.Config{Variant: spinner.Danger})`,
+		)
 
-// Large Danger Spinner
-@spinner.Spinner(spinner.Config{
-    Variant: spinner.Danger,
-    Size:    spinner.SizeLG,
-})`,
-	)
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Sizes",
+				Description: "Four sizes via Size: SizeSM, SizeMD (default), SizeLG, SizeXL.",
+			},
+			spinnerSizesPreview(),
+			`@spinner.Spinner(spinner.Config{Size: spinner.SizeSM})
+@spinner.Spinner(spinner.Config{Size: spinner.SizeXL})`,
+		)
+	</div>
+	// API reference lives outside #spinner-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Variant", Type: "Variant", Default: "Default", Description: `Color: "default", "primary", "secondary", "info", "success", "warning", "danger".`},
+		{Name: "Size", Type: "Size", Default: "SizeMD", Description: `Size: "sm", "md", "lg", "xl".`},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the spinner SVG."},
+	})
 }
 
-// spinnerDemoPreview renders the Goshtoso spinner preview
-templ spinnerDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Default Spinner
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Spinner</h4>
-			<div class="flex items-center gap-4">
-				@spinner.Spinner(spinner.Config{})
-			</div>
+// spinnerDefaultPreview renders the default spinner.
+templ spinnerDefaultPreview() {
+	<div id="spinner-default" class="w-full max-w-md mx-auto">
+		<div class="flex items-center justify-center gap-4">
+			@spinner.Spinner(spinner.Config{})
 		</div>
+	</div>
+}
 
-		// Color Variants
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Color Variants</h4>
-			<div class="flex items-center gap-4">
-				@spinner.Spinner(spinner.Config{Variant: spinner.Primary})
-				@spinner.Spinner(spinner.Config{Variant: spinner.Secondary})
-				@spinner.Spinner(spinner.Config{Variant: spinner.Info})
-				@spinner.Spinner(spinner.Config{Variant: spinner.Success})
-				@spinner.Spinner(spinner.Config{Variant: spinner.Warning})
-				@spinner.Spinner(spinner.Config{Variant: spinner.Danger})
-			</div>
+// spinnerVariantsPreview renders the six color variants.
+templ spinnerVariantsPreview() {
+	<div id="spinner-variants" class="w-full max-w-md mx-auto">
+		<div class="flex items-center justify-center gap-4">
+			@spinner.Spinner(spinner.Config{Variant: spinner.Primary})
+			@spinner.Spinner(spinner.Config{Variant: spinner.Secondary})
+			@spinner.Spinner(spinner.Config{Variant: spinner.Info})
+			@spinner.Spinner(spinner.Config{Variant: spinner.Success})
+			@spinner.Spinner(spinner.Config{Variant: spinner.Warning})
+			@spinner.Spinner(spinner.Config{Variant: spinner.Danger})
 		</div>
+	</div>
+}
 
-		// Sizes
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Sizes</h4>
-			<div class="flex items-center gap-4">
-				@spinner.Spinner(spinner.Config{Variant: spinner.Primary, Size: spinner.SizeSM})
-				@spinner.Spinner(spinner.Config{Variant: spinner.Primary, Size: spinner.SizeMD})
-				@spinner.Spinner(spinner.Config{Variant: spinner.Primary, Size: spinner.SizeLG})
-				@spinner.Spinner(spinner.Config{Variant: spinner.Primary, Size: spinner.SizeXL})
-			</div>
+// spinnerSizesPreview renders the four sizes.
+templ spinnerSizesPreview() {
+	<div id="spinner-sizes" class="w-full max-w-md mx-auto">
+		<div class="flex items-center justify-center gap-4">
+			@spinner.Spinner(spinner.Config{Variant: spinner.Primary, Size: spinner.SizeSM})
+			@spinner.Spinner(spinner.Config{Variant: spinner.Primary, Size: spinner.SizeMD})
+			@spinner.Spinner(spinner.Config{Variant: spinner.Primary, Size: spinner.SizeLG})
+			@spinner.Spinner(spinner.Config{Variant: spinner.Primary, Size: spinner.SizeXL})
 		</div>
 	</div>
 }

--- a/internal/pages/demo/components/spinner_templ.go
+++ b/internal/pages/demo/components/spinner_templ.go
@@ -43,7 +43,9 @@ func SpinnerDemoPage() templ.Component {
 	})
 }
 
-// spinnerDemoContent renders the actual content inside the layout
+// spinnerDemoContent renders the demo. Each spinner variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/spinner). Wrapped in #spinner-fragment.
 func spinnerDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,26 +67,54 @@ func spinnerDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"spinner-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Spinner",
-				Description: "A spinner indicates loading state with an animated circular indicator. Available in multiple color variants and sizes.",
+				Description: "An animated circular loading indicator in six semantic colors and four sizes.",
 			},
-			spinnerDemoPreview(),
-			`// Default Spinner
-@spinner.Spinner(spinner.Config{})
-
-// Primary Spinner
-@spinner.Spinner(spinner.Config{
-    Variant: spinner.Primary,
-})
-
-// Large Danger Spinner
-@spinner.Spinner(spinner.Config{
-    Variant: spinner.Danger,
-    Size:    spinner.SizeLG,
-})`,
+			spinnerDefaultPreview(),
+			`@spinner.Spinner(spinner.Config{})`,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Color Variants",
+				Description: "Set Variant: Primary, Secondary, Info, Success, Warning, or Danger.",
+			},
+			spinnerVariantsPreview(),
+			`@spinner.Spinner(spinner.Config{Variant: spinner.Primary})
+@spinner.Spinner(spinner.Config{Variant: spinner.Danger})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Sizes",
+				Description: "Four sizes via Size: SizeSM, SizeMD (default), SizeLG, SizeXL.",
+			},
+			spinnerSizesPreview(),
+			`@spinner.Spinner(spinner.Config{Size: spinner.SizeSM})
+@spinner.Spinner(spinner.Config{Size: spinner.SizeXL})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Color: "default", "primary", "secondary", "info", "success", "warning", "danger".`},
+			{Name: "Size", Type: "Size", Default: "SizeMD", Description: `Size: "sm", "md", "lg", "xl".`},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the spinner SVG."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -92,8 +122,8 @@ func spinnerDemoContent() templ.Component {
 	})
 }
 
-// spinnerDemoPreview renders the Goshtoso spinner preview
-func spinnerDemoPreview() templ.Component {
+// spinnerDefaultPreview renders the default spinner.
+func spinnerDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -114,7 +144,7 @@ func spinnerDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Spinner</h4><div class=\"flex items-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"spinner-default\" class=\"w-full max-w-md mx-auto\"><div class=\"flex items-center justify-center gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -122,7 +152,37 @@ func spinnerDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Color Variants</h4><div class=\"flex items-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// spinnerVariantsPreview renders the six color variants.
+func spinnerVariantsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"spinner-variants\" class=\"w-full max-w-md mx-auto\"><div class=\"flex items-center justify-center gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -150,7 +210,37 @@ func spinnerDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Sizes</h4><div class=\"flex items-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// spinnerSizesPreview renders the four sizes.
+func spinnerSizesPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"spinner-sizes\" class=\"w-full max-w-md mx-auto\"><div class=\"flex items-center justify-center gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -170,7 +260,7 @@ func spinnerDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/table.templ
+++ b/internal/pages/demo/components/table.templ
@@ -10,16 +10,19 @@ templ TableDemoPage() {
 	@demo.Layout("Table", "table", tableDemoContent())
 }
 
-// tableDemoContent renders the actual content inside the layout
+// tableDemoContent renders the demo. Each table variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/table).
+// The variant set stays wrapped in #table-fragment; each preview wrapper carries a
+// unique #table-<variant> id so the e2e suite can scope to it.
 templ tableDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Table",
-			Description:   "Tables display structured data in rows and columns. Supports static, sortable, lazy-loaded, paginated, and infinite scroll variants.",
-		},
-		tableDemoPreview(),
-		`// Default Table
-@table.Table(table.Config{
+	<div id="table-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Table",
+				Description: "Tables display structured data in rows and columns. Supports static, striped, checkbox, sortable, lazy-loaded, paginated, filtered, and infinite-scroll variants.",
+			},
+			tableDefaultPreview(),
+			`@table.Table(table.Config{
     Columns: []table.Column{
         {Key: "id", Label: "CustomerID"},
         {Key: "name", Label: "Name"},
@@ -27,46 +30,173 @@ templ tableDemoContent() {
         {Key: "membership", Label: "Membership"},
     },
     Rows: rows,
-})
+})`,
+		)
 
-// Sortable Table (HTMX)
-@table.Table(table.Config{
-    ID:           "sortable",
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Striped Table",
+				Description: "Set Variant: table.Striped to zebra-stripe the rows.",
+			},
+			tableStripedPreview(),
+			`@table.Table(table.Config{
+    Variant: table.Striped,
+    Columns: columns,
+    Rows:    rows,
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Table with Action",
+				Description: "Render an interactive control in a cell via Cell.Component (e.g. table.ActionButton).",
+			},
+			tableActionPreview(),
+			`@table.Table(table.Config{
+    Columns: actionColumns(),
+    Rows: []table.Row{
+        {ID: "2335", Cells: map[string]table.Cell{
+            "id":     {Text: "2335"},
+            "name":   {Text: "Alice Brown"},
+            "email":  {Text: "alice.brown@gmail.com"},
+            "action": {Component: table.ActionButton("Edit")},
+        }},
+    },
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Table with Checkbox",
+				Description: "Set ShowCheckbox: true to add a select column with a header check-all toggle.",
+			},
+			tableCheckboxPreview(),
+			`@table.Table(table.Config{
+    ShowCheckbox: true,
+    Columns:      actionColumns(),
+    Rows:         rows,
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Users Table",
+				Description: "Compose rich cells: table.UserCell (avatar + name + email), table.StatusBadge, and table.ActionButton.",
+			},
+			tableUsersPreview(),
+			`@table.Table(table.Config{
+    Columns: usersColumns(),
+    Rows: []table.Row{
+        {ID: "2335", Cells: map[string]table.Cell{
+            "user":   {Component: table.UserCell("/.../avatar-8.webp", "Alice Brown", "alice.brown@gmail.com")},
+            "id":     {Text: "2335"},
+            "since":  {Text: "Nov 14, 2021"},
+            "status": {Component: table.StatusBadge("Active", "success")},
+            "action": {Component: table.ActionButton("Edit")},
+        }},
+    },
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Sortable Table (HTMX)",
+				Description: "Mark columns Sortable: true and set HTMXEndpoint. Clicking a header cycles neutral → asc → desc and fetches sorted rows from the server.",
+			},
+			tableSortablePreview(),
+			`@table.Table(table.Config{
+    ID:           "sortable-table",
     HTMXEndpoint: "/api/components/table/rows",
+    SortBy:       "id",
+    SortDir:      table.SortAsc,
     Columns: []table.Column{
         {Key: "id", Label: "CustomerID", Sortable: true},
         {Key: "name", Label: "Name", Sortable: true},
         {Key: "email", Label: "Email"},
         {Key: "membership", Label: "Membership", Sortable: true},
     },
-    SortBy:  "id",
-    SortDir: table.SortAsc,
-    Rows:    rows,
-})
+    Rows: rows,
+})`,
+		)
 
-// Lazy-Loaded Table (HTMX)
-@table.Table(table.Config{
-    ID:           "lazy",
-    HTMXEndpoint: "/api/components/table/rows",
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Lazy-Loaded Table",
+				Description: "Set LazyLoad: true and the tbody fetches from HTMXEndpoint on page load (hx-trigger=\"load\").",
+			},
+			tableLazyPreview(),
+			`@table.Table(table.Config{
+    ID:           "lazy-table",
+    HTMXEndpoint: "/api/components/table/rows?variant=lazy",
     LazyLoad:     true,
     Columns:      columns,
-})
+})`,
+		)
 
-// Paginated Table
-@table.Table(table.Config{
-    ID:           "paginated",
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Paginated Table",
+				Description: "Pass a Pagination config; Prev/Next and page links swap the tbody and paginator via HTMX OOB.",
+			},
+			tablePaginatedPreview(),
+			`@table.Table(table.Config{
+    ID:           "paginated-table",
     HTMXEndpoint: "/api/components/table/rows",
     Columns:      columns,
-    Rows:         rows,
+    Rows:         pageRows(1),
     Pagination:   &table.PaginationConfig{CurrentPage: 1, TotalPages: 4, PerPage: 3},
-})
+})`,
+		)
 
-// Infinite Scroll Table
-@table.Table(table.Config{
-    ID:           "infinite",
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Filtered Table",
+				Description: "Add a Filters config with search/select/toggle filters. The bar variant renders a collapsible bordered block.",
+			},
+			tableFilteredPreview(),
+			`@table.Table(table.Config{
+    ID:           "filtered-table",
+    HTMXEndpoint: "/api/components/table/rows",
+    Columns:      sortableColumns(),
+    Rows:         pageRows(1),
+    Pagination:   &table.PaginationConfig{CurrentPage: 1, TotalPages: 4, PerPage: 3},
+    Filters: &table.FilterConfig{
+        Collapsible:       true,
+        InitiallyExpanded: true,
+        Filters: []table.Filter{
+            {Key: "search", Label: "Search", Type: table.FilterSearch, Placeholder: "Search by name or email..."},
+            {Key: "membership", Label: "Membership", Type: table.FilterSelect, Options: memberships},
+        },
+    },
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Inline Filter Variant",
+				Description: "Set Filters.Variant: table.FilterVariantInline for the same controls without the bordered block or collapsible toggle — suited to modal bodies and toolbar strips.",
+			},
+			tableInlineFilteredPreview(),
+			`Filters: &table.FilterConfig{
+    Variant: table.FilterVariantInline,
+    Filters: []table.Filter{
+        {Key: "search", Type: table.FilterSearch, Placeholder: "Search…"},
+        {Key: "membership", Type: table.FilterSelect, Options: memberships},
+    },
+}`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Infinite Scroll Table",
+				Description: "Use Pagination.Mode: table.PaginationInfiniteScroll. A sentinel row drives htmx.ajax from an IntersectionObserver to append the next page.",
+			},
+			tableInfinitePreview(),
+			`@table.Table(table.Config{
+    ID:           "infinite-table",
     HTMXEndpoint: "/api/components/table/rows?variant=infinite",
     Columns:      columns,
-    Rows:         rows,
+    Rows:         initialRows,
     Pagination: &table.PaginationConfig{
         Mode:            table.PaginationInfiniteScroll,
         CurrentPage:     1,
@@ -75,193 +205,213 @@ templ tableDemoContent() {
         ContainerHeight: "300px",
     },
 })`,
-	)
+		)
+	</div>
+	// API reference lives outside #table-fragment so its <table>/tbody.divide-y
+	// rows don't pollute the page-level "table" selectors the e2e suite counts.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Columns", Type: "[]Column", Default: "nil", Description: "Column definitions (Key, Label, Sortable, Width, Align)."},
+		{Name: "Rows", Type: "[]Row", Default: "nil", Description: "Row data; each Row.Cells maps a column Key to a Cell (Text or Component)."},
+		{Name: "Variant", Type: "Variant", Default: "Default", Description: `Style: "default", "striped", or "checkbox".`},
+		{Name: "ShowCheckbox", Type: "bool", Default: "false", Description: "Adds a leading select column with a header check-all toggle."},
+		{Name: "ID", Type: "string", Default: `""`, Description: "Table element id; required for HTMX variants (seeds tbody/paginator ids)."},
+		{Name: "Caption", Type: "string", Default: `""`, Description: "Optional accessible table caption."},
+		{Name: "SortBy", Type: "string", Default: `""`, Description: "Initial sort column key."},
+		{Name: "SortDir", Type: "SortDir", Default: "SortNone", Description: `Initial sort direction: "asc", "desc", or "" (none).`},
+		{Name: "HTMXEndpoint", Type: "string", Default: `""`, Description: "Server URL that returns row HTML for sort/page/filter/lazy/infinite."},
+		{Name: "HTMXTarget", Type: "string", Default: `""`, Description: "Override the default tbody swap target."},
+		{Name: "LazyLoad", Type: "bool", Default: "false", Description: "Fetch the tbody from HTMXEndpoint on page load."},
+		{Name: "Pagination", Type: "*PaginationConfig", Default: "nil", Description: "Pagination/infinite-scroll config (CurrentPage, TotalPages, PerPage, Mode, ...)."},
+		{Name: "Filters", Type: "*FilterConfig", Default: "nil", Description: "Filter bar config (Variant, Collapsible, Filters[]: search/select/toggle)."},
+		{Name: "ExtraQueryParams", Type: "string", Default: `""`, Description: "Extra query string appended to every HTMX request."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the table container."},
+	})
 }
 
-// tableDemoPreview renders the Goshtoso table preview
-templ tableDemoPreview() {
-	<div class="w-full max-w-5xl mx-auto space-y-12">
-		// Default Table
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Table</h4>
-			@table.Table(table.Config{
-				Columns: defaultColumns(),
-				Rows:    defaultRows(),
-			})
-		</div>
+// tableDefaultPreview renders the default static table.
+templ tableDefaultPreview() {
+	<div id="table-default" class="w-full">
+		@table.Table(table.Config{
+			Columns: defaultColumns(),
+			Rows:    defaultRows(),
+		})
+	</div>
+}
 
-		// Striped Table
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Striped Table</h4>
-			@table.Table(table.Config{
-				Variant: table.Striped,
-				Columns: defaultColumns(),
-				Rows:    stripedRows(),
-			})
-		</div>
+// tableStripedPreview renders the striped variant.
+templ tableStripedPreview() {
+	<div id="table-striped" class="w-full">
+		@table.Table(table.Config{
+			Variant: table.Striped,
+			Columns: defaultColumns(),
+			Rows:    stripedRows(),
+		})
+	</div>
+}
 
-		// Table with Action
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Table with Action</h4>
-			@table.Table(table.Config{
-				Columns: actionColumns(),
-				Rows:    actionRows(),
-			})
-		</div>
+// tableActionPreview renders a table with an action button column.
+templ tableActionPreview() {
+	<div id="table-action" class="w-full">
+		@table.Table(table.Config{
+			Columns: actionColumns(),
+			Rows:    actionRows(),
+		})
+	</div>
+}
 
-		// Table with Checkbox
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Table with Checkbox</h4>
-			@table.Table(table.Config{
-				ShowCheckbox: true,
-				Columns:      actionColumns(),
-				Rows:         checkboxRows(),
-			})
-		</div>
+// tableCheckboxPreview renders the checkbox-select variant.
+templ tableCheckboxPreview() {
+	<div id="table-checkbox" class="w-full">
+		@table.Table(table.Config{
+			ShowCheckbox: true,
+			Columns:      actionColumns(),
+			Rows:         checkboxRows(),
+		})
+	</div>
+}
 
-		// Users Table
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Users Table</h4>
-			@table.Table(table.Config{
-				Columns: usersColumns(),
-				Rows:    usersRows(),
-			})
-		</div>
+// tableUsersPreview renders the rich users table (avatars, badges, actions).
+templ tableUsersPreview() {
+	<div id="table-users" class="w-full">
+		@table.Table(table.Config{
+			Columns: usersColumns(),
+			Rows:    usersRows(),
+		})
+	</div>
+}
 
-		// Sortable Table (HTMX)
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Sortable Table (click headers)</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2">Click column headers to sort. Uses HTMX to fetch sorted data from the server.</p>
-			@table.Table(table.Config{
-				ID:           "sortable-table",
-				HTMXEndpoint: "/api/components/table/rows",
-				SortBy:       "id",
-				SortDir:      table.SortAsc,
-				Columns:      sortableColumns(),
-				Rows:         stripedRows(),
-			})
-		</div>
+// tableSortablePreview renders the HTMX sortable table.
+templ tableSortablePreview() {
+	<div id="table-sortable" class="w-full">
+		@table.Table(table.Config{
+			ID:           "sortable-table",
+			HTMXEndpoint: "/api/components/table/rows",
+			SortBy:       "id",
+			SortDir:      table.SortAsc,
+			Columns:      sortableColumns(),
+			Rows:         stripedRows(),
+		})
+	</div>
+}
 
-		// Lazy-Loaded Table
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Lazy-Loaded Table</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2">Table body loads from the server via HTMX on page load.</p>
-			@table.Table(table.Config{
-				ID:           "lazy-table",
-				HTMXEndpoint: "/api/components/table/rows?variant=lazy",
-				LazyLoad:     true,
-				Columns:      defaultColumns(),
-			})
-		</div>
+// tableLazyPreview renders the lazy-loaded table.
+templ tableLazyPreview() {
+	<div id="table-lazy" class="w-full">
+		@table.Table(table.Config{
+			ID:           "lazy-table",
+			HTMXEndpoint: "/api/components/table/rows?variant=lazy",
+			LazyLoad:     true,
+			Columns:      defaultColumns(),
+		})
+	</div>
+}
 
-		// Paginated Table
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Paginated Table</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2">Navigate between pages with HTMX-powered pagination controls.</p>
-			@table.Table(table.Config{
-				ID:           "paginated-table",
-				HTMXEndpoint: "/api/components/table/rows",
-				Columns:      defaultColumns(),
-				Rows:         paginatedRows(1),
-				Pagination:   &table.PaginationConfig{CurrentPage: 1, TotalPages: 4, PerPage: 3},
-			})
-		</div>
+// tablePaginatedPreview renders the paginated table.
+templ tablePaginatedPreview() {
+	<div id="table-paginated" class="w-full">
+		@table.Table(table.Config{
+			ID:           "paginated-table",
+			HTMXEndpoint: "/api/components/table/rows",
+			Columns:      defaultColumns(),
+			Rows:         paginatedRows(1),
+			Pagination:   &table.PaginationConfig{CurrentPage: 1, TotalPages: 4, PerPage: 3},
+		})
+	</div>
+}
 
-		// Filtered Table
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Filtered Table</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2">Search and filter table data with HTMX-powered filter controls.</p>
-			@table.Table(table.Config{
-				ID:           "filtered-table",
-				HTMXEndpoint: "/api/components/table/rows",
-				Columns: []table.Column{
-					{Key: "id", Label: "CustomerID", Sortable: true},
-					{Key: "name", Label: "Name", Sortable: true},
-					{Key: "email", Label: "Email"},
-					{Key: "membership", Label: "Membership", Sortable: true},
-				},
-				Rows:       paginatedRows(1),
-				Pagination: &table.PaginationConfig{CurrentPage: 1, TotalPages: 4, PerPage: 3},
-				Filters: &table.FilterConfig{
-					Collapsible:       true,
-					InitiallyExpanded: true,
-					Filters: []table.Filter{
-						{
-							Key:         "search",
-							Label:       "Search",
-							Type:        table.FilterSearch,
-							Placeholder: "Search by name or email...",
-						},
-						{
-							Key:   "membership",
-							Label: "Membership",
-							Type:  table.FilterSelect,
-							Options: []table.FilterOption{
-								{Value: "", Label: "All Memberships"},
-								{Value: "Gold", Label: "Gold"},
-								{Value: "Silver", Label: "Silver"},
-							},
+// tableFilteredPreview renders the filter-bar (collapsible) table.
+templ tableFilteredPreview() {
+	<div id="table-filtered" class="w-full">
+		@table.Table(table.Config{
+			ID:           "filtered-table",
+			HTMXEndpoint: "/api/components/table/rows",
+			Columns: []table.Column{
+				{Key: "id", Label: "CustomerID", Sortable: true},
+				{Key: "name", Label: "Name", Sortable: true},
+				{Key: "email", Label: "Email"},
+				{Key: "membership", Label: "Membership", Sortable: true},
+			},
+			Rows:       paginatedRows(1),
+			Pagination: &table.PaginationConfig{CurrentPage: 1, TotalPages: 4, PerPage: 3},
+			Filters: &table.FilterConfig{
+				Collapsible:       true,
+				InitiallyExpanded: true,
+				Filters: []table.Filter{
+					{
+						Key:         "search",
+						Label:       "Search",
+						Type:        table.FilterSearch,
+						Placeholder: "Search by name or email...",
+					},
+					{
+						Key:   "membership",
+						Label: "Membership",
+						Type:  table.FilterSelect,
+						Options: []table.FilterOption{
+							{Value: "", Label: "All Memberships"},
+							{Value: "Gold", Label: "Gold"},
+							{Value: "Silver", Label: "Silver"},
 						},
 					},
 				},
-			})
-		</div>
+			},
+		})
+	</div>
+}
 
-		// Inline Filter Variant (modal-style chrome)
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Inline Filter Variant</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2">Same filter controls, no bordered block, no collapsible toggle. Suitable for modal bodies or toolbar strips where the host already provides chrome.</p>
-			@table.Table(table.Config{
-				ID:           "inline-filtered-table",
-				HTMXEndpoint: "/api/components/table/rows",
-				Columns: []table.Column{
-					{Key: "id", Label: "CustomerID"},
-					{Key: "name", Label: "Name"},
-					{Key: "email", Label: "Email"},
-					{Key: "membership", Label: "Membership"},
-				},
-				Rows:       paginatedRows(1),
-				Pagination: &table.PaginationConfig{CurrentPage: 1, TotalPages: 4, PerPage: 3},
-				Filters: &table.FilterConfig{
-					Variant: table.FilterVariantInline,
-					Filters: []table.Filter{
-						{
-							Key:         "search",
-							Type:        table.FilterSearch,
-							Placeholder: "Search…",
-						},
-						{
-							Key:  "membership",
-							Type: table.FilterSelect,
-							Options: []table.FilterOption{
-								{Value: "", Label: "All"},
-								{Value: "Gold", Label: "Gold"},
-								{Value: "Silver", Label: "Silver"},
-							},
+// tableInlineFilteredPreview renders the inline filter variant.
+templ tableInlineFilteredPreview() {
+	<div id="table-inline-filtered" class="w-full">
+		@table.Table(table.Config{
+			ID:           "inline-filtered-table",
+			HTMXEndpoint: "/api/components/table/rows",
+			Columns: []table.Column{
+				{Key: "id", Label: "CustomerID"},
+				{Key: "name", Label: "Name"},
+				{Key: "email", Label: "Email"},
+				{Key: "membership", Label: "Membership"},
+			},
+			Rows:       paginatedRows(1),
+			Pagination: &table.PaginationConfig{CurrentPage: 1, TotalPages: 4, PerPage: 3},
+			Filters: &table.FilterConfig{
+				Variant: table.FilterVariantInline,
+				Filters: []table.Filter{
+					{
+						Key:         "search",
+						Type:        table.FilterSearch,
+						Placeholder: "Search…",
+					},
+					{
+						Key:  "membership",
+						Type: table.FilterSelect,
+						Options: []table.FilterOption{
+							{Value: "", Label: "All"},
+							{Value: "Gold", Label: "Gold"},
+							{Value: "Silver", Label: "Silver"},
 						},
 					},
 				},
-			})
-		</div>
+			},
+		})
+	</div>
+}
 
-		// Infinite Scroll Table
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Infinite Scroll Table</h4>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2">Scroll down in the container to automatically load more rows via HTMX.</p>
-			@table.Table(table.Config{
-				ID:           "infinite-table",
-				HTMXEndpoint: "/api/components/table/rows?variant=infinite",
-				Columns:      defaultColumns(),
-				Rows:         infiniteScrollInitialRows(),
-				Pagination: &table.PaginationConfig{
-					Mode:            table.PaginationInfiniteScroll,
-					CurrentPage:     1,
-					PerPage:         3,
-					HasMore:         true,
-					ContainerHeight: "300px",
-				},
-			})
-		</div>
+// tableInfinitePreview renders the infinite-scroll table.
+templ tableInfinitePreview() {
+	<div id="table-infinite" class="w-full">
+		@table.Table(table.Config{
+			ID:           "infinite-table",
+			HTMXEndpoint: "/api/components/table/rows?variant=infinite",
+			Columns:      defaultColumns(),
+			Rows:         infiniteScrollInitialRows(),
+			Pagination: &table.PaginationConfig{
+				Mode:            table.PaginationInfiniteScroll,
+				CurrentPage:     1,
+				PerPage:         3,
+				HasMore:         true,
+				ContainerHeight: "300px",
+			},
+		})
 	</div>
 }
 

--- a/internal/pages/demo/components/table_templ.go
+++ b/internal/pages/demo/components/table_templ.go
@@ -43,7 +43,10 @@ func TableDemoPage() templ.Component {
 	})
 }
 
-// tableDemoContent renders the actual content inside the layout
+// tableDemoContent renders the demo. Each table variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/table).
+// The variant set stays wrapped in #table-fragment; each preview wrapper carries a
+// unique #table-<variant> id so the e2e suite can scope to it.
 func tableDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,14 +68,17 @@ func tableDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"table-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Table",
-				Description: "Tables display structured data in rows and columns. Supports static, sortable, lazy-loaded, paginated, and infinite scroll variants.",
+				Description: "Tables display structured data in rows and columns. Supports static, striped, checkbox, sortable, lazy-loaded, paginated, filtered, and infinite-scroll variants.",
 			},
-			tableDemoPreview(),
-			`// Default Table
-@table.Table(table.Config{
+			tableDefaultPreview(),
+			`@table.Table(table.Config{
     Columns: []table.Column{
         {Key: "id", Label: "CustomerID"},
         {Key: "name", Label: "Name"},
@@ -80,46 +86,193 @@ func tableDemoContent() templ.Component {
         {Key: "membership", Label: "Membership"},
     },
     Rows: rows,
-})
-
-// Sortable Table (HTMX)
-@table.Table(table.Config{
-    ID:           "sortable",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Striped Table",
+				Description: "Set Variant: table.Striped to zebra-stripe the rows.",
+			},
+			tableStripedPreview(),
+			`@table.Table(table.Config{
+    Variant: table.Striped,
+    Columns: columns,
+    Rows:    rows,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Table with Action",
+				Description: "Render an interactive control in a cell via Cell.Component (e.g. table.ActionButton).",
+			},
+			tableActionPreview(),
+			`@table.Table(table.Config{
+    Columns: actionColumns(),
+    Rows: []table.Row{
+        {ID: "2335", Cells: map[string]table.Cell{
+            "id":     {Text: "2335"},
+            "name":   {Text: "Alice Brown"},
+            "email":  {Text: "alice.brown@gmail.com"},
+            "action": {Component: table.ActionButton("Edit")},
+        }},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Table with Checkbox",
+				Description: "Set ShowCheckbox: true to add a select column with a header check-all toggle.",
+			},
+			tableCheckboxPreview(),
+			`@table.Table(table.Config{
+    ShowCheckbox: true,
+    Columns:      actionColumns(),
+    Rows:         rows,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Users Table",
+				Description: "Compose rich cells: table.UserCell (avatar + name + email), table.StatusBadge, and table.ActionButton.",
+			},
+			tableUsersPreview(),
+			`@table.Table(table.Config{
+    Columns: usersColumns(),
+    Rows: []table.Row{
+        {ID: "2335", Cells: map[string]table.Cell{
+            "user":   {Component: table.UserCell("/.../avatar-8.webp", "Alice Brown", "alice.brown@gmail.com")},
+            "id":     {Text: "2335"},
+            "since":  {Text: "Nov 14, 2021"},
+            "status": {Component: table.StatusBadge("Active", "success")},
+            "action": {Component: table.ActionButton("Edit")},
+        }},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Sortable Table (HTMX)",
+				Description: "Mark columns Sortable: true and set HTMXEndpoint. Clicking a header cycles neutral → asc → desc and fetches sorted rows from the server.",
+			},
+			tableSortablePreview(),
+			`@table.Table(table.Config{
+    ID:           "sortable-table",
     HTMXEndpoint: "/api/components/table/rows",
+    SortBy:       "id",
+    SortDir:      table.SortAsc,
     Columns: []table.Column{
         {Key: "id", Label: "CustomerID", Sortable: true},
         {Key: "name", Label: "Name", Sortable: true},
         {Key: "email", Label: "Email"},
         {Key: "membership", Label: "Membership", Sortable: true},
     },
-    SortBy:  "id",
-    SortDir: table.SortAsc,
-    Rows:    rows,
-})
-
-// Lazy-Loaded Table (HTMX)
-@table.Table(table.Config{
-    ID:           "lazy",
-    HTMXEndpoint: "/api/components/table/rows",
+    Rows: rows,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Lazy-Loaded Table",
+				Description: "Set LazyLoad: true and the tbody fetches from HTMXEndpoint on page load (hx-trigger=\"load\").",
+			},
+			tableLazyPreview(),
+			`@table.Table(table.Config{
+    ID:           "lazy-table",
+    HTMXEndpoint: "/api/components/table/rows?variant=lazy",
     LazyLoad:     true,
     Columns:      columns,
-})
-
-// Paginated Table
-@table.Table(table.Config{
-    ID:           "paginated",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Paginated Table",
+				Description: "Pass a Pagination config; Prev/Next and page links swap the tbody and paginator via HTMX OOB.",
+			},
+			tablePaginatedPreview(),
+			`@table.Table(table.Config{
+    ID:           "paginated-table",
     HTMXEndpoint: "/api/components/table/rows",
     Columns:      columns,
-    Rows:         rows,
+    Rows:         pageRows(1),
     Pagination:   &table.PaginationConfig{CurrentPage: 1, TotalPages: 4, PerPage: 3},
-})
-
-// Infinite Scroll Table
-@table.Table(table.Config{
-    ID:           "infinite",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Filtered Table",
+				Description: "Add a Filters config with search/select/toggle filters. The bar variant renders a collapsible bordered block.",
+			},
+			tableFilteredPreview(),
+			`@table.Table(table.Config{
+    ID:           "filtered-table",
+    HTMXEndpoint: "/api/components/table/rows",
+    Columns:      sortableColumns(),
+    Rows:         pageRows(1),
+    Pagination:   &table.PaginationConfig{CurrentPage: 1, TotalPages: 4, PerPage: 3},
+    Filters: &table.FilterConfig{
+        Collapsible:       true,
+        InitiallyExpanded: true,
+        Filters: []table.Filter{
+            {Key: "search", Label: "Search", Type: table.FilterSearch, Placeholder: "Search by name or email..."},
+            {Key: "membership", Label: "Membership", Type: table.FilterSelect, Options: memberships},
+        },
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Inline Filter Variant",
+				Description: "Set Filters.Variant: table.FilterVariantInline for the same controls without the bordered block or collapsible toggle — suited to modal bodies and toolbar strips.",
+			},
+			tableInlineFilteredPreview(),
+			`Filters: &table.FilterConfig{
+    Variant: table.FilterVariantInline,
+    Filters: []table.Filter{
+        {Key: "search", Type: table.FilterSearch, Placeholder: "Search…"},
+        {Key: "membership", Type: table.FilterSelect, Options: memberships},
+    },
+}`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Infinite Scroll Table",
+				Description: "Use Pagination.Mode: table.PaginationInfiniteScroll. A sentinel row drives htmx.ajax from an IntersectionObserver to append the next page.",
+			},
+			tableInfinitePreview(),
+			`@table.Table(table.Config{
+    ID:           "infinite-table",
     HTMXEndpoint: "/api/components/table/rows?variant=infinite",
     Columns:      columns,
-    Rows:         rows,
+    Rows:         initialRows,
     Pagination: &table.PaginationConfig{
         Mode:            table.PaginationInfiniteScroll,
         CurrentPage:     1,
@@ -132,12 +285,36 @@ func tableDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Columns", Type: "[]Column", Default: "nil", Description: "Column definitions (Key, Label, Sortable, Width, Align)."},
+			{Name: "Rows", Type: "[]Row", Default: "nil", Description: "Row data; each Row.Cells maps a column Key to a Cell (Text or Component)."},
+			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Style: "default", "striped", or "checkbox".`},
+			{Name: "ShowCheckbox", Type: "bool", Default: "false", Description: "Adds a leading select column with a header check-all toggle."},
+			{Name: "ID", Type: "string", Default: `""`, Description: "Table element id; required for HTMX variants (seeds tbody/paginator ids)."},
+			{Name: "Caption", Type: "string", Default: `""`, Description: "Optional accessible table caption."},
+			{Name: "SortBy", Type: "string", Default: `""`, Description: "Initial sort column key."},
+			{Name: "SortDir", Type: "SortDir", Default: "SortNone", Description: `Initial sort direction: "asc", "desc", or "" (none).`},
+			{Name: "HTMXEndpoint", Type: "string", Default: `""`, Description: "Server URL that returns row HTML for sort/page/filter/lazy/infinite."},
+			{Name: "HTMXTarget", Type: "string", Default: `""`, Description: "Override the default tbody swap target."},
+			{Name: "LazyLoad", Type: "bool", Default: "false", Description: "Fetch the tbody from HTMXEndpoint on page load."},
+			{Name: "Pagination", Type: "*PaginationConfig", Default: "nil", Description: "Pagination/infinite-scroll config (CurrentPage, TotalPages, PerPage, Mode, ...)."},
+			{Name: "Filters", Type: "*FilterConfig", Default: "nil", Description: "Filter bar config (Variant, Collapsible, Filters[]: search/select/toggle)."},
+			{Name: "ExtraQueryParams", Type: "string", Default: `""`, Description: "Extra query string appended to every HTMX request."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the table container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// tableDemoPreview renders the Goshtoso table preview
-func tableDemoPreview() templ.Component {
+// tableDefaultPreview renders the default static table.
+func tableDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -158,7 +335,7 @@ func tableDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-5xl mx-auto space-y-12\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Table</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"table-default\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -169,7 +346,37 @@ func tableDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Striped Table</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tableStripedPreview renders the striped variant.
+func tableStripedPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"table-striped\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -181,7 +388,37 @@ func tableDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Table with Action</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tableActionPreview renders a table with an action button column.
+func tableActionPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"table-action\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -192,7 +429,37 @@ func tableDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Table with Checkbox</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tableCheckboxPreview renders the checkbox-select variant.
+func tableCheckboxPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"table-checkbox\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -204,7 +471,37 @@ func tableDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Users Table</h4>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tableUsersPreview renders the rich users table (avatars, badges, actions).
+func tableUsersPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"table-users\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -215,7 +512,37 @@ func tableDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Sortable Table (click headers)</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2\">Click column headers to sort. Uses HTMX to fetch sorted data from the server.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tableSortablePreview renders the HTMX sortable table.
+func tableSortablePreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"table-sortable\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -230,7 +557,37 @@ func tableDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Lazy-Loaded Table</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2\">Table body loads from the server via HTMX on page load.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tableLazyPreview renders the lazy-loaded table.
+func tableLazyPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"table-lazy\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -243,7 +600,37 @@ func tableDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Paginated Table</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2\">Navigate between pages with HTMX-powered pagination controls.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tablePaginatedPreview renders the paginated table.
+func tablePaginatedPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"table-paginated\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -257,7 +644,37 @@ func tableDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Filtered Table</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2\">Search and filter table data with HTMX-powered filter controls.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tableFilteredPreview renders the filter-bar (collapsible) table.
+func tableFilteredPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div id=\"table-filtered\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -298,7 +715,37 @@ func tableDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Inline Filter Variant</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2\">Same filter controls, no bordered block, no collapsible toggle. Suitable for modal bodies or toolbar strips where the host already provides chrome.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tableInlineFilteredPreview renders the inline filter variant.
+func tableInlineFilteredPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div id=\"table-inline-filtered\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -336,7 +783,37 @@ func tableDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Infinite Scroll Table</h4><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2\">Scroll down in the container to automatically load more rows via HTMX.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tableInfinitePreview renders the infinite-scroll table.
+func tableInfinitePreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div id=\"table-infinite\" class=\"w-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -356,7 +833,7 @@ func tableDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/tabs.templ
+++ b/internal/pages/demo/components/tabs.templ
@@ -10,136 +10,169 @@ templ TabsDemoPage() {
 	@demo.Layout("Tabs", "tabs", tabsDemoContent())
 }
 
-// tabsDemoContent renders all tab variant demos
+// tabsDemoContent renders the demo. Each tabs variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/tabs).
+// Wrapped in #tabs-fragment.
 templ tabsDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Tabs",
-			Description:   "Tabs organize content into multiple panels, allowing users to navigate between them. They support keyboard navigation, icons, and badges.",
-		},
-		tabsDemoPreview(),
-		`// Default Tabs
-@tabs.Tabs(tabs.Config{
+	<div id="tabs-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Tabs",
+				Description: "Organize content into switchable panels. Supports keyboard navigation, icons, badges, HTMX lazy-loaded panels, and URL-hash sync.",
+			},
+			tabsDefaultPreview(),
+			`@tabs.Tabs(tabs.Config{
     ID: "demo",
     Tabs: []tabs.Tab{
         {ID: "groups", Label: "Groups", Content: groupsContent()},
         {ID: "likes", Label: "Likes", Content: likesContent()},
-        {ID: "comments", Label: "Comments", Content: commentsContent()},
-        {ID: "saved", Label: "Saved", Content: savedContent()},
     },
-})
+})`,
+		)
 
-// Tabs with Icons
-@tabs.Tabs(tabs.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Icons",
+				Description: "Give each Tab an Icon component to render before its label.",
+			},
+			tabsIconPreview(),
+			`@tabs.Tabs(tabs.Config{
     ID: "icon-demo",
     Tabs: []tabs.Tab{
         {ID: "groups", Label: "Groups", Icon: groupsIcon(), Content: groupsContent()},
         {ID: "likes", Label: "Likes", Icon: likesIcon(), Content: likesContent()},
     },
-})
+})`,
+		)
 
-// Tabs with Icons and Badges
-@tabs.Tabs(tabs.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Icons and Badges",
+				Description: "Set Tab.Badge to show a count pill alongside the label.",
+			},
+			tabsBadgePreview(),
+			`@tabs.Tabs(tabs.Config{
     ID: "badge-demo",
     Tabs: []tabs.Tab{
         {ID: "groups", Label: "Groups", Icon: groupsIcon(), Badge: "2", Content: groupsContent()},
         {ID: "likes", Label: "Likes", Icon: likesIcon(), Badge: "3124", Content: likesContent()},
     },
-})
+})`,
+		)
 
-// Tabs with HTMX Lazy Loading
-@tabs.Tabs(tabs.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "HTMX Lazy Loading",
+				Description: "Give a Tab an HTMX config instead of Content; its panel is fetched from the server the first time it's opened.",
+			},
+			tabsHTMXPreview(),
+			`@tabs.Tabs(tabs.Config{
     ID: "htmx-demo",
     Tabs: []tabs.Tab{
         {ID: "overview", Label: "Overview", Content: overviewContent()},
         {ID: "details", Label: "Details", HTMX: &tabs.TabHTMX{Get: "/api/components/tab-content/details"}},
-        {ID: "activity", Label: "Activity", HTMX: &tabs.TabHTMX{Get: "/api/components/tab-content/activity"}},
     },
-})
+})`,
+		)
 
-// Tabs with URL Hash Sync
-@tabs.Tabs(tabs.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "URL Hash Sync",
+				Description: "SyncHash: true mirrors the active tab in the URL fragment, so switching updates the hash and deep links like #comments restore on load.",
+			},
+			tabsHashPreview(),
+			`@tabs.Tabs(tabs.Config{
     ID:       "my-tabs",
     SyncHash: true,
     Tabs: []tabs.Tab{
-        {ID: "members", Label: "Members", Content: membersContent()},
-        {ID: "clusters", Label: "Clusters", Content: clustersContent()},
+        {ID: "groups", Label: "Groups", Content: groupsContent()},
+        {ID: "comments", Label: "Comments", Content: commentsContent()},
     },
 })`,
-	)
+		)
+	</div>
+	// API reference lives outside #tabs-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique tab-set id (scopes Alpine state and panel ids)."},
+		{Name: "Tabs", Type: "[]Tab", Default: "nil", Description: "Tab definitions (ID, Label, optional Icon, Badge, Content, HTMX)."},
+		{Name: "DefaultTab", Type: "string", Default: `""`, Description: "ID of the initially active tab (defaults to the first)."},
+		{Name: "SyncHash", Type: "bool", Default: "false", Description: "Mirror the active tab in the URL fragment."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the tab-set container."},
+	})
 }
 
-// tabsDemoPreview renders all tab variants
-templ tabsDemoPreview() {
-	<div class="space-y-12">
-		<!-- Default Tabs -->
-		<div>
-			<h3 class="text-sm font-medium text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Default Tabs</h3>
-			@tabs.Tabs(tabs.Config{
-				ID: "default",
-				Tabs: []tabs.Tab{
-					{ID: "groups", Label: "Groups", Content: tabContent("Groups")},
-					{ID: "likes", Label: "Likes", Content: tabContent("Likes")},
-					{ID: "comments", Label: "Comments", Content: tabContent("Comments")},
-					{ID: "saved", Label: "Saved", Content: tabContent("Saved")},
-				},
-			})
-		</div>
+// tabsDefaultPreview renders the default tabs.
+templ tabsDefaultPreview() {
+	<div id="tabs-default" class="w-full max-w-2xl mx-auto">
+		@tabs.Tabs(tabs.Config{
+			ID: "default",
+			Tabs: []tabs.Tab{
+				{ID: "groups", Label: "Groups", Content: tabContent("Groups")},
+				{ID: "likes", Label: "Likes", Content: tabContent("Likes")},
+				{ID: "comments", Label: "Comments", Content: tabContent("Comments")},
+				{ID: "saved", Label: "Saved", Content: tabContent("Saved")},
+			},
+		})
+	</div>
+}
 
-		<!-- Tabs with Icons -->
-		<div>
-			<h3 class="text-sm font-medium text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Tabs with Icon</h3>
-			@tabs.Tabs(tabs.Config{
-				ID: "icon",
-				Tabs: []tabs.Tab{
-					{ID: "groups", Label: "Groups", Icon: groupsIcon(), Content: tabContent("Groups")},
-					{ID: "likes", Label: "Likes", Icon: likesIcon(), Content: tabContent("Likes")},
-					{ID: "comments", Label: "Comments", Icon: commentsIcon(), Content: tabContent("Comments")},
-					{ID: "saved", Label: "Saved", Icon: savedIcon(), Content: tabContent("Saved")},
-				},
-			})
-		</div>
+// tabsIconPreview renders tabs with icons.
+templ tabsIconPreview() {
+	<div id="tabs-icons" class="w-full max-w-2xl mx-auto">
+		@tabs.Tabs(tabs.Config{
+			ID: "icon",
+			Tabs: []tabs.Tab{
+				{ID: "groups", Label: "Groups", Icon: groupsIcon(), Content: tabContent("Groups")},
+				{ID: "likes", Label: "Likes", Icon: likesIcon(), Content: tabContent("Likes")},
+				{ID: "comments", Label: "Comments", Icon: commentsIcon(), Content: tabContent("Comments")},
+				{ID: "saved", Label: "Saved", Icon: savedIcon(), Content: tabContent("Saved")},
+			},
+		})
+	</div>
+}
 
-		<!-- Tabs with Icons and Badges -->
-		<div>
-			<h3 class="text-sm font-medium text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Tabs with Icon and Badge</h3>
-			@tabs.Tabs(tabs.Config{
-				ID: "badge",
-				Tabs: []tabs.Tab{
-					{ID: "groups", Label: "Groups", Icon: groupsIcon(), Badge: "2", Content: tabContent("Groups")},
-					{ID: "likes", Label: "Likes", Icon: likesIcon(), Badge: "3124", Content: tabContent("Likes")},
-					{ID: "comments", Label: "Comments", Icon: commentsIcon(), Badge: "243", Content: tabContent("Comments")},
-					{ID: "saved", Label: "Saved", Icon: savedIcon(), Badge: "32", Content: tabContent("Saved")},
-				},
-			})
-		</div>
-		<!-- Tabs with HTMX Lazy Loading -->
-		<div>
-			<h3 class="text-sm font-medium text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Tabs with HTMX Lazy Loading</h3>
-			@tabs.Tabs(tabs.Config{
-				ID: "htmx",
-				Tabs: []tabs.Tab{
-					{ID: "overview", Label: "Overview", Content: tabContent("Overview")},
-					{ID: "details", Label: "Details", HTMX: &tabs.TabHTMX{Get: "/api/components/tab-content/details"}},
-					{ID: "activity", Label: "Activity", HTMX: &tabs.TabHTMX{Get: "/api/components/tab-content/activity"}},
-				},
-			})
-		</div>
-		<!-- Tabs with Hash Sync -->
-		<div>
-			<h3 class="text-sm font-medium text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Tabs with URL Hash Sync</h3>
-			<p class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2">Selected tab syncs with the URL fragment. Try switching tabs — the hash updates. Refresh with <code class="bg-surface-alt dark:bg-surface-dark-alt px-1 rounded">#comments</code> in the URL.</p>
-			@tabs.Tabs(tabs.Config{
-				ID:       "hash-sync",
-				SyncHash: true,
-				Tabs: []tabs.Tab{
-					{ID: "groups", Label: "Groups", Icon: groupsIcon(), Content: tabContent("Groups")},
-					{ID: "likes", Label: "Likes", Icon: likesIcon(), Content: tabContent("Likes")},
-					{ID: "comments", Label: "Comments", Icon: commentsIcon(), Content: tabContent("Comments")},
-					{ID: "saved", Label: "Saved", Icon: savedIcon(), Content: tabContent("Saved")},
-				},
-			})
-		</div>
+// tabsBadgePreview renders tabs with icons and badges.
+templ tabsBadgePreview() {
+	<div id="tabs-badges" class="w-full max-w-2xl mx-auto">
+		@tabs.Tabs(tabs.Config{
+			ID: "badge",
+			Tabs: []tabs.Tab{
+				{ID: "groups", Label: "Groups", Icon: groupsIcon(), Badge: "2", Content: tabContent("Groups")},
+				{ID: "likes", Label: "Likes", Icon: likesIcon(), Badge: "3124", Content: tabContent("Likes")},
+				{ID: "comments", Label: "Comments", Icon: commentsIcon(), Badge: "243", Content: tabContent("Comments")},
+				{ID: "saved", Label: "Saved", Icon: savedIcon(), Badge: "32", Content: tabContent("Saved")},
+			},
+		})
+	</div>
+}
+
+// tabsHTMXPreview renders HTMX lazy-loaded tabs.
+templ tabsHTMXPreview() {
+	<div id="tabs-htmx" class="w-full max-w-2xl mx-auto">
+		@tabs.Tabs(tabs.Config{
+			ID: "htmx",
+			Tabs: []tabs.Tab{
+				{ID: "overview", Label: "Overview", Content: tabContent("Overview")},
+				{ID: "details", Label: "Details", HTMX: &tabs.TabHTMX{Get: "/api/components/tab-content/details"}},
+				{ID: "activity", Label: "Activity", HTMX: &tabs.TabHTMX{Get: "/api/components/tab-content/activity"}},
+			},
+		})
+	</div>
+}
+
+// tabsHashPreview renders the URL-hash-synced tabs.
+templ tabsHashPreview() {
+	<div id="tabs-hash" class="w-full max-w-2xl mx-auto">
+		@tabs.Tabs(tabs.Config{
+			ID:       "hash-sync",
+			SyncHash: true,
+			Tabs: []tabs.Tab{
+				{ID: "groups", Label: "Groups", Icon: groupsIcon(), Content: tabContent("Groups")},
+				{ID: "likes", Label: "Likes", Icon: likesIcon(), Content: tabContent("Likes")},
+				{ID: "comments", Label: "Comments", Icon: commentsIcon(), Content: tabContent("Comments")},
+				{ID: "saved", Label: "Saved", Icon: savedIcon(), Content: tabContent("Saved")},
+			},
+		})
 	</div>
 }
 

--- a/internal/pages/demo/components/tabs_templ.go
+++ b/internal/pages/demo/components/tabs_templ.go
@@ -43,7 +43,9 @@ func TabsDemoPage() templ.Component {
 	})
 }
 
-// tabsDemoContent renders all tab variant demos
+// tabsDemoContent renders the demo. Each tabs variant lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/tabs).
+// Wrapped in #tabs-fragment.
 func tabsDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,61 +67,107 @@ func tabsDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"tabs-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Tabs",
-				Description: "Tabs organize content into multiple panels, allowing users to navigate between them. They support keyboard navigation, icons, and badges.",
+				Description: "Organize content into switchable panels. Supports keyboard navigation, icons, badges, HTMX lazy-loaded panels, and URL-hash sync.",
 			},
-			tabsDemoPreview(),
-			`// Default Tabs
-@tabs.Tabs(tabs.Config{
+			tabsDefaultPreview(),
+			`@tabs.Tabs(tabs.Config{
     ID: "demo",
     Tabs: []tabs.Tab{
         {ID: "groups", Label: "Groups", Content: groupsContent()},
         {ID: "likes", Label: "Likes", Content: likesContent()},
-        {ID: "comments", Label: "Comments", Content: commentsContent()},
-        {ID: "saved", Label: "Saved", Content: savedContent()},
     },
-})
-
-// Tabs with Icons
-@tabs.Tabs(tabs.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Icons",
+				Description: "Give each Tab an Icon component to render before its label.",
+			},
+			tabsIconPreview(),
+			`@tabs.Tabs(tabs.Config{
     ID: "icon-demo",
     Tabs: []tabs.Tab{
         {ID: "groups", Label: "Groups", Icon: groupsIcon(), Content: groupsContent()},
         {ID: "likes", Label: "Likes", Icon: likesIcon(), Content: likesContent()},
     },
-})
-
-// Tabs with Icons and Badges
-@tabs.Tabs(tabs.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Icons and Badges",
+				Description: "Set Tab.Badge to show a count pill alongside the label.",
+			},
+			tabsBadgePreview(),
+			`@tabs.Tabs(tabs.Config{
     ID: "badge-demo",
     Tabs: []tabs.Tab{
         {ID: "groups", Label: "Groups", Icon: groupsIcon(), Badge: "2", Content: groupsContent()},
         {ID: "likes", Label: "Likes", Icon: likesIcon(), Badge: "3124", Content: likesContent()},
     },
-})
-
-// Tabs with HTMX Lazy Loading
-@tabs.Tabs(tabs.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "HTMX Lazy Loading",
+				Description: "Give a Tab an HTMX config instead of Content; its panel is fetched from the server the first time it's opened.",
+			},
+			tabsHTMXPreview(),
+			`@tabs.Tabs(tabs.Config{
     ID: "htmx-demo",
     Tabs: []tabs.Tab{
         {ID: "overview", Label: "Overview", Content: overviewContent()},
         {ID: "details", Label: "Details", HTMX: &tabs.TabHTMX{Get: "/api/components/tab-content/details"}},
-        {ID: "activity", Label: "Activity", HTMX: &tabs.TabHTMX{Get: "/api/components/tab-content/activity"}},
-    },
-})
-
-// Tabs with URL Hash Sync
-@tabs.Tabs(tabs.Config{
-    ID:       "my-tabs",
-    SyncHash: true,
-    Tabs: []tabs.Tab{
-        {ID: "members", Label: "Members", Content: membersContent()},
-        {ID: "clusters", Label: "Clusters", Content: clustersContent()},
     },
 })`,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "URL Hash Sync",
+				Description: "SyncHash: true mirrors the active tab in the URL fragment, so switching updates the hash and deep links like #comments restore on load.",
+			},
+			tabsHashPreview(),
+			`@tabs.Tabs(tabs.Config{
+    ID:       "my-tabs",
+    SyncHash: true,
+    Tabs: []tabs.Tab{
+        {ID: "groups", Label: "Groups", Content: groupsContent()},
+        {ID: "comments", Label: "Comments", Content: commentsContent()},
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique tab-set id (scopes Alpine state and panel ids)."},
+			{Name: "Tabs", Type: "[]Tab", Default: "nil", Description: "Tab definitions (ID, Label, optional Icon, Badge, Content, HTMX)."},
+			{Name: "DefaultTab", Type: "string", Default: `""`, Description: "ID of the initially active tab (defaults to the first)."},
+			{Name: "SyncHash", Type: "bool", Default: "false", Description: "Mirror the active tab in the URL fragment."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the tab-set container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -127,8 +175,8 @@ func tabsDemoContent() templ.Component {
 	})
 }
 
-// tabsDemoPreview renders all tab variants
-func tabsDemoPreview() templ.Component {
+// tabsDefaultPreview renders the default tabs.
+func tabsDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -149,7 +197,7 @@ func tabsDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"space-y-12\"><!-- Default Tabs --><div><h3 class=\"text-sm font-medium text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Default Tabs</h3>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"tabs-default\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -165,7 +213,37 @@ func tabsDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><!-- Tabs with Icons --><div><h3 class=\"text-sm font-medium text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Tabs with Icon</h3>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tabsIconPreview renders tabs with icons.
+func tabsIconPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"tabs-icons\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -181,7 +259,37 @@ func tabsDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><!-- Tabs with Icons and Badges --><div><h3 class=\"text-sm font-medium text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Tabs with Icon and Badge</h3>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tabsBadgePreview renders tabs with icons and badges.
+func tabsBadgePreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"tabs-badges\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -197,7 +305,37 @@ func tabsDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><!-- Tabs with HTMX Lazy Loading --><div><h3 class=\"text-sm font-medium text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Tabs with HTMX Lazy Loading</h3>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tabsHTMXPreview renders HTMX lazy-loaded tabs.
+func tabsHTMXPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"tabs-htmx\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -212,7 +350,37 @@ func tabsDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div><!-- Tabs with Hash Sync --><div><h3 class=\"text-sm font-medium text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Tabs with URL Hash Sync</h3><p class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted mb-2\">Selected tab syncs with the URL fragment. Try switching tabs — the hash updates. Refresh with <code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1 rounded\">#comments</code> in the URL.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tabsHashPreview renders the URL-hash-synced tabs.
+func tabsHashPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"tabs-hash\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -229,7 +397,7 @@ func tabsDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -254,25 +422,25 @@ func tabContent(name string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var4 == nil {
-			templ_7745c5c3_Var4 = templ.NopComponent
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<b><a href=\"#\" class=\"underline\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<b><a href=\"#\" class=\"underline\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/pages/demo/components/tabs.templ`, Line: 148, Col: 40}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/pages/demo/components/tabs.templ`, Line: 181, Col: 40}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</a></b> tab is selected")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</a></b> tab is selected")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -297,12 +465,12 @@ func groupsIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" aria-hidden=\"true\" class=\"size-4\"><path d=\"M10 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM6 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM1.49 15.326a.78.78 0 0 1-.358-.442 3 3 0 0 1 4.308-3.516 6.484 6.484 0 0 0-1.905 3.959c-.023.222-.014.442.025.654a4.97 4.97 0 0 1-2.07-.655ZM16.44 15.98a4.97 4.97 0 0 0 2.07-.654.78.78 0 0 0 .357-.442 3 3 0 0 0-4.308-3.517 6.484 6.484 0 0 1 1.907 3.96 2.32 2.32 0 0 1-.026.654ZM18 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM5.304 16.19a.844.844 0 0 1-.277-.71 5 5 0 0 1 9.947 0 .843.843 0 0 1-.277.71A6.975 6.975 0 0 1 10 18a6.974 6.974 0 0 1-4.696-1.81Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" aria-hidden=\"true\" class=\"size-4\"><path d=\"M10 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM6 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM1.49 15.326a.78.78 0 0 1-.358-.442 3 3 0 0 1 4.308-3.516 6.484 6.484 0 0 0-1.905 3.959c-.023.222-.014.442.025.654a4.97 4.97 0 0 1-2.07-.655ZM16.44 15.98a4.97 4.97 0 0 0 2.07-.654.78.78 0 0 0 .357-.442 3 3 0 0 0-4.308-3.517 6.484 6.484 0 0 1 1.907 3.96 2.32 2.32 0 0 1-.026.654ZM18 8a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM5.304 16.19a.844.844 0 0 1-.277-.71 5 5 0 0 1 9.947 0 .843.843 0 0 1-.277.71A6.975 6.975 0 0 1 10 18a6.974 6.974 0 0 1-4.696-1.81Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -326,12 +494,12 @@ func likesIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" aria-hidden=\"true\" class=\"size-4\"><path d=\"m9.653 16.915-.005-.003-.019-.01a20.759 20.759 0 0 1-1.162-.682 22.045 22.045 0 0 1-2.582-1.9C4.045 12.733 2 10.352 2 7.5a4.5 4.5 0 0 1 8-2.828A4.5 4.5 0 0 1 18 7.5c0 2.852-2.044 5.233-3.885 6.82a22.049 22.049 0 0 1-3.744 2.582l-.019.01-.005.003h-.002a.739.739 0 0 1-.69.001l-.002-.001Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" aria-hidden=\"true\" class=\"size-4\"><path d=\"m9.653 16.915-.005-.003-.019-.01a20.759 20.759 0 0 1-1.162-.682 22.045 22.045 0 0 1-2.582-1.9C4.045 12.733 2 10.352 2 7.5a4.5 4.5 0 0 1 8-2.828A4.5 4.5 0 0 1 18 7.5c0 2.852-2.044 5.233-3.885 6.82a22.049 22.049 0 0 1-3.744 2.582l-.019.01-.005.003h-.002a.739.739 0 0 1-.69.001l-.002-.001Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -355,12 +523,12 @@ func commentsIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" aria-hidden=\"true\" class=\"size-4\"><path d=\"M3.505 2.365A41.369 41.369 0 0 1 9 2c1.863 0 3.697.124 5.495.365 1.247.167 2.18 1.108 2.435 2.268a4.45 4.45 0 0 0-.577-.069 43.141 43.141 0 0 0-4.706 0C9.229 4.696 7.5 6.727 7.5 8.998v2.24c0 1.413.67 2.735 1.76 3.562l-2.98 2.98A.75.75 0 0 1 5 17.25v-3.443c-.501-.048-1-.106-1.495-.172C2.033 13.438 1 12.162 1 10.72V5.28c0-1.441 1.033-2.717 2.505-2.914Z\"></path> <path d=\"M14 6c-.762 0-1.52.02-2.271.062C10.157 6.148 9 7.472 9 8.998v2.24c0 1.519 1.147 2.839 2.71 2.935.214.013.428.024.642.034.2.009.385.09.518.224l2.35 2.35a.75.75 0 0 0 1.28-.531v-2.07c1.453-.195 2.5-1.463 2.5-2.915V8.998c0-1.526-1.157-2.85-2.729-2.936A41.645 41.645 0 0 0 14 6Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" aria-hidden=\"true\" class=\"size-4\"><path d=\"M3.505 2.365A41.369 41.369 0 0 1 9 2c1.863 0 3.697.124 5.495.365 1.247.167 2.18 1.108 2.435 2.268a4.45 4.45 0 0 0-.577-.069 43.141 43.141 0 0 0-4.706 0C9.229 4.696 7.5 6.727 7.5 8.998v2.24c0 1.413.67 2.735 1.76 3.562l-2.98 2.98A.75.75 0 0 1 5 17.25v-3.443c-.501-.048-1-.106-1.495-.172C2.033 13.438 1 12.162 1 10.72V5.28c0-1.441 1.033-2.717 2.505-2.914Z\"></path> <path d=\"M14 6c-.762 0-1.52.02-2.271.062C10.157 6.148 9 7.472 9 8.998v2.24c0 1.519 1.147 2.839 2.71 2.935.214.013.428.024.642.034.2.009.385.09.518.224l2.35 2.35a.75.75 0 0 0 1.28-.531v-2.07c1.453-.195 2.5-1.463 2.5-2.915V8.998c0-1.526-1.157-2.85-2.729-2.936A41.645 41.645 0 0 0 14 6Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -384,12 +552,12 @@ func savedIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" aria-hidden=\"true\" class=\"size-4\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M10 2c-1.716 0-3.408.106-5.07.31C3.806 2.45 3 3.414 3 4.517V17.25a.75.75 0 0 0 1.075.676L10 15.082l5.925 2.844A.75.75 0 0 0 17 17.25V4.517c0-1.103-.806-2.068-1.93-2.207A41.403 41.403 0 0 0 10 2Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 20 20\" fill=\"currentColor\" aria-hidden=\"true\" class=\"size-4\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M10 2c-1.716 0-3.408.106-5.07.31C3.806 2.45 3 3.414 3 4.517V17.25a.75.75 0 0 0 1.075.676L10 15.082l5.925 2.844A.75.75 0 0 0 17 17.25V4.517c0-1.103-.806-2.068-1.93-2.207A41.403 41.403 0 0 0 10 2Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/tagslist.templ
+++ b/internal/pages/demo/components/tagslist.templ
@@ -11,71 +11,92 @@ templ TagsListDemoPage() {
 }
 
 templ tagsListDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:       "Tags List",
-			Description: "A list of removable tag chips with an input and Add button for appending new tags. Submits as name[0], name[1], ... via hidden inputs.",
-		},
-		tagsListDemoPreview(),
-		`// Tags List with initial values
-@tagslist.TagsList(tagslist.Config{
+	<div id="tagslist-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Tags List",
+				Description: "Removable tag chips with an input and Add button for appending new tags. Submits as name[0], name[1], ... via hidden inputs.",
+			},
+			tagsListInitialPreview(),
+			`@tagslist.TagsList(tagslist.Config{
     ID:          "tags",
     Name:        "tags",
     Values:      []string{"production", "gpu"},
     Placeholder: "Add a tag...",
-})
+})`,
+		)
 
-// Empty Tags List
-@tagslist.TagsList(tagslist.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Empty (Start Adding)",
+				Description: "With no Values, the list starts empty and grows as the user adds tags.",
+			},
+			tagsListEmptyPreview(),
+			`@tagslist.TagsList(tagslist.Config{
     ID:          "labels",
     Name:        "labels",
     Placeholder: "Add a label...",
     AddLabel:    "Add",
-})
+})`,
+		)
 
-// Disabled (read-only chips)
-@tagslist.TagsList(tagslist.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true renders read-only chips with no input or remove buttons.",
+			},
+			tagsListDisabledPreview(),
+			`@tagslist.TagsList(tagslist.Config{
     ID:       "lockedTags",
     Name:     "locked",
     Values:   []string{"locked", "readonly"},
     Disabled: true,
 })`,
-	)
+		)
+	</div>
+	// API reference lives outside #tagslist-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the tags-list root and input."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Base form field name (submits as name[0], name[1], ...)."},
+		{Name: "Values", Type: "[]string", Default: "nil", Description: "Initial tag values."},
+		{Name: "Placeholder", Type: "string", Default: `""`, Description: "Input placeholder."},
+		{Name: "AddLabel", Type: "string", Default: `"Add"`, Description: "Label of the add button."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Render read-only chips (no input/remove)."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+	})
 }
 
-templ tagsListDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">With Initial Values</h4>
-			<div class="max-w-md">
-				@tagslist.TagsList(tagslist.Config{
-					ID:          "tagsDemo",
-					Name:        "tags",
-					Values:      []string{"production", "critical", "gpu"},
-					Placeholder: "Add a tag...",
-				})
-			</div>
-		</div>
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Empty (Start Adding)</h4>
-			<div class="max-w-md">
-				@tagslist.TagsList(tagslist.Config{
-					ID:          "labelsDemo",
-					Name:        "labels",
-					Placeholder: "Add a label...",
-				})
-			</div>
-		</div>
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Disabled</h4>
-			<div class="max-w-md">
-				@tagslist.TagsList(tagslist.Config{
-					ID:       "disabledTagsDemo",
-					Name:     "disabled-tags",
-					Values:   []string{"locked", "readonly"},
-					Disabled: true,
-				})
-			</div>
-		</div>
+// tagsListInitialPreview renders a tags list with initial values.
+templ tagsListInitialPreview() {
+	<div id="tagslist-initial" class="w-full max-w-md mx-auto">
+		@tagslist.TagsList(tagslist.Config{
+			ID:          "tagsDemo",
+			Name:        "tags",
+			Values:      []string{"production", "critical", "gpu"},
+			Placeholder: "Add a tag...",
+		})
+	</div>
+}
+
+// tagsListEmptyPreview renders an empty tags list.
+templ tagsListEmptyPreview() {
+	<div id="tagslist-empty" class="w-full max-w-md mx-auto">
+		@tagslist.TagsList(tagslist.Config{
+			ID:          "labelsDemo",
+			Name:        "labels",
+			Placeholder: "Add a label...",
+		})
+	</div>
+}
+
+// tagsListDisabledPreview renders a disabled (read-only) tags list.
+templ tagsListDisabledPreview() {
+	<div id="tagslist-disabled" class="w-full max-w-md mx-auto">
+		@tagslist.TagsList(tagslist.Config{
+			ID:       "disabledTagsDemo",
+			Name:     "disabled-tags",
+			Values:   []string{"locked", "readonly"},
+			Disabled: true,
+		})
 	</div>
 }

--- a/internal/pages/demo/components/tagslist_templ.go
+++ b/internal/pages/demo/components/tagslist_templ.go
@@ -64,30 +64,49 @@ func tagsListDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"tagslist-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Tags List",
-				Description: "A list of removable tag chips with an input and Add button for appending new tags. Submits as name[0], name[1], ... via hidden inputs.",
+				Description: "Removable tag chips with an input and Add button for appending new tags. Submits as name[0], name[1], ... via hidden inputs.",
 			},
-			tagsListDemoPreview(),
-			`// Tags List with initial values
-@tagslist.TagsList(tagslist.Config{
+			tagsListInitialPreview(),
+			`@tagslist.TagsList(tagslist.Config{
     ID:          "tags",
     Name:        "tags",
     Values:      []string{"production", "gpu"},
     Placeholder: "Add a tag...",
-})
-
-// Empty Tags List
-@tagslist.TagsList(tagslist.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Empty (Start Adding)",
+				Description: "With no Values, the list starts empty and grows as the user adds tags.",
+			},
+			tagsListEmptyPreview(),
+			`@tagslist.TagsList(tagslist.Config{
     ID:          "labels",
     Name:        "labels",
     Placeholder: "Add a label...",
     AddLabel:    "Add",
-})
-
-// Disabled (read-only chips)
-@tagslist.TagsList(tagslist.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true renders read-only chips with no input or remove buttons.",
+			},
+			tagsListDisabledPreview(),
+			`@tagslist.TagsList(tagslist.Config{
     ID:       "lockedTags",
     Name:     "locked",
     Values:   []string{"locked", "readonly"},
@@ -97,11 +116,28 @@ func tagsListDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the tags-list root and input."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Base form field name (submits as name[0], name[1], ...)."},
+			{Name: "Values", Type: "[]string", Default: "nil", Description: "Initial tag values."},
+			{Name: "Placeholder", Type: "string", Default: `""`, Description: "Input placeholder."},
+			{Name: "AddLabel", Type: "string", Default: `"Add"`, Description: "Label of the add button."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Render read-only chips (no input/remove)."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-func tagsListDemoPreview() templ.Component {
+// tagsListInitialPreview renders a tags list with initial values.
+func tagsListInitialPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -122,7 +158,7 @@ func tagsListDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">With Initial Values</h4><div class=\"max-w-md\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"tagslist-initial\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -135,7 +171,37 @@ func tagsListDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Empty (Start Adding)</h4><div class=\"max-w-md\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tagsListEmptyPreview renders an empty tags list.
+func tagsListEmptyPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"tagslist-empty\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -147,7 +213,37 @@ func tagsListDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Disabled</h4><div class=\"max-w-md\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tagsListDisabledPreview renders a disabled (read-only) tags list.
+func tagsListDisabledPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"tagslist-disabled\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -160,7 +256,7 @@ func tagsListDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/textarea.templ
+++ b/internal/pages/demo/components/textarea.templ
@@ -10,132 +10,163 @@ templ TextareaDemoPage() {
 	@demo.Layout("Textarea", "textarea", textareaDemoContent())
 }
 
-// textareaDemoContent renders the actual content inside the layout
+// textareaDemoContent renders the demo. Each textarea variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/textarea). Wrapped in #textarea-fragment.
 templ textareaDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Textarea",
-			Description:   "A textarea is a multi-line text input field for longer form content like comments, messages, and descriptions.",
-		},
-		textareaDemoPreview(),
-		`// Default Textarea
-@textarea.Textarea(textarea.Config{
+	<div id="textarea-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Textarea",
+				Description: "A multi-line text input for longer content — comments, messages, descriptions. Supports validation states, disabled, and an actions variant.",
+			},
+			textareaDefaultPreview(),
+			`@textarea.Textarea(textarea.Config{
     ID:          "comment",
     Name:        "comment",
     Label:       "Comment",
     Placeholder: "We'd love to hear from you...",
     Rows:        3,
-})
+})`,
+		)
 
-// Error State
-@textarea.Textarea(textarea.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Error State",
+				Description: "State: textarea.StateError recolors the border and HelperText for validation errors.",
+			},
+			textareaErrorPreview(),
+			`@textarea.Textarea(textarea.Config{
     ID:         "comment-error",
     Name:       "comment",
     Label:      "Comment",
     State:      textarea.StateError,
     HelperText: "Error: Please add some comments to your evaluation",
     Rows:       3,
-})
+})`,
+		)
 
-// Success State
-@textarea.Textarea(textarea.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Success State",
+				Description: "State: textarea.StateSuccess applies the success styling.",
+			},
+			textareaSuccessPreview(),
+			`@textarea.Textarea(textarea.Config{
     ID:    "comment-success",
     Name:  "comment",
     Label: "Comment",
     State: textarea.StateSuccess,
     Rows:  3,
-})
+})`,
+		)
 
-// Disabled Textarea
-@textarea.Textarea(textarea.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks editing and dims the field.",
+			},
+			textareaDisabledPreview(),
+			`@textarea.Textarea(textarea.Config{
     ID:          "comment-disabled",
     Name:        "comment",
     Label:       "Comment",
     Placeholder: "This textarea is disabled",
     Disabled:    true,
-})
+})`,
+		)
 
-// Textarea with Actions
-@textarea.TextareaWithActions(textarea.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Actions",
+				Description: "textarea.TextareaWithActions wraps the field with a toolbar/footer for inline actions.",
+			},
+			textareaActionsPreview(),
+			`@textarea.TextareaWithActions(textarea.Config{
     ID:          "message",
     Name:        "message",
     Placeholder: "Type your message here...",
     Rows:        6,
 })`,
-	)
+		)
+	</div>
+	// API reference lives outside #textarea-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the textarea (and label's for target)."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+		{Name: "Label", Type: "string", Default: `""`, Description: "Label above the textarea."},
+		{Name: "Placeholder", Type: "string", Default: `""`, Description: "Placeholder when empty."},
+		{Name: "Value", Type: "string", Default: `""`, Description: "Current value."},
+		{Name: "Rows", Type: "int", Default: "0", Description: "Visible rows (height)."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable the textarea."},
+		{Name: "ReadOnly", Type: "bool", Default: "false", Description: "Non-editable but submittable."},
+		{Name: "State", Type: "State", Default: "StateDefault", Description: `Validation state: "" (default), "error", "success".`},
+		{Name: "HelperText", Type: "string", Default: `""`, Description: "Text below the field, recolored by State."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+	})
 }
 
-// textareaDemoPreview renders the Goshtoso textarea preview
-templ textareaDemoPreview() {
-	<div class="w-full max-w-5xl mx-auto space-y-12">
-		// Default Textarea
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Textarea</h4>
-			<div class="flex flex-wrap gap-6">
-				@textarea.Textarea(textarea.Config{
-					ID:          "demo-default",
-					Name:        "comment",
-					Label:       "Comment",
-					Placeholder: "We'd love to hear from you...",
-					Rows:        3,
-				})
-			</div>
-		</div>
+// textareaDefaultPreview renders the default textarea.
+templ textareaDefaultPreview() {
+	<div id="textarea-default" class="w-full max-w-md mx-auto">
+		@textarea.Textarea(textarea.Config{
+			ID:          "demo-default",
+			Name:        "comment",
+			Label:       "Comment",
+			Placeholder: "We'd love to hear from you...",
+			Rows:        3,
+		})
+	</div>
+}
 
-		// Error State
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Error State</h4>
-			<div class="flex flex-wrap gap-6">
-				@textarea.Textarea(textarea.Config{
-					ID:         "demo-error",
-					Name:       "comment",
-					Label:      "Comment",
-					State:      textarea.StateError,
-					HelperText: "Error: Please add some comments to your evaluation",
-					Rows:       3,
-				})
-			</div>
-		</div>
+// textareaErrorPreview renders the error state.
+templ textareaErrorPreview() {
+	<div id="textarea-error" class="w-full max-w-md mx-auto">
+		@textarea.Textarea(textarea.Config{
+			ID:         "demo-error",
+			Name:       "comment",
+			Label:      "Comment",
+			State:      textarea.StateError,
+			HelperText: "Error: Please add some comments to your evaluation",
+			Rows:       3,
+		})
+	</div>
+}
 
-		// Success State
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Success State</h4>
-			<div class="flex flex-wrap gap-6">
-				@textarea.Textarea(textarea.Config{
-					ID:    "demo-success",
-					Name:  "comment",
-					Label: "Comment",
-					State: textarea.StateSuccess,
-					Rows:  3,
-				})
-			</div>
-		</div>
+// textareaSuccessPreview renders the success state.
+templ textareaSuccessPreview() {
+	<div id="textarea-success" class="w-full max-w-md mx-auto">
+		@textarea.Textarea(textarea.Config{
+			ID:    "demo-success",
+			Name:  "comment",
+			Label: "Comment",
+			State: textarea.StateSuccess,
+			Rows:  3,
+		})
+	</div>
+}
 
-		// Disabled
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Disabled Textarea</h4>
-			<div class="flex flex-wrap gap-6">
-				@textarea.Textarea(textarea.Config{
-					ID:          "demo-disabled",
-					Name:        "comment",
-					Label:       "Comment",
-					Placeholder: "This textarea is disabled",
-					Disabled:    true,
-				})
-			</div>
-		</div>
+// textareaDisabledPreview renders the disabled textarea.
+templ textareaDisabledPreview() {
+	<div id="textarea-disabled" class="w-full max-w-md mx-auto">
+		@textarea.Textarea(textarea.Config{
+			ID:          "demo-disabled",
+			Name:        "comment",
+			Label:       "Comment",
+			Placeholder: "This textarea is disabled",
+			Disabled:    true,
+		})
+	</div>
+}
 
-		// Textarea with Actions
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Textarea with Actions</h4>
-			<div class="flex flex-wrap gap-6">
-				@textarea.TextareaWithActions(textarea.Config{
-					ID:          "demo-actions",
-					Name:        "message",
-					Placeholder: "Type your message here...",
-					Rows:        6,
-				})
-			</div>
-		</div>
+// textareaActionsPreview renders the textarea-with-actions variant.
+templ textareaActionsPreview() {
+	<div id="textarea-actions" class="w-full max-w-md mx-auto">
+		@textarea.TextareaWithActions(textarea.Config{
+			ID:          "demo-actions",
+			Name:        "message",
+			Placeholder: "Type your message here...",
+			Rows:        6,
+		})
 	</div>
 }

--- a/internal/pages/demo/components/textarea_templ.go
+++ b/internal/pages/demo/components/textarea_templ.go
@@ -43,7 +43,9 @@ func TextareaDemoPage() templ.Component {
 	})
 }
 
-// textareaDemoContent renders the actual content inside the layout
+// textareaDemoContent renders the demo. Each textarea variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/textarea). Wrapped in #textarea-fragment.
 func textareaDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,51 +67,86 @@ func textareaDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"textarea-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Textarea",
-				Description: "A textarea is a multi-line text input field for longer form content like comments, messages, and descriptions.",
+				Description: "A multi-line text input for longer content — comments, messages, descriptions. Supports validation states, disabled, and an actions variant.",
 			},
-			textareaDemoPreview(),
-			`// Default Textarea
-@textarea.Textarea(textarea.Config{
+			textareaDefaultPreview(),
+			`@textarea.Textarea(textarea.Config{
     ID:          "comment",
     Name:        "comment",
     Label:       "Comment",
     Placeholder: "We'd love to hear from you...",
     Rows:        3,
-})
-
-// Error State
-@textarea.Textarea(textarea.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Error State",
+				Description: "State: textarea.StateError recolors the border and HelperText for validation errors.",
+			},
+			textareaErrorPreview(),
+			`@textarea.Textarea(textarea.Config{
     ID:         "comment-error",
     Name:       "comment",
     Label:      "Comment",
     State:      textarea.StateError,
     HelperText: "Error: Please add some comments to your evaluation",
     Rows:       3,
-})
-
-// Success State
-@textarea.Textarea(textarea.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Success State",
+				Description: "State: textarea.StateSuccess applies the success styling.",
+			},
+			textareaSuccessPreview(),
+			`@textarea.Textarea(textarea.Config{
     ID:    "comment-success",
     Name:  "comment",
     Label: "Comment",
     State: textarea.StateSuccess,
     Rows:  3,
-})
-
-// Disabled Textarea
-@textarea.Textarea(textarea.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled",
+				Description: "Disabled: true blocks editing and dims the field.",
+			},
+			textareaDisabledPreview(),
+			`@textarea.Textarea(textarea.Config{
     ID:          "comment-disabled",
     Name:        "comment",
     Label:       "Comment",
     Placeholder: "This textarea is disabled",
     Disabled:    true,
-})
-
-// Textarea with Actions
-@textarea.TextareaWithActions(textarea.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Actions",
+				Description: "textarea.TextareaWithActions wraps the field with a toolbar/footer for inline actions.",
+			},
+			textareaActionsPreview(),
+			`@textarea.TextareaWithActions(textarea.Config{
     ID:          "message",
     Name:        "message",
     Placeholder: "Type your message here...",
@@ -119,12 +156,32 @@ func textareaDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the textarea (and label's for target)."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+			{Name: "Label", Type: "string", Default: `""`, Description: "Label above the textarea."},
+			{Name: "Placeholder", Type: "string", Default: `""`, Description: "Placeholder when empty."},
+			{Name: "Value", Type: "string", Default: `""`, Description: "Current value."},
+			{Name: "Rows", Type: "int", Default: "0", Description: "Visible rows (height)."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable the textarea."},
+			{Name: "ReadOnly", Type: "bool", Default: "false", Description: "Non-editable but submittable."},
+			{Name: "State", Type: "State", Default: "StateDefault", Description: `Validation state: "" (default), "error", "success".`},
+			{Name: "HelperText", Type: "string", Default: `""`, Description: "Text below the field, recolored by State."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// textareaDemoPreview renders the Goshtoso textarea preview
-func textareaDemoPreview() templ.Component {
+// textareaDefaultPreview renders the default textarea.
+func textareaDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -145,7 +202,7 @@ func textareaDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-5xl mx-auto space-y-12\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Textarea</h4><div class=\"flex flex-wrap gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"textarea-default\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -159,7 +216,37 @@ func textareaDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Error State</h4><div class=\"flex flex-wrap gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textareaErrorPreview renders the error state.
+func textareaErrorPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"textarea-error\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -174,7 +261,37 @@ func textareaDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Success State</h4><div class=\"flex flex-wrap gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textareaSuccessPreview renders the success state.
+func textareaSuccessPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"textarea-success\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -188,7 +305,37 @@ func textareaDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Disabled Textarea</h4><div class=\"flex flex-wrap gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textareaDisabledPreview renders the disabled textarea.
+func textareaDisabledPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"textarea-disabled\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -202,7 +349,37 @@ func textareaDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Textarea with Actions</h4><div class=\"flex flex-wrap gap-6\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textareaActionsPreview renders the textarea-with-actions variant.
+func textareaActionsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"textarea-actions\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -215,7 +392,7 @@ func textareaDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/textinput.templ
+++ b/internal/pages/demo/components/textinput.templ
@@ -10,59 +10,78 @@ templ TextInputDemoPage() {
 	@demo.Layout("Text Input", "text-input", textInputDemoContent())
 }
 
-// textInputDemoContent renders the actual content inside the layout
+// textInputDemoContent renders the demo. Each text-input variant lives in its
+// own preview frame followed by its own code block (mirrors
+// penguinui.com/components/text-input). The variant set stays wrapped in
+// #textinput-fragment.
 templ textInputDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Text Input",
-			Description:   "Text inputs allow users to enter and edit text. Supports various types including password with toggle, search with icon, validation states, and input masks.",
-		},
-		textInputDemoPreview(),
-		`// Default text input
-@textinput.TextInput(textinput.Config{
+	<div id="textinput-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Text Input",
+				Description: "Text inputs let users enter and edit text. Supports password toggle, search icon, validation states, masks, patterns, and length limits.",
+			},
+			textInputDefaultPreview(),
+			`@textinput.TextInput(textinput.Config{
     ID:          "name",
     Name:        "name",
     Label:       "Name",
     Placeholder: "Enter your name",
-})
+})`,
+		)
 
-// Password input with toggle
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Validation States",
+				Description: "Set State to textinput.StateError or textinput.StateSuccess; the label, border, and HelperText recolor to match.",
+			},
+			textInputStatesPreview(),
+			`@textinput.TextInput(textinput.Config{
+    ID: "email-error", Name: "email", Label: "Email",
+    State: textinput.StateError, HelperText: "Error: Email is required",
+})
 @textinput.TextInput(textinput.Config{
+    ID: "name-success", Name: "name", Label: "Name",
+    State: textinput.StateSuccess, Value: "John",
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Password Input",
+				Description: "Type: textinput.TypePassword renders a built-in show/hide toggle button.",
+			},
+			textInputPasswordPreview(),
+			`@textinput.TextInput(textinput.Config{
     ID:           "password",
     Name:         "password",
     Label:        "Password",
     Type:         textinput.TypePassword,
     Placeholder:  "Enter your password",
     Autocomplete: "current-password",
-})
+})`,
+		)
 
-// Input with error state
-@textinput.TextInput(textinput.Config{
-    ID:         "email-error",
-    Name:       "email",
-    Label:      "Email",
-    State:      textinput.StateError,
-    HelperText: "Error: Email is required",
-})
-
-// Input with success state
-@textinput.TextInput(textinput.Config{
-    ID:         "name-success",
-    Name:       "name",
-    Label:      "Name",
-    State:      textinput.StateSuccess,
-    Value:      "John",
-})
-
-// Search input
-@textinput.TextInput(textinput.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Search Input",
+				Description: "Type: textinput.TypeSearch adds a leading search icon.",
+			},
+			textInputSearchPreview(),
+			`@textinput.TextInput(textinput.Config{
     Name:        "search",
     Type:        textinput.TypeSearch,
     Placeholder: "Search",
-})
+})`,
+		)
 
-// Input with mask
-@textinput.TextInput(textinput.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Input with Mask",
+				Description: "Mask applies an Alpine.js x-mask pattern as the user types.",
+			},
+			textInputMaskPreview(),
+			`@textinput.TextInput(textinput.Config{
     ID:           "phone",
     Name:         "phone",
     Label:        "Phone",
@@ -70,144 +89,203 @@ templ textInputDemoContent() {
     Placeholder:  "(999) 999-9999",
     Autocomplete: "tel-national",
 })`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled Input",
+				Description: "Disabled: true blocks editing and dims the field.",
+			},
+			textInputDisabledPreview(),
+			`@textinput.TextInput(textinput.Config{
+    ID: "disabled", Name: "disabled", Label: "Disabled",
+    Placeholder: "Cannot edit", Disabled: true,
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Readonly Input",
+				Description: "Readonly: true keeps the value submittable but non-editable.",
+			},
+			textInputReadonlyPreview(),
+			`@textinput.TextInput(textinput.Config{
+    ID: "readonly", Name: "readonly", Label: "Readonly",
+    Value: "Cannot change this", Readonly: true,
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Pattern Validation",
+				Description: "Pattern sets the HTML pattern attribute for native regex validation on submit.",
+			},
+			textInputPatternPreview(),
+			`@textinput.TextInput(textinput.Config{
+    ID: "cluster", Name: "cluster_id", Label: "Cluster ID",
+    Placeholder: "tabc123",
+    Pattern:     "t[a-z0-9]{6}",
+    HelperText:  "Must match: t[a-z0-9]{6}",
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "MaxLength",
+				Description: "MaxLength caps the number of characters (0 = no limit).",
+			},
+			textInputMaxLengthPreview(),
+			`@textinput.TextInput(textinput.Config{
+    ID: "code", Name: "code", Label: "Code (max 7 chars)",
+    Placeholder: "tabc123", MaxLength: 7,
+})`,
+		)
+	</div>
+	// API reference lives outside #textinput-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the input (and the label's for target)."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+		{Name: "Label", Type: "string", Default: `""`, Description: "Label text shown above the input."},
+		{Name: "Placeholder", Type: "string", Default: `""`, Description: "Placeholder text when empty."},
+		{Name: "Value", Type: "string", Default: `""`, Description: "Current input value."},
+		{Name: "Type", Type: "InputType", Default: "TypeText", Description: `Input type: "text", "password", "search", "email", "tel", "url", "number".`},
+		{Name: "State", Type: "State", Default: "StateDefault", Description: `Validation state: "" (default), "error", "success".`},
+		{Name: "HelperText", Type: "string", Default: `""`, Description: "Text below the input, recolored by State."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disables the input."},
+		{Name: "Required", Type: "bool", Default: "false", Description: "Marks the input as required."},
+		{Name: "Readonly", Type: "bool", Default: "false", Description: "Non-editable but still submittable."},
+		{Name: "Autocomplete", Type: "string", Default: `""`, Description: "HTML autocomplete attribute value."},
+		{Name: "Mask", Type: "string", Default: `""`, Description: `Alpine.js x-mask pattern (e.g. "(999) 999-9999").`},
+		{Name: "Pattern", Type: "string", Default: `""`, Description: "HTML pattern attribute for regex validation."},
+		{Name: "MaxLength", Type: "int", Default: "0", Description: "Character limit (0 = no limit)."},
+		{Name: "Attrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the <input> (e.g. hx-post, hx-indicator)."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+	})
 }
 
-// textInputDemoPreview renders the Goshtoso text input preview
-templ textInputDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Default Text Input
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Text Input</h4>
-			<div class="flex flex-wrap gap-4">
-				@textinput.TextInput(textinput.Config{
-					ID:           "textInputDefault",
-					Name:         "name",
-					Label:        "Name",
-					Placeholder:  "Enter your name",
-					Autocomplete: "name",
-				})
-			</div>
-		</div>
+// textInputDefaultPreview renders the default text input.
+templ textInputDefaultPreview() {
+	<div id="textinput-default" class="w-full max-w-sm mx-auto">
+		@textinput.TextInput(textinput.Config{
+			ID:           "textInputDefault",
+			Name:         "name",
+			Label:        "Name",
+			Placeholder:  "Enter your name",
+			Autocomplete: "name",
+		})
+	</div>
+}
 
-		// Validation States
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Validation States</h4>
-			<div class="flex flex-wrap gap-4">
-				@textinput.TextInput(textinput.Config{
-					ID:         "inputError",
-					Name:       "inputStates",
-					Label:      "Name",
-					State:      textinput.StateError,
-					HelperText: "Error: Name field is required",
-				})
-				@textinput.TextInput(textinput.Config{
-					ID:    "inputSuccess",
-					Name:  "inputStates",
-					Label: "Name",
-					State: textinput.StateSuccess,
-					Value: "John",
-				})
-			</div>
+// textInputStatesPreview renders the error + success validation states.
+templ textInputStatesPreview() {
+	<div id="textinput-states" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-4">
+			@textinput.TextInput(textinput.Config{
+				ID:         "inputError",
+				Name:       "inputStates",
+				Label:      "Name",
+				State:      textinput.StateError,
+				HelperText: "Error: Name field is required",
+			})
+			@textinput.TextInput(textinput.Config{
+				ID:    "inputSuccess",
+				Name:  "inputStates",
+				Label: "Name",
+				State: textinput.StateSuccess,
+				Value: "John",
+			})
 		</div>
+	</div>
+}
 
-		// Password Input
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Password Input</h4>
-			<div class="flex flex-wrap gap-4">
-				@textinput.TextInput(textinput.Config{
-					ID:           "passwordInput",
-					Name:         "password",
-					Label:        "Password",
-					Type:         textinput.TypePassword,
-					Placeholder:  "Enter your password",
-					Autocomplete: "current-password",
-				})
-			</div>
-		</div>
+// textInputPasswordPreview renders the password input with toggle.
+templ textInputPasswordPreview() {
+	<div id="textinput-password" class="w-full max-w-sm mx-auto">
+		@textinput.TextInput(textinput.Config{
+			ID:           "passwordInput",
+			Name:         "password",
+			Label:        "Password",
+			Type:         textinput.TypePassword,
+			Placeholder:  "Enter your password",
+			Autocomplete: "current-password",
+		})
+	</div>
+}
 
-		// Search Input
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Search Input</h4>
-			<div class="flex flex-wrap gap-4">
-				@textinput.TextInput(textinput.Config{
-					Name:        "search",
-					Type:        textinput.TypeSearch,
-					Placeholder: "Search",
-				})
-			</div>
-		</div>
+// textInputSearchPreview renders the search input with icon.
+templ textInputSearchPreview() {
+	<div id="textinput-search" class="w-full max-w-sm mx-auto">
+		@textinput.TextInput(textinput.Config{
+			Name:        "search",
+			Type:        textinput.TypeSearch,
+			Placeholder: "Search",
+		})
+	</div>
+}
 
-		// Input with Mask
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Input with Mask</h4>
-			<div class="flex flex-wrap gap-4">
-				@textinput.TextInput(textinput.Config{
-					ID:           "phoneInput",
-					Name:         "phone",
-					Label:        "Phone",
-					Mask:         "(999) 999-9999",
-					Placeholder:  "(999) 999-9999",
-					Autocomplete: "tel-national",
-				})
-			</div>
-		</div>
+// textInputMaskPreview renders the masked phone input.
+templ textInputMaskPreview() {
+	<div id="textinput-mask" class="w-full max-w-sm mx-auto">
+		@textinput.TextInput(textinput.Config{
+			ID:           "phoneInput",
+			Name:         "phone",
+			Label:        "Phone",
+			Mask:         "(999) 999-9999",
+			Placeholder:  "(999) 999-9999",
+			Autocomplete: "tel-national",
+		})
+	</div>
+}
 
-		// Disabled Input
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Disabled Input</h4>
-			<div class="flex flex-wrap gap-4">
-				@textinput.TextInput(textinput.Config{
-					ID:          "disabledInput",
-					Name:        "disabled",
-					Label:       "Disabled",
-					Placeholder: "Cannot edit",
-					Disabled:    true,
-				})
-			</div>
-		</div>
+// textInputDisabledPreview renders the disabled input.
+templ textInputDisabledPreview() {
+	<div id="textinput-disabled" class="w-full max-w-sm mx-auto">
+		@textinput.TextInput(textinput.Config{
+			ID:          "disabledInput",
+			Name:        "disabled",
+			Label:       "Disabled",
+			Placeholder: "Cannot edit",
+			Disabled:    true,
+		})
+	</div>
+}
 
-		// Readonly Input
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Readonly Input</h4>
-			<div class="flex flex-wrap gap-4">
-				@textinput.TextInput(textinput.Config{
-					ID:       "readonlyInput",
-					Name:     "readonly",
-					Label:    "Readonly",
-					Value:    "Cannot change this",
-					Readonly: true,
-				})
-			</div>
-		</div>
+// textInputReadonlyPreview renders the readonly input.
+templ textInputReadonlyPreview() {
+	<div id="textinput-readonly" class="w-full max-w-sm mx-auto">
+		@textinput.TextInput(textinput.Config{
+			ID:       "readonlyInput",
+			Name:     "readonly",
+			Label:    "Readonly",
+			Value:    "Cannot change this",
+			Readonly: true,
+		})
+	</div>
+}
 
-		// Pattern Validation
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Pattern Validation</h4>
-			<div class="flex flex-wrap gap-4">
-				@textinput.TextInput(textinput.Config{
-					ID:          "patternInput",
-					Name:        "cluster_id",
-					Label:       "Cluster ID",
-					Placeholder: "tabc123",
-					Pattern:     "t[a-z0-9]{6}",
-					HelperText:  "Must match: t[a-z0-9]{6}",
-				})
-			</div>
-		</div>
+// textInputPatternPreview renders the pattern-validated input.
+templ textInputPatternPreview() {
+	<div id="textinput-pattern" class="w-full max-w-sm mx-auto">
+		@textinput.TextInput(textinput.Config{
+			ID:          "patternInput",
+			Name:        "cluster_id",
+			Label:       "Cluster ID",
+			Placeholder: "tabc123",
+			Pattern:     "t[a-z0-9]{6}",
+			HelperText:  "Must match: t[a-z0-9]{6}",
+		})
+	</div>
+}
 
-		// MaxLength
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">MaxLength</h4>
-			<div class="flex flex-wrap gap-4">
-				@textinput.TextInput(textinput.Config{
-					ID:          "maxlengthInput",
-					Name:        "code",
-					Label:       "Code (max 7 chars)",
-					Placeholder: "tabc123",
-					MaxLength:   7,
-				})
-			</div>
-		</div>
+// textInputMaxLengthPreview renders the max-length input.
+templ textInputMaxLengthPreview() {
+	<div id="textinput-maxlength" class="w-full max-w-sm mx-auto">
+		@textinput.TextInput(textinput.Config{
+			ID:          "maxlengthInput",
+			Name:        "code",
+			Label:       "Code (max 7 chars)",
+			Placeholder: "tabc123",
+			MaxLength:   7,
+		})
 	</div>
 }

--- a/internal/pages/demo/components/textinput_templ.go
+++ b/internal/pages/demo/components/textinput_templ.go
@@ -43,7 +43,10 @@ func TextInputDemoPage() templ.Component {
 	})
 }
 
-// textInputDemoContent renders the actual content inside the layout
+// textInputDemoContent renders the demo. Each text-input variant lives in its
+// own preview frame followed by its own code block (mirrors
+// penguinui.com/components/text-input). The variant set stays wrapped in
+// #textinput-fragment.
 func textInputDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,57 +68,84 @@ func textInputDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"textinput-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Text Input",
-				Description: "Text inputs allow users to enter and edit text. Supports various types including password with toggle, search with icon, validation states, and input masks.",
+				Description: "Text inputs let users enter and edit text. Supports password toggle, search icon, validation states, masks, patterns, and length limits.",
 			},
-			textInputDemoPreview(),
-			`// Default text input
-@textinput.TextInput(textinput.Config{
+			textInputDefaultPreview(),
+			`@textinput.TextInput(textinput.Config{
     ID:          "name",
     Name:        "name",
     Label:       "Name",
     Placeholder: "Enter your name",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Validation States",
+				Description: "Set State to textinput.StateError or textinput.StateSuccess; the label, border, and HelperText recolor to match.",
+			},
+			textInputStatesPreview(),
+			`@textinput.TextInput(textinput.Config{
+    ID: "email-error", Name: "email", Label: "Email",
+    State: textinput.StateError, HelperText: "Error: Email is required",
 })
-
-// Password input with toggle
 @textinput.TextInput(textinput.Config{
+    ID: "name-success", Name: "name", Label: "Name",
+    State: textinput.StateSuccess, Value: "John",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Password Input",
+				Description: "Type: textinput.TypePassword renders a built-in show/hide toggle button.",
+			},
+			textInputPasswordPreview(),
+			`@textinput.TextInput(textinput.Config{
     ID:           "password",
     Name:         "password",
     Label:        "Password",
     Type:         textinput.TypePassword,
     Placeholder:  "Enter your password",
     Autocomplete: "current-password",
-})
-
-// Input with error state
-@textinput.TextInput(textinput.Config{
-    ID:         "email-error",
-    Name:       "email",
-    Label:      "Email",
-    State:      textinput.StateError,
-    HelperText: "Error: Email is required",
-})
-
-// Input with success state
-@textinput.TextInput(textinput.Config{
-    ID:         "name-success",
-    Name:       "name",
-    Label:      "Name",
-    State:      textinput.StateSuccess,
-    Value:      "John",
-})
-
-// Search input
-@textinput.TextInput(textinput.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Search Input",
+				Description: "Type: textinput.TypeSearch adds a leading search icon.",
+			},
+			textInputSearchPreview(),
+			`@textinput.TextInput(textinput.Config{
     Name:        "search",
     Type:        textinput.TypeSearch,
     Placeholder: "Search",
-})
-
-// Input with mask
-@textinput.TextInput(textinput.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Input with Mask",
+				Description: "Mask applies an Alpine.js x-mask pattern as the user types.",
+			},
+			textInputMaskPreview(),
+			`@textinput.TextInput(textinput.Config{
     ID:           "phone",
     Name:         "phone",
     Label:        "Phone",
@@ -127,12 +157,96 @@ func textInputDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled Input",
+				Description: "Disabled: true blocks editing and dims the field.",
+			},
+			textInputDisabledPreview(),
+			`@textinput.TextInput(textinput.Config{
+    ID: "disabled", Name: "disabled", Label: "Disabled",
+    Placeholder: "Cannot edit", Disabled: true,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Readonly Input",
+				Description: "Readonly: true keeps the value submittable but non-editable.",
+			},
+			textInputReadonlyPreview(),
+			`@textinput.TextInput(textinput.Config{
+    ID: "readonly", Name: "readonly", Label: "Readonly",
+    Value: "Cannot change this", Readonly: true,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Pattern Validation",
+				Description: "Pattern sets the HTML pattern attribute for native regex validation on submit.",
+			},
+			textInputPatternPreview(),
+			`@textinput.TextInput(textinput.Config{
+    ID: "cluster", Name: "cluster_id", Label: "Cluster ID",
+    Placeholder: "tabc123",
+    Pattern:     "t[a-z0-9]{6}",
+    HelperText:  "Must match: t[a-z0-9]{6}",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "MaxLength",
+				Description: "MaxLength caps the number of characters (0 = no limit).",
+			},
+			textInputMaxLengthPreview(),
+			`@textinput.TextInput(textinput.Config{
+    ID: "code", Name: "code", Label: "Code (max 7 chars)",
+    Placeholder: "tabc123", MaxLength: 7,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the input (and the label's for target)."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+			{Name: "Label", Type: "string", Default: `""`, Description: "Label text shown above the input."},
+			{Name: "Placeholder", Type: "string", Default: `""`, Description: "Placeholder text when empty."},
+			{Name: "Value", Type: "string", Default: `""`, Description: "Current input value."},
+			{Name: "Type", Type: "InputType", Default: "TypeText", Description: `Input type: "text", "password", "search", "email", "tel", "url", "number".`},
+			{Name: "State", Type: "State", Default: "StateDefault", Description: `Validation state: "" (default), "error", "success".`},
+			{Name: "HelperText", Type: "string", Default: `""`, Description: "Text below the input, recolored by State."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disables the input."},
+			{Name: "Required", Type: "bool", Default: "false", Description: "Marks the input as required."},
+			{Name: "Readonly", Type: "bool", Default: "false", Description: "Non-editable but still submittable."},
+			{Name: "Autocomplete", Type: "string", Default: `""`, Description: "HTML autocomplete attribute value."},
+			{Name: "Mask", Type: "string", Default: `""`, Description: `Alpine.js x-mask pattern (e.g. "(999) 999-9999").`},
+			{Name: "Pattern", Type: "string", Default: `""`, Description: "HTML pattern attribute for regex validation."},
+			{Name: "MaxLength", Type: "int", Default: "0", Description: "Character limit (0 = no limit)."},
+			{Name: "Attrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the <input> (e.g. hx-post, hx-indicator)."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// textInputDemoPreview renders the Goshtoso text input preview
-func textInputDemoPreview() templ.Component {
+// textInputDefaultPreview renders the default text input.
+func textInputDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -153,7 +267,7 @@ func textInputDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Text Input</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"textinput-default\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -167,7 +281,37 @@ func textInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Validation States</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textInputStatesPreview renders the error + success validation states.
+func textInputStatesPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"textinput-states\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -191,7 +335,37 @@ func textInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Password Input</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textInputPasswordPreview renders the password input with toggle.
+func textInputPasswordPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"textinput-password\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -206,7 +380,37 @@ func textInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Search Input</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textInputSearchPreview renders the search input with icon.
+func textInputSearchPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"textinput-search\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -218,7 +422,37 @@ func textInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Input with Mask</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textInputMaskPreview renders the masked phone input.
+func textInputMaskPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"textinput-mask\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -233,7 +467,37 @@ func textInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Disabled Input</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textInputDisabledPreview renders the disabled input.
+func textInputDisabledPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"textinput-disabled\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -247,7 +511,37 @@ func textInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Readonly Input</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textInputReadonlyPreview renders the readonly input.
+func textInputReadonlyPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"textinput-readonly\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -261,7 +555,37 @@ func textInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Pattern Validation</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textInputPatternPreview renders the pattern-validated input.
+func textInputPatternPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"textinput-pattern\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -276,7 +600,37 @@ func textInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">MaxLength</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// textInputMaxLengthPreview renders the max-length input.
+func textInputMaxLengthPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div id=\"textinput-maxlength\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -290,7 +644,7 @@ func textInputDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/toast.templ
+++ b/internal/pages/demo/components/toast.templ
@@ -10,15 +10,20 @@ templ ToastDemoPage() {
 	@demo.Layout("Toast", "toast", toastDemoContent())
 }
 
-// toastDemoContent renders the actual content inside the layout
+// toastDemoContent renders the demo. Each trigger style lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/toast).
+// The toast.Container (global listener) is placed once at the top of the fragment.
 templ toastDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Toast Notification",
-			Description:   "Stacking toast notifications with auto-dismiss, hover pause, and multiple variants. Supports both client-side Alpine.js events and server-side HTMX OOB swaps.",
-		},
-		toastDemoPreview(),
-		`// 1. Place the container once in your layout
+	<div id="toast-fragment">
+		<!-- Toast Container (global listener) — placed once -->
+		@toast.Container(toast.ContainerConfig{})
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Toast Notification",
+				Description: "Stacking notifications with auto-dismiss, hover pause, and five variants. Trigger client-side via Alpine.js $dispatch('notify', ...) or server-side via HTMX out-of-band swaps. Place @toast.Container once in your layout.",
+			},
+			toastAlpinePreview(),
+			`// 1. Place the container once in your layout
 @toast.Container(toast.ContainerConfig{})
 
 // 2. Trigger toasts from Alpine.js
@@ -28,37 +33,62 @@ templ toastDemoContent() {
     message: 'Your changes have been saved.',
 })">Save</button>
 
-// 3. Server-side OOB toast (in your Go handler)
-func handler(w http.ResponseWriter, r *http.Request) {
-    // ... your logic ...
-    toast.OOBToast(toast.Config{
-        Variant: toast.Success,
-        Title:   "Created!",
-        Message: "The item was created successfully.",
-    }).Render(r.Context(), w)
-}
-
-// Available variants: Info, Success, Warning, Danger, Message
-// Message variant includes sender avatar and reply button:
+// Message variant carries a sender avatar + reply button:
 <button x-on:click="$dispatch('notify', {
     variant: 'message',
     sender: { name: 'Jane', avatar: '/avatar.jpg' },
     message: 'Hey, check this out!',
 })">Send</button>`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Server-side Triggers (HTMX OOB)",
+				Description: "Render a toast from a Go handler and swap it in out-of-band — the trigger button posts with hx-swap=\"none\".",
+			},
+			toastHTMXPreview(),
+			`// Trigger button
+<button hx-post="/api/components/toast" hx-swap="none"
+    hx-vals='{"variant":"success","title":"Server Says Hello!","message":"..."}'>
+    Server Success Toast
+</button>
+
+// Handler
+func handler(w http.ResponseWriter, r *http.Request) {
+    toast.OOBToast(toast.Config{
+        Variant: toast.Success, Title: "Created!", Message: "The item was created.",
+    }).Render(r.Context(), w)
+}`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Static Examples (Server-Rendered)",
+				Description: "Each variant rendered statically with @toast.Toast — Info, Success, Warning, Danger, and Message (with sender).",
+			},
+			toastStaticPreview(),
+			`@toast.Toast(toast.Config{Variant: toast.Success, Title: "Success!", Message: "Your changes have been saved."})
+@toast.Toast(toast.Config{
+    Variant: toast.Message,
+    Message: "Hey, can you review the PR I just submitted?",
+    Sender:  &toast.Sender{Name: "Jack Ellis", Avatar: "/avatar.webp"},
+})`,
+		)
+	</div>
+	// API reference lives outside #toast-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Variant", Type: "Variant", Default: "Info", Description: `Color/style: "info", "success", "warning", "danger", "message".`},
+		{Name: "Title", Type: "string", Default: `""`, Description: "Toast heading (omitted by the message variant)."},
+		{Name: "Message", Type: "string", Default: `""`, Description: "Toast body text."},
+		{Name: "Sender", Type: "*Sender", Default: "nil", Description: "Message-variant sender (Name + Avatar); adds avatar and reply button."},
+		{Name: "DisplayDuration", Type: "int", Default: "0", Description: "Auto-dismiss delay in ms (0 uses the container default)."},
+	})
 }
 
-// toastDemoPreview renders the Goshtoso toast preview with trigger buttons
-templ toastDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		<!-- Toast Container (global listener) -->
-		@toast.Container(toast.ContainerConfig{})
-
-		<!-- Client-side Alpine.js Triggers -->
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Client-side Triggers (Alpine.js)</h4>
-			<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Click to dispatch toast notifications via Alpine.js events.</p>
-			<div class="flex flex-wrap gap-3">
+// toastAlpinePreview renders the client-side Alpine.js trigger buttons.
+templ toastAlpinePreview() {
+	<div id="toast-alpine" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-3">
 				<!-- Message Trigger -->
 				<button
 					x-on:click="$dispatch('notify', { variant: 'message', sender: { name: 'Jack Ellis', avatar: '/assets/images/avatars/avatar-2.webp' }, message: 'Hey, can you review the PR I just submitted? Let me know if you spot any issues!' })"
@@ -101,12 +131,12 @@ templ toastDemoPreview() {
 				</button>
 			</div>
 		</div>
+}
 
-		<!-- Server-side HTMX OOB Triggers -->
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Server-side Triggers (HTMX OOB)</h4>
-			<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">Click to fetch a toast from the server via HTMX out-of-band swap.</p>
-			<div class="flex flex-wrap gap-3">
+// toastHTMXPreview renders the server-side HTMX OOB trigger buttons.
+templ toastHTMXPreview() {
+	<div id="toast-htmx" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-3">
 				<button
 					type="button"
 					hx-post="/api/components/toast"
@@ -136,12 +166,12 @@ templ toastDemoPreview() {
 				</button>
 			</div>
 		</div>
+}
 
-		<!-- Static Server-Rendered Toast Examples -->
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Static Examples (Server-Rendered)</h4>
-			<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">These toasts are rendered server-side, showing each variant statically.</p>
-			<div class="space-y-3">
+// toastStaticPreview renders the static server-rendered toast variants.
+templ toastStaticPreview() {
+	<div id="toast-static" class="w-full max-w-2xl mx-auto">
+		<div class="space-y-3">
 				@toast.Toast(toast.Config{
 					Variant: toast.Info,
 					Title:   "Update Available",
@@ -170,7 +200,6 @@ templ toastDemoPreview() {
 						Avatar: "/assets/images/avatars/avatar-2.webp",
 					},
 				})
-			</div>
 		</div>
 	</div>
 }

--- a/internal/pages/demo/components/toast_templ.go
+++ b/internal/pages/demo/components/toast_templ.go
@@ -43,7 +43,9 @@ func ToastDemoPage() templ.Component {
 	})
 }
 
-// toastDemoContent renders the actual content inside the layout
+// toastDemoContent renders the demo. Each trigger style lives in its own preview
+// frame followed by its own code block (mirrors penguinui.com/components/toast).
+// The toast.Container (global listener) is placed once at the top of the fragment.
 func toastDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,12 +67,20 @@ func toastDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"toast-fragment\"><!-- Toast Container (global listener) — placed once -->")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = toast.Container(toast.ContainerConfig{}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Toast Notification",
-				Description: "Stacking toast notifications with auto-dismiss, hover pause, and multiple variants. Supports both client-side Alpine.js events and server-side HTMX OOB swaps.",
+				Description: "Stacking notifications with auto-dismiss, hover pause, and five variants. Trigger client-side via Alpine.js $dispatch('notify', ...) or server-side via HTMX out-of-band swaps. Place @toast.Container once in your layout.",
 			},
-			toastDemoPreview(),
+			toastAlpinePreview(),
 			`// 1. Place the container once in your layout
 @toast.Container(toast.ContainerConfig{})
 
@@ -81,18 +91,7 @@ func toastDemoContent() templ.Component {
     message: 'Your changes have been saved.',
 })">Save</button>
 
-// 3. Server-side OOB toast (in your Go handler)
-func handler(w http.ResponseWriter, r *http.Request) {
-    // ... your logic ...
-    toast.OOBToast(toast.Config{
-        Variant: toast.Success,
-        Title:   "Created!",
-        Message: "The item was created successfully.",
-    }).Render(r.Context(), w)
-}
-
-// Available variants: Info, Success, Warning, Danger, Message
-// Message variant includes sender avatar and reply button:
+// Message variant carries a sender avatar + reply button:
 <button x-on:click="$dispatch('notify', {
     variant: 'message',
     sender: { name: 'Jane', avatar: '/avatar.jpg' },
@@ -102,12 +101,64 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Server-side Triggers (HTMX OOB)",
+				Description: "Render a toast from a Go handler and swap it in out-of-band — the trigger button posts with hx-swap=\"none\".",
+			},
+			toastHTMXPreview(),
+			`// Trigger button
+<button hx-post="/api/components/toast" hx-swap="none"
+    hx-vals='{"variant":"success","title":"Server Says Hello!","message":"..."}'>
+    Server Success Toast
+</button>
+
+// Handler
+func handler(w http.ResponseWriter, r *http.Request) {
+    toast.OOBToast(toast.Config{
+        Variant: toast.Success, Title: "Created!", Message: "The item was created.",
+    }).Render(r.Context(), w)
+}`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Static Examples (Server-Rendered)",
+				Description: "Each variant rendered statically with @toast.Toast — Info, Success, Warning, Danger, and Message (with sender).",
+			},
+			toastStaticPreview(),
+			`@toast.Toast(toast.Config{Variant: toast.Success, Title: "Success!", Message: "Your changes have been saved."})
+@toast.Toast(toast.Config{
+    Variant: toast.Message,
+    Message: "Hey, can you review the PR I just submitted?",
+    Sender:  &toast.Sender{Name: "Jack Ellis", Avatar: "/avatar.webp"},
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Variant", Type: "Variant", Default: "Info", Description: `Color/style: "info", "success", "warning", "danger", "message".`},
+			{Name: "Title", Type: "string", Default: `""`, Description: "Toast heading (omitted by the message variant)."},
+			{Name: "Message", Type: "string", Default: `""`, Description: "Toast body text."},
+			{Name: "Sender", Type: "*Sender", Default: "nil", Description: "Message-variant sender (Name + Avatar); adds avatar and reply button."},
+			{Name: "DisplayDuration", Type: "int", Default: "0", Description: "Auto-dismiss delay in ms (0 uses the container default)."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// toastDemoPreview renders the Goshtoso toast preview with trigger buttons
-func toastDemoPreview() templ.Component {
+// toastAlpinePreview renders the client-side Alpine.js trigger buttons.
+func toastAlpinePreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -128,15 +179,67 @@ func toastDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><!-- Toast Container (global listener) -->")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"toast-alpine\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-3\"><!-- Message Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'message', sender: { name: 'Jack Ellis', avatar: '/assets/images/avatars/avatar-2.webp' }, message: 'Hey, can you review the PR I just submitted? Let me know if you spot any issues!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-primary px-4 py-2 text-center text-sm font-medium tracking-wide text-on-primary transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:opacity-100 active:outline-offset-0 dark:bg-primary-dark dark:text-on-primary-dark dark:focus-visible:outline-primary-dark\">Message</button><!-- Info Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'info', title: 'Update Available', message: 'A new version of the app is ready for you. Update now to enjoy the latest features!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-info px-4 py-2 text-center text-sm font-medium tracking-wide text-on-info transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-info active:opacity-100 active:outline-offset-0\">Info</button><!-- Success Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'success', title: 'Success!', message: 'Your changes have been saved. Keep up the great work!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-success px-4 py-2 text-center text-sm font-medium tracking-wide text-on-success transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-success active:opacity-100 active:outline-offset-0\">Success</button><!-- Danger Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'danger', title: 'Oops!', message: 'Something went wrong. Please try again. If the problem persists, we&#39;re here to help!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-danger px-4 py-2 text-center text-sm font-medium tracking-wide text-on-danger transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger active:opacity-100 active:outline-offset-0\">Danger</button><!-- Warning Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'warning', title: 'Action Needed', message: 'Your storage is getting low. Consider upgrading your plan.' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-warning px-4 py-2 text-center text-sm font-medium tracking-wide text-on-warning transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-warning active:opacity-100 active:outline-offset-0\">Warning</button></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = toast.Container(toast.ContainerConfig{}).Render(ctx, templ_7745c5c3_Buffer)
+		return nil
+	})
+}
+
+// toastHTMXPreview renders the server-side HTMX OOB trigger buttons.
+func toastHTMXPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div id=\"toast-htmx\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-3\"><button type=\"button\" hx-post=\"/api/components/toast\" hx-vals='{\"variant\": \"success\", \"title\": \"Server Says Hello!\", \"message\": \"This toast was rendered on the server and swapped in via HTMX OOB.\"}' hx-swap=\"none\" class=\"whitespace-nowrap rounded-radius bg-success px-4 py-2 text-center text-sm font-medium tracking-wide text-on-success transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-success active:opacity-100 active:outline-offset-0\">Server Success Toast</button> <button type=\"button\" hx-post=\"/api/components/toast\" hx-vals='{\"variant\": \"danger\", \"title\": \"Server Error\", \"message\": \"The server encountered an error processing your request.\"}' hx-swap=\"none\" class=\"whitespace-nowrap rounded-radius bg-danger px-4 py-2 text-center text-sm font-medium tracking-wide text-on-danger transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger active:opacity-100 active:outline-offset-0\">Server Danger Toast</button> <button type=\"button\" hx-post=\"/api/components/toast\" hx-vals='{\"variant\": \"info\", \"title\": \"Server Info\", \"message\": \"This is an informational toast from the server.\"}' hx-swap=\"none\" class=\"whitespace-nowrap rounded-radius bg-info px-4 py-2 text-center text-sm font-medium tracking-wide text-on-info transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-info active:opacity-100 active:outline-offset-0\">Server Info Toast</button></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<!-- Client-side Alpine.js Triggers --><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Client-side Triggers (Alpine.js)</h4><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Click to dispatch toast notifications via Alpine.js events.</p><div class=\"flex flex-wrap gap-3\"><!-- Message Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'message', sender: { name: 'Jack Ellis', avatar: '/assets/images/avatars/avatar-2.webp' }, message: 'Hey, can you review the PR I just submitted? Let me know if you spot any issues!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-primary px-4 py-2 text-center text-sm font-medium tracking-wide text-on-primary transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:opacity-100 active:outline-offset-0 dark:bg-primary-dark dark:text-on-primary-dark dark:focus-visible:outline-primary-dark\">Message</button><!-- Info Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'info', title: 'Update Available', message: 'A new version of the app is ready for you. Update now to enjoy the latest features!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-info px-4 py-2 text-center text-sm font-medium tracking-wide text-on-info transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-info active:opacity-100 active:outline-offset-0\">Info</button><!-- Success Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'success', title: 'Success!', message: 'Your changes have been saved. Keep up the great work!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-success px-4 py-2 text-center text-sm font-medium tracking-wide text-on-success transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-success active:opacity-100 active:outline-offset-0\">Success</button><!-- Danger Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'danger', title: 'Oops!', message: 'Something went wrong. Please try again. If the problem persists, we&#39;re here to help!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-danger px-4 py-2 text-center text-sm font-medium tracking-wide text-on-danger transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger active:opacity-100 active:outline-offset-0\">Danger</button><!-- Warning Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'warning', title: 'Action Needed', message: 'Your storage is getting low. Consider upgrading your plan.' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-warning px-4 py-2 text-center text-sm font-medium tracking-wide text-on-warning transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-warning active:opacity-100 active:outline-offset-0\">Warning</button></div></div><!-- Server-side HTMX OOB Triggers --><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Server-side Triggers (HTMX OOB)</h4><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">Click to fetch a toast from the server via HTMX out-of-band swap.</p><div class=\"flex flex-wrap gap-3\"><button type=\"button\" hx-post=\"/api/components/toast\" hx-vals='{\"variant\": \"success\", \"title\": \"Server Says Hello!\", \"message\": \"This toast was rendered on the server and swapped in via HTMX OOB.\"}' hx-swap=\"none\" class=\"whitespace-nowrap rounded-radius bg-success px-4 py-2 text-center text-sm font-medium tracking-wide text-on-success transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-success active:opacity-100 active:outline-offset-0\">Server Success Toast</button> <button type=\"button\" hx-post=\"/api/components/toast\" hx-vals='{\"variant\": \"danger\", \"title\": \"Server Error\", \"message\": \"The server encountered an error processing your request.\"}' hx-swap=\"none\" class=\"whitespace-nowrap rounded-radius bg-danger px-4 py-2 text-center text-sm font-medium tracking-wide text-on-danger transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger active:opacity-100 active:outline-offset-0\">Server Danger Toast</button> <button type=\"button\" hx-post=\"/api/components/toast\" hx-vals='{\"variant\": \"info\", \"title\": \"Server Info\", \"message\": \"This is an informational toast from the server.\"}' hx-swap=\"none\" class=\"whitespace-nowrap rounded-radius bg-info px-4 py-2 text-center text-sm font-medium tracking-wide text-on-info transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-info active:opacity-100 active:outline-offset-0\">Server Info Toast</button></div></div><!-- Static Server-Rendered Toast Examples --><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Static Examples (Server-Rendered)</h4><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4\">These toasts are rendered server-side, showing each variant statically.</p><div class=\"space-y-3\">")
+		return nil
+	})
+}
+
+// toastStaticPreview renders the static server-rendered toast variants.
+func toastStaticPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"toast-static\" class=\"w-full max-w-2xl mx-auto\"><div class=\"space-y-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -183,7 +286,7 @@ func toastDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/toggle.templ
+++ b/internal/pages/demo/components/toggle.templ
@@ -10,133 +10,109 @@ templ ToggleDemoPage() {
 	@demo.Layout("Toggle", "toggle", toggleDemoContent())
 }
 
-// toggleDemoContent renders the actual content inside the layout
+// toggleDemoContent renders the demo. Each toggle variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/toggle). Wrapped in #toggle-fragment.
 templ toggleDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Toggle",
-			Description:   "A toggle switch allows users to turn an option on or off. It provides a visual indicator of the current state and supports multiple color variants.",
-		},
-		toggleDemoPreview(),
-		`// Default Toggle
-@toggle.Toggle(toggle.Config{
+	<div id="toggle-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Toggle",
+				Description: "An on/off switch with a visual state indicator, six color variants, an optional bordered container style, and disabled states.",
+			},
+			toggleDefaultPreview(),
+			`@toggle.Toggle(toggle.Config{
     ID:      "myToggle",
     Label:   "Toggle",
     Checked: true,
-})
-
-// Toggle with Variant
-@toggle.Toggle(toggle.Config{
-    ID:      "successToggle",
-    Label:   "success",
-    Variant: toggle.Success,
-    Checked: true,
-})
-
-// Toggle with Container
-@toggle.Toggle(toggle.Config{
-    ID:    "containerToggle",
-    Label: "Toggle",
-    Style: toggle.StyleContainer,
-    Checked: true,
-})
-
-// Disabled Toggle
-@toggle.Toggle(toggle.Config{
-    ID:       "disabledToggle",
-    Label:    "Disabled",
-    Disabled: true,
 })`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Container",
+				Description: "Style: toggle.StyleContainer wraps the switch and label in a bordered container.",
+			},
+			toggleContainerPreview(),
+			`@toggle.Toggle(toggle.Config{
+    ID:      "containerToggle",
+    Label:   "Toggle",
+    Style:   toggle.StyleContainer,
+    Checked: true,
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Color Variations",
+				Description: "Set Variant: Primary, Secondary, Info, Success, Warning, or Danger.",
+			},
+			toggleColorsPreview(),
+			`@toggle.Toggle(toggle.Config{ID: "successToggle", Label: "success", Variant: toggle.Success, Checked: true})
+@toggle.Toggle(toggle.Config{ID: "dangerToggle", Label: "danger", Variant: toggle.Danger, Checked: true})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled States",
+				Description: "Disabled: true blocks interaction in both the off and on positions.",
+			},
+			toggleDisabledPreview(),
+			`@toggle.Toggle(toggle.Config{ID: "offToggle", Label: "Disabled (off)", Disabled: true})
+@toggle.Toggle(toggle.Config{ID: "onToggle", Label: "Disabled (on)", Checked: true, Disabled: true})`,
+		)
+	</div>
+	// API reference lives outside #toggle-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the toggle input (and label's for target)."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+		{Name: "Label", Type: "string", Default: `""`, Description: "Label text beside the switch."},
+		{Name: "Checked", Type: "bool", Default: "false", Description: "Initial on state."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
+		{Name: "Variant", Type: "Variant", Default: "Primary", Description: `Color: "primary", "secondary", "info", "success", "warning", "danger".`},
+		{Name: "Style", Type: "Style", Default: "StyleDefault", Description: `Layout: "default" (inline) or "container" (bordered).`},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the toggle root."},
+	})
 }
 
-// toggleDemoPreview renders the Goshtoso toggle preview
-templ toggleDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Default Toggle
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Toggle</h4>
-			<div class="flex flex-wrap gap-4">
-				@toggle.Toggle(toggle.Config{
-					ID:      "demoDefault",
-					Label:   "Toggle",
-					Checked: true,
-				})
-			</div>
+// toggleDefaultPreview renders the default toggle.
+templ toggleDefaultPreview() {
+	<div id="toggle-default" class="w-full max-w-md mx-auto">
+		<div class="flex flex-wrap gap-4">
+			@toggle.Toggle(toggle.Config{ID: "demoDefault", Label: "Toggle", Checked: true})
 		</div>
+	</div>
+}
 
-		// Toggle with Container
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Toggle with Container</h4>
-			<div class="flex flex-wrap gap-4">
-				@toggle.Toggle(toggle.Config{
-					ID:      "demoContainer",
-					Label:   "Toggle",
-					Style:   toggle.StyleContainer,
-					Checked: true,
-				})
-			</div>
+// toggleContainerPreview renders the container-style toggle.
+templ toggleContainerPreview() {
+	<div id="toggle-container" class="w-full max-w-md mx-auto">
+		<div class="flex flex-wrap gap-4">
+			@toggle.Toggle(toggle.Config{ID: "demoContainer", Label: "Toggle", Style: toggle.StyleContainer, Checked: true})
 		</div>
+	</div>
+}
 
-		// Color Variations
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Color Variations</h4>
-			<div class="flex flex-wrap gap-4">
-				@toggle.Toggle(toggle.Config{
-					ID:      "demoPrimary",
-					Label:   "primary",
-					Variant: toggle.Primary,
-					Checked: true,
-				})
-				@toggle.Toggle(toggle.Config{
-					ID:      "demoSecondary",
-					Label:   "secondary",
-					Variant: toggle.Secondary,
-					Checked: true,
-				})
-				@toggle.Toggle(toggle.Config{
-					ID:      "demoSuccess",
-					Label:   "success",
-					Variant: toggle.Success,
-					Checked: true,
-				})
-				@toggle.Toggle(toggle.Config{
-					ID:      "demoWarning",
-					Label:   "warning",
-					Variant: toggle.Warning,
-					Checked: true,
-				})
-				@toggle.Toggle(toggle.Config{
-					ID:      "demoDanger",
-					Label:   "danger",
-					Variant: toggle.Danger,
-					Checked: true,
-				})
-				@toggle.Toggle(toggle.Config{
-					ID:      "demoInfo",
-					Label:   "info",
-					Variant: toggle.Info,
-					Checked: true,
-				})
-			</div>
+// toggleColorsPreview renders the six color variants.
+templ toggleColorsPreview() {
+	<div id="toggle-colors" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap gap-4">
+			@toggle.Toggle(toggle.Config{ID: "demoPrimary", Label: "primary", Variant: toggle.Primary, Checked: true})
+			@toggle.Toggle(toggle.Config{ID: "demoSecondary", Label: "secondary", Variant: toggle.Secondary, Checked: true})
+			@toggle.Toggle(toggle.Config{ID: "demoSuccess", Label: "success", Variant: toggle.Success, Checked: true})
+			@toggle.Toggle(toggle.Config{ID: "demoWarning", Label: "warning", Variant: toggle.Warning, Checked: true})
+			@toggle.Toggle(toggle.Config{ID: "demoDanger", Label: "danger", Variant: toggle.Danger, Checked: true})
+			@toggle.Toggle(toggle.Config{ID: "demoInfo", Label: "info", Variant: toggle.Info, Checked: true})
 		</div>
+	</div>
+}
 
-		// Disabled States
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Disabled States</h4>
-			<div class="flex flex-wrap gap-4">
-				@toggle.Toggle(toggle.Config{
-					ID:       "demoDisabledOff",
-					Label:    "Disabled (off)",
-					Disabled: true,
-				})
-				@toggle.Toggle(toggle.Config{
-					ID:       "demoDisabledOn",
-					Label:    "Disabled (on)",
-					Checked:  true,
-					Disabled: true,
-				})
-			</div>
+// toggleDisabledPreview renders the disabled off/on states.
+templ toggleDisabledPreview() {
+	<div id="toggle-disabled" class="w-full max-w-md mx-auto">
+		<div class="flex flex-wrap gap-4">
+			@toggle.Toggle(toggle.Config{ID: "demoDisabledOff", Label: "Disabled (off)", Disabled: true})
+			@toggle.Toggle(toggle.Config{ID: "demoDisabledOn", Label: "Disabled (on)", Checked: true, Disabled: true})
 		</div>
 	</div>
 }

--- a/internal/pages/demo/components/toggle_templ.go
+++ b/internal/pages/demo/components/toggle_templ.go
@@ -43,7 +43,9 @@ func ToggleDemoPage() templ.Component {
 	})
 }
 
-// toggleDemoContent renders the actual content inside the layout
+// toggleDemoContent renders the demo. Each toggle variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/toggle). Wrapped in #toggle-fragment.
 func toggleDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,42 +67,79 @@ func toggleDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"toggle-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Toggle",
-				Description: "A toggle switch allows users to turn an option on or off. It provides a visual indicator of the current state and supports multiple color variants.",
+				Description: "An on/off switch with a visual state indicator, six color variants, an optional bordered container style, and disabled states.",
 			},
-			toggleDemoPreview(),
-			`// Default Toggle
-@toggle.Toggle(toggle.Config{
+			toggleDefaultPreview(),
+			`@toggle.Toggle(toggle.Config{
     ID:      "myToggle",
     Label:   "Toggle",
     Checked: true,
-})
-
-// Toggle with Variant
-@toggle.Toggle(toggle.Config{
-    ID:      "successToggle",
-    Label:   "success",
-    Variant: toggle.Success,
-    Checked: true,
-})
-
-// Toggle with Container
-@toggle.Toggle(toggle.Config{
-    ID:    "containerToggle",
-    Label: "Toggle",
-    Style: toggle.StyleContainer,
-    Checked: true,
-})
-
-// Disabled Toggle
-@toggle.Toggle(toggle.Config{
-    ID:       "disabledToggle",
-    Label:    "Disabled",
-    Disabled: true,
 })`,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Container",
+				Description: "Style: toggle.StyleContainer wraps the switch and label in a bordered container.",
+			},
+			toggleContainerPreview(),
+			`@toggle.Toggle(toggle.Config{
+    ID:      "containerToggle",
+    Label:   "Toggle",
+    Style:   toggle.StyleContainer,
+    Checked: true,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Color Variations",
+				Description: "Set Variant: Primary, Secondary, Info, Success, Warning, or Danger.",
+			},
+			toggleColorsPreview(),
+			`@toggle.Toggle(toggle.Config{ID: "successToggle", Label: "success", Variant: toggle.Success, Checked: true})
+@toggle.Toggle(toggle.Config{ID: "dangerToggle", Label: "danger", Variant: toggle.Danger, Checked: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Disabled States",
+				Description: "Disabled: true blocks interaction in both the off and on positions.",
+			},
+			toggleDisabledPreview(),
+			`@toggle.Toggle(toggle.Config{ID: "offToggle", Label: "Disabled (off)", Disabled: true})
+@toggle.Toggle(toggle.Config{ID: "onToggle", Label: "Disabled (on)", Checked: true, Disabled: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the toggle input (and label's for target)."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
+			{Name: "Label", Type: "string", Default: `""`, Description: "Label text beside the switch."},
+			{Name: "Checked", Type: "bool", Default: "false", Description: "Initial on state."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
+			{Name: "Variant", Type: "Variant", Default: "Primary", Description: `Color: "primary", "secondary", "info", "success", "warning", "danger".`},
+			{Name: "Style", Type: "Style", Default: "StyleDefault", Description: `Layout: "default" (inline) or "container" (bordered).`},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the toggle root."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -108,8 +147,8 @@ func toggleDemoContent() templ.Component {
 	})
 }
 
-// toggleDemoPreview renders the Goshtoso toggle preview
-func toggleDemoPreview() templ.Component {
+// toggleDefaultPreview renders the default toggle.
+func toggleDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -130,111 +169,153 @@ func toggleDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Toggle</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"toggle-default\" class=\"w-full max-w-md mx-auto\"><div class=\"flex flex-wrap gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{
-			ID:      "demoDefault",
-			Label:   "Toggle",
-			Checked: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{ID: "demoDefault", Label: "Toggle", Checked: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Toggle with Container</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{
-			ID:      "demoContainer",
-			Label:   "Toggle",
-			Style:   toggle.StyleContainer,
-			Checked: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		return nil
+	})
+}
+
+// toggleContainerPreview renders the container-style toggle.
+func toggleContainerPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"toggle-container\" class=\"w-full max-w-md mx-auto\"><div class=\"flex flex-wrap gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Color Variations</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{ID: "demoContainer", Label: "Toggle", Style: toggle.StyleContainer, Checked: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{
-			ID:      "demoPrimary",
-			Label:   "primary",
-			Variant: toggle.Primary,
-			Checked: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{
-			ID:      "demoSecondary",
-			Label:   "secondary",
-			Variant: toggle.Secondary,
-			Checked: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		return nil
+	})
+}
+
+// toggleColorsPreview renders the six color variants.
+func toggleColorsPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"toggle-colors\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{
-			ID:      "demoSuccess",
-			Label:   "success",
-			Variant: toggle.Success,
-			Checked: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{ID: "demoPrimary", Label: "primary", Variant: toggle.Primary, Checked: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{
-			ID:      "demoWarning",
-			Label:   "warning",
-			Variant: toggle.Warning,
-			Checked: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{ID: "demoSecondary", Label: "secondary", Variant: toggle.Secondary, Checked: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{
-			ID:      "demoDanger",
-			Label:   "danger",
-			Variant: toggle.Danger,
-			Checked: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{ID: "demoSuccess", Label: "success", Variant: toggle.Success, Checked: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{
-			ID:      "demoInfo",
-			Label:   "info",
-			Variant: toggle.Info,
-			Checked: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{ID: "demoWarning", Label: "warning", Variant: toggle.Warning, Checked: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Disabled States</h4><div class=\"flex flex-wrap gap-4\">")
+		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{ID: "demoDanger", Label: "danger", Variant: toggle.Danger, Checked: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{
-			ID:       "demoDisabledOff",
-			Label:    "Disabled (off)",
-			Disabled: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{ID: "demoInfo", Label: "info", Variant: toggle.Info, Checked: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{
-			ID:       "demoDisabledOn",
-			Label:    "Disabled (on)",
-			Checked:  true,
-			Disabled: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div></div>")
+		return nil
+	})
+}
+
+// toggleDisabledPreview renders the disabled off/on states.
+func toggleDisabledPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"toggle-disabled\" class=\"w-full max-w-md mx-auto\"><div class=\"flex flex-wrap gap-4\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{ID: "demoDisabledOff", Label: "Disabled (off)", Disabled: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = toggle.Toggle(toggle.Config{ID: "demoDisabledOn", Label: "Disabled (on)", Checked: true, Disabled: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/tooltip.templ
+++ b/internal/pages/demo/components/tooltip.templ
@@ -10,54 +10,69 @@ templ TooltipDemoPage() {
 	@demo.Layout("Tooltip", "tooltip", tooltipDemoContent())
 }
 
-// tooltipDemoContent renders the actual content inside the layout
+// tooltipDemoContent renders the demo. Each tooltip variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/tooltip). Wrapped in #tooltip-fragment.
 templ tooltipDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Tooltip",
-			Description:   "A tooltip displays informative text when users hover over, focus on, or click an element. Useful for providing additional context without cluttering the interface.",
-		},
-		tooltipDemoPreview(),
-		`// Simple Tooltip (top, hover)
-@tooltip.Tooltip(tooltip.Config{
+	<div id="tooltip-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Tooltip",
+				Description: "Informative text shown on hover, focus, or click. Four positions (top, bottom, left, right), optional rich description, and hover or click triggers.",
+			},
+			tooltipDefaultPreview(),
+			`@tooltip.Tooltip(tooltip.Config{
     ID:          "myTooltip",
     Text:        "Tooltip top",
-    TriggerText: "Hover Me",
-})
+    Position:    tooltip.Top,
+    TriggerText: "Top",
+})`,
+		)
 
-// Tooltip with position
-@tooltip.Tooltip(tooltip.Config{
-    ID:          "bottomTooltip",
-    Text:        "Tooltip bottom",
-    Position:    tooltip.Bottom,
-    TriggerText: "Hover Me",
-})
-
-// Rich tooltip with description
-@tooltip.Tooltip(tooltip.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Description",
+				Description: "Add a Description for a richer two-line tooltip.",
+			},
+			tooltipRichPreview(),
+			`@tooltip.Tooltip(tooltip.Config{
     ID:          "richTooltip",
     Text:        "Tooltip top",
     Description: "A rich tooltip with longer text.",
     TriggerText: "Hover Me",
-})
+})`,
+		)
 
-// Click tooltip
-@tooltip.Tooltip(tooltip.Config{
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Click Trigger",
+				Description: "Set Trigger: tooltip.Click to toggle the tooltip on click instead of hover.",
+			},
+			tooltipClickPreview(),
+			`@tooltip.Tooltip(tooltip.Config{
     ID:          "clickTooltip",
     Text:        "Tooltip top",
     Trigger:     tooltip.Click,
     TriggerText: "Click Me",
 })`,
-	)
+		)
+	</div>
+	// API reference lives outside #tooltip-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id (wires the trigger to the tooltip for accessibility)."},
+		{Name: "Text", Type: "string", Default: `""`, Description: "Tooltip text (heading line)."},
+		{Name: "Description", Type: "string", Default: `""`, Description: "Optional secondary line for a rich tooltip."},
+		{Name: "Position", Type: "Position", Default: "Top", Description: `Placement: "top", "bottom", "left", "right".`},
+		{Name: "Trigger", Type: "Trigger", Default: "Hover", Description: `Activation: "hover" (hover/focus) or "click".`},
+		{Name: "TriggerText", Type: "string", Default: `""`, Description: "Text of the trigger element."},
+		{Name: "TriggerContent", Type: "templ.Component", Default: "nil", Description: "Custom trigger content (overrides TriggerText)."},
+	})
 }
 
-// tooltipDemoPreview renders the Goshtoso tooltip preview
-templ tooltipDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		// Default Hover Tooltips (all positions)
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Default Tooltip (Hover)</h4>
-			<div class="flex flex-wrap items-center gap-8 py-8 justify-center">
+// tooltipDefaultPreview renders the four hover positions.
+templ tooltipDefaultPreview() {
+	<div id="tooltip-default" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap items-center gap-8 py-8 justify-center">
 				@tooltip.Tooltip(tooltip.Config{
 					ID:          "demoTop",
 					Text:        "Tooltip top",
@@ -84,11 +99,12 @@ templ tooltipDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Rich Tooltip with Description
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Tooltip with Description</h4>
-			<div class="flex flex-wrap items-center gap-8 py-8 justify-center">
+// tooltipRichPreview renders the rich (description) tooltips.
+templ tooltipRichPreview() {
+	<div id="tooltip-rich" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap items-center gap-8 py-8 justify-center">
 				@tooltip.Tooltip(tooltip.Config{
 					ID:          "richTop",
 					Text:        "Tooltip top",
@@ -105,11 +121,12 @@ templ tooltipDemoPreview() {
 				})
 			</div>
 		</div>
+}
 
-		// Click Tooltip
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Click Tooltip</h4>
-			<div class="flex flex-wrap items-center gap-8 py-8 justify-center">
+// tooltipClickPreview renders the click-trigger tooltips.
+templ tooltipClickPreview() {
+	<div id="tooltip-click" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap items-center gap-8 py-8 justify-center">
 				@tooltip.Tooltip(tooltip.Config{
 					ID:          "clickTop",
 					Text:        "Tooltip top",
@@ -126,5 +143,4 @@ templ tooltipDemoPreview() {
 				})
 			</div>
 		</div>
-	</div>
 }

--- a/internal/pages/demo/components/tooltip_templ.go
+++ b/internal/pages/demo/components/tooltip_templ.go
@@ -43,7 +43,9 @@ func TooltipDemoPage() templ.Component {
 	})
 }
 
-// tooltipDemoContent renders the actual content inside the layout
+// tooltipDemoContent renders the demo. Each tooltip variant lives in its own
+// preview frame followed by its own code block (mirrors
+// penguinui.com/components/tooltip). Wrapped in #tooltip-fragment.
 func tooltipDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -65,37 +67,49 @@ func tooltipDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"tooltip-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Tooltip",
-				Description: "A tooltip displays informative text when users hover over, focus on, or click an element. Useful for providing additional context without cluttering the interface.",
+				Description: "Informative text shown on hover, focus, or click. Four positions (top, bottom, left, right), optional rich description, and hover or click triggers.",
 			},
-			tooltipDemoPreview(),
-			`// Simple Tooltip (top, hover)
-@tooltip.Tooltip(tooltip.Config{
+			tooltipDefaultPreview(),
+			`@tooltip.Tooltip(tooltip.Config{
     ID:          "myTooltip",
     Text:        "Tooltip top",
-    TriggerText: "Hover Me",
-})
-
-// Tooltip with position
-@tooltip.Tooltip(tooltip.Config{
-    ID:          "bottomTooltip",
-    Text:        "Tooltip bottom",
-    Position:    tooltip.Bottom,
-    TriggerText: "Hover Me",
-})
-
-// Rich tooltip with description
-@tooltip.Tooltip(tooltip.Config{
+    Position:    tooltip.Top,
+    TriggerText: "Top",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "With Description",
+				Description: "Add a Description for a richer two-line tooltip.",
+			},
+			tooltipRichPreview(),
+			`@tooltip.Tooltip(tooltip.Config{
     ID:          "richTooltip",
     Text:        "Tooltip top",
     Description: "A rich tooltip with longer text.",
     TriggerText: "Hover Me",
-})
-
-// Click tooltip
-@tooltip.Tooltip(tooltip.Config{
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Click Trigger",
+				Description: "Set Trigger: tooltip.Click to toggle the tooltip on click instead of hover.",
+			},
+			tooltipClickPreview(),
+			`@tooltip.Tooltip(tooltip.Config{
     ID:          "clickTooltip",
     Text:        "Tooltip top",
     Trigger:     tooltip.Click,
@@ -105,12 +119,28 @@ func tooltipDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id (wires the trigger to the tooltip for accessibility)."},
+			{Name: "Text", Type: "string", Default: `""`, Description: "Tooltip text (heading line)."},
+			{Name: "Description", Type: "string", Default: `""`, Description: "Optional secondary line for a rich tooltip."},
+			{Name: "Position", Type: "Position", Default: "Top", Description: `Placement: "top", "bottom", "left", "right".`},
+			{Name: "Trigger", Type: "Trigger", Default: "Hover", Description: `Activation: "hover" (hover/focus) or "click".`},
+			{Name: "TriggerText", Type: "string", Default: `""`, Description: "Text of the trigger element."},
+			{Name: "TriggerContent", Type: "templ.Component", Default: "nil", Description: "Custom trigger content (overrides TriggerText)."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-// tooltipDemoPreview renders the Goshtoso tooltip preview
-func tooltipDemoPreview() templ.Component {
+// tooltipDefaultPreview renders the four hover positions.
+func tooltipDefaultPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -131,7 +161,7 @@ func tooltipDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Default Tooltip (Hover)</h4><div class=\"flex flex-wrap items-center gap-8 py-8 justify-center\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"tooltip-default\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center gap-8 py-8 justify-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -171,7 +201,37 @@ func tooltipDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Tooltip with Description</h4><div class=\"flex flex-wrap items-center gap-8 py-8 justify-center\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tooltipRichPreview renders the rich (description) tooltips.
+func tooltipRichPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"tooltip-rich\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center gap-8 py-8 justify-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -195,7 +255,37 @@ func tooltipDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Click Tooltip</h4><div class=\"flex flex-wrap items-center gap-8 py-8 justify-center\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tooltipClickPreview renders the click-trigger tooltips.
+func tooltipClickPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"tooltip-click\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center gap-8 py-8 justify-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -219,7 +309,7 @@ func tooltipDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/pages/demo/components/triplet.templ
+++ b/internal/pages/demo/components/triplet.templ
@@ -11,14 +11,14 @@ templ TripletDemoPage() {
 }
 
 templ tripletDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:       "Triplet",
-			Description: "Dynamic 3-field rows for key-value-effect data (e.g., Kubernetes taints). Each row has two text inputs and a dropdown. Powered by Alpine.js.",
-		},
-		tripletDemoPreview(),
-		`// Triplet (K8s Taints example)
-@triplet.Triplet(triplet.Config{
+	<div id="triplet-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Triplet",
+				Description: "Dynamic 3-field rows for key-value-effect data (e.g. Kubernetes taints). Each row has two text inputs and an effect dropdown. Powered by Alpine.js.",
+			},
+			tripletTaintsPreview(),
+			`@triplet.Triplet(triplet.Config{
     ID:   "taints",
     Name: "taints",
     Entries: []triplet.Entry{
@@ -26,55 +26,83 @@ templ tripletDemoContent() {
     },
     EffectOptions: []triplet.EffectOption{
         {Value: "NoSchedule", Display: "NoSchedule"},
-        {Value: "PreferNoSchedule", Display: "PreferNoSchedule"},
         {Value: "NoExecute", Display: "NoExecute"},
     },
     KeyPlaceholder:   "key",
     ValuePlaceholder: "value",
     AddLabel:         "Add taint",
 })`,
-	)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Generic Priority Rows",
+				Description: "The same component with a different EffectOptions set and no initial Entries.",
+			},
+			tripletGenericPreview(),
+			`@triplet.Triplet(triplet.Config{
+    ID:   "rules",
+    Name: "rules",
+    EffectOptions: []triplet.EffectOption{
+        {Value: "high", Display: "High"},
+        {Value: "low", Display: "Low"},
+    },
+    KeyPlaceholder:   "rule name",
+    ValuePlaceholder: "condition",
+    AddLabel:         "Add rule",
+})`,
+		)
+	</div>
+	// API reference lives outside #triplet-fragment.
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the triplet root (Alpine scope)."},
+		{Name: "Name", Type: "string", Default: `""`, Description: "Base form field name for the submitted rows."},
+		{Name: "Entries", Type: "[]Entry", Default: "nil", Description: "Initial rows (Key, Value, Effect)."},
+		{Name: "EffectOptions", Type: "[]EffectOption", Default: "nil", Description: "Options for the per-row effect dropdown (Value, Display)."},
+		{Name: "DefaultEffect", Type: "string", Default: `""`, Description: "Effect value applied to newly added rows."},
+		{Name: "KeyPlaceholder", Type: "string", Default: `""`, Description: "Placeholder for the key input."},
+		{Name: "ValuePlaceholder", Type: "string", Default: `""`, Description: "Placeholder for the value input."},
+		{Name: "AddLabel", Type: "string", Default: `"Add"`, Description: "Label of the add-row button."},
+		{Name: "Disabled", Type: "bool", Default: "false", Description: "Render read-only rows."},
+		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+	})
 }
 
-templ tripletDemoPreview() {
-	<div class="w-full max-w-4xl mx-auto space-y-8">
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Kubernetes Taints</h4>
-			<div class="max-w-2xl">
-				@triplet.Triplet(triplet.Config{
-					ID:   "taintsDemo",
-					Name: "taints",
-					Entries: []triplet.Entry{
-						{Key: "node-role.kubernetes.io/control-plane", Value: "true", Effect: "NoSchedule"},
-					},
-					EffectOptions: []triplet.EffectOption{
-						{Value: "NoSchedule", Display: "NoSchedule"},
-						{Value: "PreferNoSchedule", Display: "PreferNoSchedule"},
-						{Value: "NoExecute", Display: "NoExecute"},
-					},
-					KeyPlaceholder:   "key (e.g. node-role.kubernetes.io/control-plane)",
-					ValuePlaceholder: "value (e.g. true)",
-					AddLabel:         "Add taint",
-				})
-			</div>
-		</div>
+// tripletTaintsPreview renders the Kubernetes-taints example.
+templ tripletTaintsPreview() {
+	<div id="triplet-taints" class="w-full max-w-2xl mx-auto">
+		@triplet.Triplet(triplet.Config{
+			ID:   "taintsDemo",
+			Name: "taints",
+			Entries: []triplet.Entry{
+				{Key: "node-role.kubernetes.io/control-plane", Value: "true", Effect: "NoSchedule"},
+			},
+			EffectOptions: []triplet.EffectOption{
+				{Value: "NoSchedule", Display: "NoSchedule"},
+				{Value: "PreferNoSchedule", Display: "PreferNoSchedule"},
+				{Value: "NoExecute", Display: "NoExecute"},
+			},
+			KeyPlaceholder:   "key (e.g. node-role.kubernetes.io/control-plane)",
+			ValuePlaceholder: "value (e.g. true)",
+			AddLabel:         "Add taint",
+		})
+	</div>
+}
 
-		<div>
-			<h4 class="text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong">Generic Priority Rows</h4>
-			<div class="max-w-2xl">
-				@triplet.Triplet(triplet.Config{
-					ID:   "priorityDemo",
-					Name: "rules",
-					EffectOptions: []triplet.EffectOption{
-						{Value: "high", Display: "High"},
-						{Value: "medium", Display: "Medium"},
-						{Value: "low", Display: "Low"},
-					},
-					KeyPlaceholder:   "rule name",
-					ValuePlaceholder: "condition",
-					AddLabel:         "Add rule",
-				})
-			</div>
-		</div>
+// tripletGenericPreview renders the generic priority-rows example.
+templ tripletGenericPreview() {
+	<div id="triplet-generic" class="w-full max-w-2xl mx-auto">
+		@triplet.Triplet(triplet.Config{
+			ID:   "priorityDemo",
+			Name: "rules",
+			EffectOptions: []triplet.EffectOption{
+				{Value: "high", Display: "High"},
+				{Value: "medium", Display: "Medium"},
+				{Value: "low", Display: "Low"},
+			},
+			KeyPlaceholder:   "rule name",
+			ValuePlaceholder: "condition",
+			AddLabel:         "Add rule",
+		})
 	</div>
 }

--- a/internal/pages/demo/components/triplet_templ.go
+++ b/internal/pages/demo/components/triplet_templ.go
@@ -64,14 +64,17 @@ func tripletDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"triplet-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Triplet",
-				Description: "Dynamic 3-field rows for key-value-effect data (e.g., Kubernetes taints). Each row has two text inputs and a dropdown. Powered by Alpine.js.",
+				Description: "Dynamic 3-field rows for key-value-effect data (e.g. Kubernetes taints). Each row has two text inputs and an effect dropdown. Powered by Alpine.js.",
 			},
-			tripletDemoPreview(),
-			`// Triplet (K8s Taints example)
-@triplet.Triplet(triplet.Config{
+			tripletTaintsPreview(),
+			`@triplet.Triplet(triplet.Config{
     ID:   "taints",
     Name: "taints",
     Entries: []triplet.Entry{
@@ -79,7 +82,6 @@ func tripletDemoContent() templ.Component {
     },
     EffectOptions: []triplet.EffectOption{
         {Value: "NoSchedule", Display: "NoSchedule"},
-        {Value: "PreferNoSchedule", Display: "PreferNoSchedule"},
         {Value: "NoExecute", Display: "NoExecute"},
     },
     KeyPlaceholder:   "key",
@@ -90,11 +92,52 @@ func tripletDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Generic Priority Rows",
+				Description: "The same component with a different EffectOptions set and no initial Entries.",
+			},
+			tripletGenericPreview(),
+			`@triplet.Triplet(triplet.Config{
+    ID:   "rules",
+    Name: "rules",
+    EffectOptions: []triplet.EffectOption{
+        {Value: "high", Display: "High"},
+        {Value: "low", Display: "Low"},
+    },
+    KeyPlaceholder:   "rule name",
+    ValuePlaceholder: "condition",
+    AddLabel:         "Add rule",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the triplet root (Alpine scope)."},
+			{Name: "Name", Type: "string", Default: `""`, Description: "Base form field name for the submitted rows."},
+			{Name: "Entries", Type: "[]Entry", Default: "nil", Description: "Initial rows (Key, Value, Effect)."},
+			{Name: "EffectOptions", Type: "[]EffectOption", Default: "nil", Description: "Options for the per-row effect dropdown (Value, Display)."},
+			{Name: "DefaultEffect", Type: "string", Default: `""`, Description: "Effect value applied to newly added rows."},
+			{Name: "KeyPlaceholder", Type: "string", Default: `""`, Description: "Placeholder for the key input."},
+			{Name: "ValuePlaceholder", Type: "string", Default: `""`, Description: "Placeholder for the value input."},
+			{Name: "AddLabel", Type: "string", Default: `"Add"`, Description: "Label of the add-row button."},
+			{Name: "Disabled", Type: "bool", Default: "false", Description: "Render read-only rows."},
+			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		return nil
 	})
 }
 
-func tripletDemoPreview() templ.Component {
+// tripletTaintsPreview renders the Kubernetes-taints example.
+func tripletTaintsPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -115,7 +158,7 @@ func tripletDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-4xl mx-auto space-y-8\"><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Kubernetes Taints</h4><div class=\"max-w-2xl\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"triplet-taints\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -137,7 +180,37 @@ func tripletDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div></div><div><h4 class=\"text-sm font-medium mb-3 text-on-surface-strong dark:text-on-surface-dark-strong\">Generic Priority Rows</h4><div class=\"max-w-2xl\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// tripletGenericPreview renders the generic priority-rows example.
+func tripletGenericPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"triplet-generic\" class=\"w-full max-w-2xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -156,7 +229,7 @@ func tripletDemoPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/tests/e2e/table_test.go
+++ b/tests/e2e/table_test.go
@@ -117,8 +117,9 @@ func TestTable_StripedVariant(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Striped_Rows_Have_Even_Classes", func(t *testing.T) {
-		stripedHeading := page.Locator("h4:has-text('Striped Table')")
-		stripedSection := stripedHeading.Locator("xpath=..")
+		// Scope to the per-variant preview wrapper (#table-striped) so the
+		// codeblock's syntax-highlight spans never leak into the table query.
+		stripedSection := page.Locator("#table-striped")
 
 		rows := stripedSection.Locator("table tbody tr")
 		count, err := rows.Count()
@@ -154,8 +155,7 @@ func TestTable_WithCheckbox(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Checkbox_Table_Has_Checkboxes", func(t *testing.T) {
-		checkboxHeading := page.Locator("h4:has-text('Table with Checkbox')")
-		checkboxSection := checkboxHeading.Locator("xpath=..")
+		checkboxSection := page.Locator("#table-checkbox")
 
 		checkboxes := checkboxSection.Locator("input[type='checkbox']")
 		count, err := checkboxes.Count()
@@ -166,8 +166,7 @@ func TestTable_WithCheckbox(t *testing.T) {
 	})
 
 	t.Run("Check_All_Selects_All_Rows", func(t *testing.T) {
-		checkboxHeading := page.Locator("h4:has-text('Table with Checkbox')")
-		checkboxSection := checkboxHeading.Locator("xpath=..")
+		checkboxSection := page.Locator("#table-checkbox")
 
 		headerCheckbox := checkboxSection.Locator("thead input[type='checkbox']")
 		err := headerCheckbox.Click()
@@ -208,8 +207,7 @@ func TestTable_WithAction(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Action_Table_Has_Edit_Buttons", func(t *testing.T) {
-		actionHeading := page.Locator("h4:has-text('Table with Action')")
-		actionSection := actionHeading.Locator("xpath=..")
+		actionSection := page.Locator("#table-action")
 
 		editButtons := actionSection.Locator("button:has-text('Edit')")
 		count, err := editButtons.Count()
@@ -245,8 +243,7 @@ func TestTable_UsersTable(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("Users_Table_Has_Avatars", func(t *testing.T) {
-		usersHeading := page.Locator("h4:has-text('Users Table')")
-		usersSection := usersHeading.Locator("xpath=..")
+		usersSection := page.Locator("#table-users")
 
 		avatars := usersSection.Locator("td img[src*='avatar-']")
 		count, err := avatars.Count()
@@ -257,8 +254,7 @@ func TestTable_UsersTable(t *testing.T) {
 	})
 
 	t.Run("Users_Table_Has_Status_Badges", func(t *testing.T) {
-		usersHeading := page.Locator("h4:has-text('Users Table')")
-		usersSection := usersHeading.Locator("xpath=..")
+		usersSection := page.Locator("#table-users")
 
 		activeBadges := usersSection.Locator("span:has-text('Active')")
 		activeCount, err := activeBadges.Count()


### PR DESCRIPTION
## Summary
Converts every component demo page in `internal/pages/demo/components/` to the mandatory docs-page pattern (`component-docs` skill): one `demo.ComponentDemo` preview+code box for the primary variant, one `demo.DemoSection` per additional variant, a `demo.APIReference` table outside the `#<name>-fragment` e2e anchor, and the auto-built right-rail "On this page" TOC.

- **28 pages converted/conformed** across 25 commits (one per component or small batch): radio, card, textinput, table, carousel, badge, banner, alert, tabs, pagination, modal, fileinput, form, toast, spinner, tagslist, tooltip, toggle, textarea, checkbox, avatar, dropdown, select, button, combobox, plus the LOW pages (keyvalue, triplet, palette, form_validation) and the four hand-rolled bypass pages (breadcrumbs, navbar, sidebar, combobox-new).
- **API reference coverage** went from ~3/40 pages to every component page (via a bottom `demo.APIReference` call, or the inline `Props:` field for codeblock/steps).
- **e2e preserved**: kept every component-rendered selector (`Config.ID`, `data-testid`). Rescoped the four heading-scoped subtests in `table_test.go` (striped/checkbox/action/users) from `h4:has-text(...)` to unique per-variant container ids, because `DemoSection` emits `<h2>` and the codeblock's syntax-highlight `<span>`s could pollute `:has-text` counts.
- Shared Alpine `x-data` scopes (avatar size selector, palette picked/shellPicked) wrap their whole fragment so reactive children still work. Order-dependent `.First()` selectors (navbar) kept the simple variant first.
- combobox (v1) and combobox-new (v2) confirmed intentionally distinct — no dedupe. getting-started/landing/theme noted exempt in CLAUDE.md.

## Test Plan
- [x] `templ generate && go build -o bin/server ./cmd/server` — clean
- [x] `go test ./tests/e2e/... -count=1 -timeout 15m` — full suite green (169s, 381+ tests, 0 skips)
- [x] `golangci-lint run` — 0 source-file issues (generated `*_templ.go` excluded via `generated: strict`)
- [ ] Spot-check a few pages in the browser: per-variant boxes, bottom API table, right-rail TOC (≥xl) with working `#<variant>` deep links

🤖 Generated with [Claude Code](https://claude.com/claude-code)