### PR TITLE
fix(avatar): render on first fragment-nav paint + escape Src in x-on:error

### DIFF
--- a/components/avatar/avatar.templ
+++ b/components/avatar/avatar.templ
@@ -150,7 +150,7 @@ templ layerImage(cfg Config) {
 			src={ cfg.Src }
 		}
 		x-on:load="imgLoaded = true"
-		x-on:error={ fmt.Sprintf("imgError = true; console.warn('[avatar] failed to load image:', '%s')", cfg.Src) }
+		x-on:error={ fmt.Sprintf("imgError = true; console.warn('[avatar] failed to load image:', '%s')", jsEscapeSingle(cfg.Src)) }
 		alt={ cfg.Alt }
 		class="absolute inset-0 h-full w-full object-cover object-center"
 	/>

--- a/components/avatar/avatar_templ.go
+++ b/components/avatar/avatar_templ.go
@@ -501,9 +501,9 @@ func layerImage(cfg Config) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var21 string
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("imgError = true; console.warn('[avatar] failed to load image:', '%s')", cfg.Src))
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("imgError = true; console.warn('[avatar] failed to load image:', '%s')", jsEscapeSingle(cfg.Src)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 153, Col: 108}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 153, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 		if templ_7745c5c3_Err != nil {

--- a/components/avatar/types.go
+++ b/components/avatar/types.go
@@ -293,6 +293,25 @@ func toUpper(b byte) string {
 	return string(b)
 }
 
+// jsEscapeSingle escapes a string for safe embedding inside a single-quoted
+// JS string literal. Without this, a Src containing a single quote (data URIs
+// frequently do, e.g. `viewBox='0 0 64 64'`) would terminate the string early
+// and break the x-on:error handler with a SyntaxError at Alpine compile time.
+func jsEscapeSingle(s string) string {
+	result := ""
+	for _, c := range s {
+		switch c {
+		case '\'':
+			result += `\'`
+		case '\\':
+			result += `\\`
+		default:
+			result += string(c)
+		}
+	}
+	return result
+}
+
 func splitWords(s string) []string {
 	var result []string
 	var current string

--- a/internal/pages/demo/components/avatar.templ
+++ b/internal/pages/demo/components/avatar.templ
@@ -18,8 +18,8 @@ templ AvatarDemoPage() {
 // trap with quoted JS object literals.
 templ avatarShowcaseScript() {
 	@templ.Raw(`<script>
-document.addEventListener('alpine:init', () => {
-  Alpine.data('avatarShowcase', () => ({
+(function () {
+  var factory = () => ({
     selected: 'md',
     sizes: ['xs','sm','md','lg','xl','2xl'],
     sizeMap: {
@@ -36,8 +36,20 @@ document.addEventListener('alpine:init', () => {
     },
     get avatarSizeClass()       { return this.sizeMap[this.selected]; },
     get avatarStatusSizeClass() { return this.statusSizeMap[this.selected]; }
-  }));
-});
+  });
+  // Full page load: Alpine isn't running yet, so defer to alpine:init.
+  // htmx fragment nav: Alpine is already running and alpine:init never
+  // re-fires, so register immediately and re-init any x-data="avatarShowcase"
+  // the layout's htmx:afterSwap initTree may have walked before this script ran.
+  if (window.Alpine && window.Alpine.version) {
+    Alpine.data('avatarShowcase', factory);
+    document.querySelectorAll('[x-data="avatarShowcase"]').forEach((el) => {
+      if (typeof Alpine.initTree === 'function') Alpine.initTree(el);
+    });
+  } else {
+    document.addEventListener('alpine:init', () => Alpine.data('avatarShowcase', factory));
+  }
+})();
 </script>`)
 }
 

--- a/internal/pages/demo/components/avatar_templ.go
+++ b/internal/pages/demo/components/avatar_templ.go
@@ -71,8 +71,8 @@ func avatarShowcaseScript() templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = templ.Raw(`<script>
-document.addEventListener('alpine:init', () => {
-  Alpine.data('avatarShowcase', () => ({
+(function () {
+  var factory = () => ({
     selected: 'md',
     sizes: ['xs','sm','md','lg','xl','2xl'],
     sizeMap: {
@@ -89,8 +89,20 @@ document.addEventListener('alpine:init', () => {
     },
     get avatarSizeClass()       { return this.sizeMap[this.selected]; },
     get avatarStatusSizeClass() { return this.statusSizeMap[this.selected]; }
-  }));
-});
+  });
+  // Full page load: Alpine isn't running yet, so defer to alpine:init.
+  // htmx fragment nav: Alpine is already running and alpine:init never
+  // re-fires, so register immediately and re-init any x-data="avatarShowcase"
+  // the layout's htmx:afterSwap initTree may have walked before this script ran.
+  if (window.Alpine && window.Alpine.version) {
+    Alpine.data('avatarShowcase', factory);
+    document.querySelectorAll('[x-data="avatarShowcase"]').forEach((el) => {
+      if (typeof Alpine.initTree === 'function') Alpine.initTree(el);
+    });
+  } else {
+    document.addEventListener('alpine:init', () => Alpine.data('avatarShowcase', factory));
+  }
+})();
 </script>`).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/tests/e2e/avatar_test.go
+++ b/tests/e2e/avatar_test.go
@@ -129,6 +129,64 @@ func TestAvatar_CachedReload(t *testing.T) {
 		"initials should still be hidden after cached reload")
 }
 
+// TestAvatar_FragmentNav_ShowcaseRegistered reproduces the first-render bug:
+// the demo registered Alpine.data('avatarShowcase') only on the 'alpine:init'
+// event, which does NOT re-fire on htmx fragment navigation. Arriving via the
+// sidebar (fragment swap) left x-data="avatarShowcase" undefined, so reactive
+// avatars never received a size class and the preview rendered broken until a
+// full-page refresh. Direct page.Goto (every other avatar test) never exercised
+// this path.
+func TestAvatar_FragmentNav_ShowcaseRegistered(t *testing.T) {
+	page := newIsolatedPage(t)
+
+	// pageErrors captures uncaught JS exceptions. The avatar component used to
+	// interpolate cfg.Src unescaped into the x-on:error single-quoted JS string;
+	// a data-URI Src (with embedded single quotes) broke it with a SyntaxError.
+	var pageErrors []string
+	page.On("pageerror", func(err error) { pageErrors = append(pageErrors, err.Error()) })
+
+	// consoleErrors captures console.error, EXCLUDING the intentional 404 from
+	// the error-fallback fixture (does-not-exist-404.png), which is expected.
+	var consoleErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" && !strings.Contains(m.Text(), "404") {
+			consoleErrors = append(consoleErrors, m.Text())
+		}
+	})
+
+	// Land elsewhere first, then navigate via the sidebar (fragment swap).
+	_, err := page.Goto(baseURL + "/getting-started")
+	require.NoError(t, err)
+	_, err = page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("a[href='/components/avatar']").First().Click())
+
+	// Wait for the avatar fragment to land.
+	require.NoError(t, page.Locator("[data-testid='avatar-section-image']").WaitFor(
+		playwright.LocatorWaitForOptions{
+			State:   playwright.WaitForSelectorStateAttached,
+			Timeout: playwright.Float(3000),
+		}))
+
+	// avatarShowcase must be registered after fragment nav: the size selector
+	// must drive the reactive avatars. Click 2xl and confirm a reactive avatar
+	// root picks up size-32. If avatarShowcase is undefined, the binding never
+	// applies and this times out.
+	require.NoError(t, page.Locator("label[for='avatar-size-2xl']").Click())
+	_, err = page.WaitForFunction(
+		`() => {
+			const roots = document.querySelectorAll("[data-testid='avatar-section-image'] .relative.inline-flex");
+			return Array.from(roots).some(el => (el.getAttribute('class') || '').includes('size-32'));
+		}`,
+		nil,
+		playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)})
+	require.NoError(t, err, "avatarShowcase must be registered after fragment nav so the size selector drives reactive avatars")
+
+	require.Empty(t, pageErrors, "no uncaught JS exceptions on fragment-nav avatar page: %v", pageErrors)
+	require.Empty(t, consoleErrors, "no unexpected console errors on fragment-nav avatar page: %v", consoleErrors)
+}
+
 // TestAvatar_SizeSelector_RendersSixPills verifies the interactive size selector
 // rendered six segmented radio pills (xs/sm/md/lg/xl/2xl).
 func TestAvatar_SizeSelector_RendersSixPills(t *testing.T) {


### PR DESCRIPTION
## Problem

Avatars rendered broken on first paint and only displayed correctly after a full-page refresh.

## Root causes

**1. `Alpine.data` registered only on `alpine:init` (the visible bug).**
The avatar demo registered `Alpine.data('avatarShowcase')` inside a `document.addEventListener('alpine:init', …)` callback. `alpine:init` fires once on full page load and **never re-fires on htmx fragment navigation**, so arriving via the sidebar left `x-data="avatarShowcase"` undefined → reactive avatars got no size class → broken. A refresh (full load) re-ran `alpine:init`, which is why it "worked after refresh."
Fixed with the dual-path registration already used by `theme.templ` / `table`: register immediately when Alpine is already running (and `initTree` the matching elements), else defer to `alpine:init`.

**2. `cfg.Src` interpolated unescaped into the `x-on:error` JS string (latent bug).**
`components/avatar/avatar.templ` embedded `cfg.Src` into a single-quoted JS string. A data-URI `Src` with embedded single quotes (`viewBox='0 0 64 64'`) terminated the string early → `SyntaxError: missing ) after argument list` pageerror on every avatar-page load. Wrapped `Src` in `jsEscapeSingle()` (added to `avatar/types.go`, mirrors tabs/toast/select).

## Why tests missed it

Every existing avatar e2e used direct `page.Goto` (full load) and never exercised the sidebar fragment-nav path — the exact gap CLAUDE.md flags for examples.

## Changes

- `internal/pages/demo/components/avatar.templ` — dual-path `Alpine.data` registration
- `components/avatar/avatar.templ` + `avatar/types.go` — `jsEscapeSingle(cfg.Src)` in `x-on:error`
- `tests/e2e/avatar_test.go` — new `TestAvatar_FragmentNav_ShowcaseRegistered` (selector drives reactive avatars + no uncaught JS exceptions on fragment nav)

## Verification

- Full e2e suite green (382 tests, ~177s)
- `golangci-lint run` + `go vet` clean
- `skillgen` produced no reference change (helper is unexported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)