### PR TITLE
ci: disable redundant setup-go cache (~9min/job saved)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
+          # NFS-backed GOMODCACHE/GOCACHE already persist across runs on the
+          # self-hosted araihu runner. setup-go's own cache tars+uploads that
+          # same tree to the GHA cache backend on every go.sum change — a ~9min
+          # post-job step that buys nothing here. Disable it.
+          cache: false
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}
@@ -94,7 +98,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
+          # NFS-backed GOMODCACHE/GOCACHE already persist across runs on the
+          # self-hosted araihu runner. setup-go's own cache tars+uploads that
+          # same tree to the GHA cache backend on every go.sum change — a ~9min
+          # post-job step that buys nothing here. Disable it.
+          cache: false
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}
@@ -123,7 +131,11 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
+          # NFS-backed GOMODCACHE/GOCACHE already persist across runs on the
+          # self-hosted araihu runner. setup-go's own cache tars+uploads that
+          # same tree to the GHA cache backend on every go.sum change — a ~9min
+          # post-job step that buys nothing here. Disable it.
+          cache: false
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}


### PR DESCRIPTION
## Problem

CI wall-clock ballooned to ~38min/PR during the examples push burst. Profiling a single E2E job showed the cost is **not** the test execution (~5min, healthy) but the `actions/setup-go` cache post-step:

```
E2E tests                    20:28:26 → 20:33:01   =  4m35s
Post Run actions/setup-go    20:33:01 → 20:41:54   =  8m53s   ⚠️
```

The araihu self-hosted runner already mounts **persistent NFS-backed** `GOMODCACHE` (`/home/runner/go`) and `GOCACHE` (`/home/runner/.cache`). `setup-go`'s `cache: true` layers a *second* cache: it tars that same tree and uploads it to the GHA cache backend at job end. Every `go.sum` change (frequent during the examples burst) misses the key and forces a full multi-GB re-save over NFS — ~9min, on all 3 jobs per PR.

## Fix

`cache: false` on all three `setup-go` steps. The NFS mounts already persist the Go caches across runs; the setup-go layer is pure overhead here.

## Impact

- Removes ~9min × 3 jobs of redundant cache save per PR
- Paired with the infra-side `maxRunners` 2→4 bump (lets a PR's 3 jobs run concurrently instead of serializing), PR wall-clock should drop from ~38m toward ~10m

🤖 Generated with [Claude Code](https://claude.com/claude-code)