### PR TITLE
feat(examples): profile page — Tabs split, Modal-confirm remove, upload Tooltip

### DIFF
--- a/internal/pages/demo/examples/profile.templ
+++ b/internal/pages/demo/examples/profile.templ
@@ -5,11 +5,14 @@ import (
 	"github.com/araihu/goshtoso/components/badge"
 	"github.com/araihu/goshtoso/components/button"
 	"github.com/araihu/goshtoso/components/fileinput"
+	"github.com/araihu/goshtoso/components/modal"
 	selectfield "github.com/araihu/goshtoso/components/select"
+	"github.com/araihu/goshtoso/components/tabs"
 	"github.com/araihu/goshtoso/components/textarea"
 	"github.com/araihu/goshtoso/components/textinput"
 	"github.com/araihu/goshtoso/components/toast"
 	"github.com/araihu/goshtoso/components/toggle"
+	"github.com/araihu/goshtoso/components/tooltip"
 	"github.com/araihu/goshtoso/internal/examples/profile"
 )
 
@@ -153,131 +156,161 @@ templ ProfileApp(s profile.State) {
 				mode reuse the app's own appearance engine.
 			</p>
 		</header>
-		<!-- Photos: avatar + cover, stored client-side in IndexedDB -->
-		<section id="profile-photos" class="rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt">
-			<div class="relative">
-				<!-- Cover image area -->
-				<div class="h-40 w-full overflow-hidden rounded-t-radius bg-surface dark:bg-surface-dark">
-					<img
-						x-show="bannerSrc"
-						x-bind:src="bannerSrc"
-						alt="Cover image"
-						class="h-40 w-full object-cover"
-					/>
-					<div
-						x-show="!bannerSrc"
-						class="flex h-40 w-full items-center justify-center text-sm text-on-surface-muted dark:text-on-surface-dark-muted"
-					>
-						No cover image
-					</div>
-				</div>
-				<!-- Avatar, overlapping the cover -->
-				<div id="profile-avatar" class="-mt-12 flex justify-center">
-					@avatar.Avatar(avatar.Config{
-						SrcExpr: "avatarSrc",
-						Name:    s.Name,
-						Size:    avatar.SizeXL,
-						Shape:   avatar.ShapeCircle,
-						Border:  true,
-					})
-				</div>
-			</div>
-			<!-- Hidden file inputs driven by the Upload buttons -->
-			@fileinput.FileInput(fileinput.Config{
-				ID:     "profile-avatar-input",
-				Accept: "image/*",
-				Class:  "hidden",
-				Attrs:  templ.Attributes{"x-on:change": "onFile('avatar', $event)"},
-			})
-			@fileinput.FileInput(fileinput.Config{
-				ID:     "profile-banner-input",
-				Accept: "image/*",
-				Class:  "hidden",
-				Attrs:  templ.Attributes{"x-on:change": "onFile('banner', $event)"},
-			})
-			<div class="flex flex-wrap items-center justify-center gap-3 p-4">
-				@button.Button(button.Config{
-					Variant: button.Secondary,
-					Size:    button.SizeSmall,
-					Type:    "button",
-					Alpine:  &button.AlpineConfig{OnClick: "pick('avatar')"},
-				}) {
-					Upload avatar
-				}
-				@button.Button(button.Config{
-					Variant: button.Secondary,
-					Size:    button.SizeSmall,
-					Type:    "button",
-					Alpine:  &button.AlpineConfig{OnClick: "pick('banner')"},
-				}) {
-					Upload cover
-				}
-				@button.Button(button.Config{
-					Variant: button.Danger,
-					Size:    button.SizeSmall,
-					Type:    "button",
-					Alpine: &button.AlpineConfig{
-						OnClick: "remove('avatar'); remove('banner')",
-						Show:    "avatarSrc || bannerSrc",
-					},
-				}) {
-					Remove photos
-				}
-			</div>
-			<p class="px-4 pb-4 text-center text-xs text-on-surface-muted dark:text-on-surface-dark-muted">
-				Images stay on this device (IndexedDB). PNG, JPG, WebP, or GIF, up to 1 MB.
-			</p>
-		</section>
-		<!-- Identity: name + bio, cookie-backed via HTMX -->
-		<section id="profile-identity-section" class="mt-6 rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt">
-			<div class="flex flex-col gap-4 p-4">
-				<h2 class="text-lg font-semibold text-on-surface dark:text-on-surface-dark">Identity</h2>
-				<form
-					class="flex flex-col gap-4"
-					hx-post="/api/examples/profile/identity"
-					hx-target="#profile-identity"
-					hx-swap="outerHTML"
-				>
-					@IdentityFields(s)
-					<div class="flex justify-end">
-						@button.Button(button.Config{Type: "submit", Variant: button.Primary}) {
-							Save
-						}
-					</div>
-				</form>
-			</div>
-		</section>
-		<!-- Appearance: theme + dark mode, reusing the app's existing engine -->
-		<section id="profile-appearance" class="mt-6 rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt">
-			<div class="flex flex-col gap-4 p-4">
-				<div class="flex items-center gap-2">
-					<h2 class="text-lg font-semibold text-on-surface dark:text-on-surface-dark">Appearance</h2>
-					@badge.Badge(badge.Config{Variant: badge.Secondary, Text: "live"})
-				</div>
-				<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted">
-					These reuse the app's own theme engine — changes apply instantly and persist in your browser.
-				</p>
-				<div class="sm:w-64">
-					@selectfield.Select(selectfield.Config{
-						ID:          "profile-theme",
-						Name:        "theme",
-						Label:       "Theme",
-						AlpineModel: "theme",
-						Options:     themeOptions(""),
-					})
-				</div>
-				@toggle.Toggle(toggle.Config{
-					ID:    "profile-dark",
-					Label: "Dark mode",
-					Attrs: templ.Attributes{
-						"x-bind:checked": "$store.darkMode.on",
-						"x-on:change":    "$store.darkMode.toggle()",
-					},
-				})
-			</div>
-		</section>
+		@tabs.Tabs(tabs.Config{
+			ID:         "profile-tabs",
+			DefaultTab: "profile",
+			Tabs: []tabs.Tab{
+				{ID: "profile", Label: "Profile", Content: profileMainPanel(s)},
+				{ID: "appearance", Label: "Appearance", Content: profileAppearancePanel()},
+			},
+		})
 		@toast.Container(toast.ContainerConfig{})
 	</div>
+}
+
+// profileMainPanel is the "Profile" tab: photos (avatar + cover, IndexedDB) and
+// identity (name + bio, cookie-backed via HTMX). It lives inside the
+// #profile-fragment x-data="profileImages" wrapper, so avatarSrc/bannerSrc and
+// the avatar <img> persist across tab switches (tab panels are x-show toggled,
+// never unmounted).
+templ profileMainPanel(s profile.State) {
+	<!-- Photos: avatar + cover, stored client-side in IndexedDB -->
+	<section id="profile-photos" class="rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt">
+		<div class="relative">
+			<!-- Cover image area -->
+			<div class="h-40 w-full overflow-hidden rounded-t-radius bg-surface dark:bg-surface-dark">
+				<img
+					x-show="bannerSrc"
+					x-bind:src="bannerSrc"
+					alt="Cover image"
+					class="h-40 w-full object-cover"
+				/>
+				<div
+					x-show="!bannerSrc"
+					class="flex h-40 w-full items-center justify-center text-sm text-on-surface-muted dark:text-on-surface-dark-muted"
+				>
+					No cover image
+				</div>
+			</div>
+			<!-- Avatar, overlapping the cover -->
+			<div id="profile-avatar" class="-mt-12 flex justify-center">
+				@avatar.Avatar(avatar.Config{
+					SrcExpr: "avatarSrc",
+					Name:    s.Name,
+					Size:    avatar.SizeXL,
+					Shape:   avatar.ShapeCircle,
+					Border:  true,
+				})
+			</div>
+		</div>
+		<!-- Hidden file inputs driven by the Upload buttons -->
+		@fileinput.FileInput(fileinput.Config{
+			ID:     "profile-avatar-input",
+			Accept: "image/*",
+			Class:  "hidden",
+			Attrs:  templ.Attributes{"x-on:change": "onFile('avatar', $event)"},
+		})
+		@fileinput.FileInput(fileinput.Config{
+			ID:     "profile-banner-input",
+			Accept: "image/*",
+			Class:  "hidden",
+			Attrs:  templ.Attributes{"x-on:change": "onFile('banner', $event)"},
+		})
+		<div class="flex flex-wrap items-center justify-center gap-3 p-4">
+			@button.Button(button.Config{
+				Variant: button.Secondary,
+				Size:    button.SizeSmall,
+				Type:    "button",
+				Alpine:  &button.AlpineConfig{OnClick: "pick('avatar')"},
+			}) {
+				Upload avatar
+			}
+			@button.Button(button.Config{
+				Variant: button.Secondary,
+				Size:    button.SizeSmall,
+				Type:    "button",
+				Alpine:  &button.AlpineConfig{OnClick: "pick('banner')"},
+			}) {
+				Upload cover
+			}
+			<!-- Tooltip: upload requirements hint (hover/focus) -->
+			@tooltip.Tooltip(tooltip.Config{
+				ID:          "profile-upload-hint",
+				Text:        "PNG, JPG, WebP, or GIF, up to 1 MB. Stored only in your browser.",
+				Position:    tooltip.Top,
+				TriggerText: "Upload requirements",
+			})
+			<!-- Modal-confirmed photo removal; only meaningful when an image exists -->
+			<span x-show="avatarSrc || bannerSrc">
+				@modal.Modal(modal.Config{
+					ID:            "profileRemoveModal",
+					Title:         "Remove photos?",
+					Body:          "This removes your avatar and cover image from this browser. It cannot be undone.",
+					TriggerText:   "Remove photos",
+					Variant:       modal.Danger,
+					PrimaryText:   "Remove",
+					PrimaryAction: &modal.ButtonAction{OnClick: "remove('avatar'); remove('banner')"},
+					SecondaryText: "Cancel",
+				})
+			</span>
+		</div>
+		<p class="px-4 pb-4 text-center text-xs text-on-surface-muted dark:text-on-surface-dark-muted">
+			Images stay on this device (IndexedDB). PNG, JPG, WebP, or GIF, up to 1 MB.
+		</p>
+	</section>
+	<!-- Identity: name + bio, cookie-backed via HTMX -->
+	<section id="profile-identity-section" class="mt-6 rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt">
+		<div class="flex flex-col gap-4 p-4">
+			<h2 class="text-lg font-semibold text-on-surface dark:text-on-surface-dark">Identity</h2>
+			<form
+				class="flex flex-col gap-4"
+				hx-post="/api/examples/profile/identity"
+				hx-target="#profile-identity"
+				hx-swap="outerHTML"
+			>
+				@IdentityFields(s)
+				<div class="flex justify-end">
+					@button.Button(button.Config{Type: "submit", Variant: button.Primary}) {
+						Save
+					}
+				</div>
+			</form>
+		</div>
+	</section>
+}
+
+// profileAppearancePanel is the "Appearance" tab: theme Select + dark Toggle,
+// reusing the app's own theme engine (root x-data `theme` + $store.darkMode).
+templ profileAppearancePanel() {
+	<!-- Appearance: theme + dark mode, reusing the app's existing engine -->
+	<section id="profile-appearance" class="rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt">
+		<div class="flex flex-col gap-4 p-4">
+			<div class="flex items-center gap-2">
+				<h2 class="text-lg font-semibold text-on-surface dark:text-on-surface-dark">Appearance</h2>
+				@badge.Badge(badge.Config{Variant: badge.Secondary, Text: "live"})
+			</div>
+			<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted">
+				These reuse the app's own theme engine — changes apply instantly and persist in your browser.
+			</p>
+			<div class="sm:w-64">
+				@selectfield.Select(selectfield.Config{
+					ID:          "profile-theme",
+					Name:        "theme",
+					Label:       "Theme",
+					AlpineModel: "theme",
+					Options:     themeOptions(""),
+				})
+			</div>
+			@toggle.Toggle(toggle.Config{
+				ID:    "profile-dark",
+				Label: "Dark mode",
+				Attrs: templ.Attributes{
+					"x-bind:checked": "$store.darkMode.on",
+					"x-on:change":    "$store.darkMode.toggle()",
+				},
+			})
+		</div>
+	</section>
 }
 
 // ProfileContent is the registry entry point: renders an empty-state app for

--- a/internal/pages/demo/examples/profile_templ.go
+++ b/internal/pages/demo/examples/profile_templ.go
@@ -13,11 +13,14 @@ import (
 	"github.com/araihu/goshtoso/components/badge"
 	"github.com/araihu/goshtoso/components/button"
 	"github.com/araihu/goshtoso/components/fileinput"
+	"github.com/araihu/goshtoso/components/modal"
 	selectfield "github.com/araihu/goshtoso/components/select"
+	"github.com/araihu/goshtoso/components/tabs"
 	"github.com/araihu/goshtoso/components/textarea"
 	"github.com/araihu/goshtoso/components/textinput"
 	"github.com/araihu/goshtoso/components/toast"
 	"github.com/araihu/goshtoso/components/toggle"
+	"github.com/araihu/goshtoso/components/tooltip"
 	"github.com/araihu/goshtoso/internal/examples/profile"
 )
 
@@ -233,7 +236,60 @@ func ProfileApp(s profile.State) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"profile-fragment\" class=\"mx-auto max-w-3xl\" x-data=\"profileImages\"><header class=\"mb-6\"><h1 class=\"text-2xl font-bold text-on-surface dark:text-on-surface-dark\">Profile</h1><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">A profile screen built from Goshtoso components. Your name and bio live in a cookie (HTMX form, no server-side memory); your avatar and cover image stay on your device in IndexedDB — the server never receives the bytes; and theme + dark mode reuse the app's own appearance engine.</p></header><!-- Photos: avatar + cover, stored client-side in IndexedDB --><section id=\"profile-photos\" class=\"rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt\"><div class=\"relative\"><!-- Cover image area --><div class=\"h-40 w-full overflow-hidden rounded-t-radius bg-surface dark:bg-surface-dark\"><img x-show=\"bannerSrc\" x-bind:src=\"bannerSrc\" alt=\"Cover image\" class=\"h-40 w-full object-cover\"><div x-show=\"!bannerSrc\" class=\"flex h-40 w-full items-center justify-center text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">No cover image</div></div><!-- Avatar, overlapping the cover --><div id=\"profile-avatar\" class=\"-mt-12 flex justify-center\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"profile-fragment\" class=\"mx-auto max-w-3xl\" x-data=\"profileImages\"><header class=\"mb-6\"><h1 class=\"text-2xl font-bold text-on-surface dark:text-on-surface-dark\">Profile</h1><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">A profile screen built from Goshtoso components. Your name and bio live in a cookie (HTMX form, no server-side memory); your avatar and cover image stay on your device in IndexedDB — the server never receives the bytes; and theme + dark mode reuse the app's own appearance engine.</p></header>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = tabs.Tabs(tabs.Config{
+			ID:         "profile-tabs",
+			DefaultTab: "profile",
+			Tabs: []tabs.Tab{
+				{ID: "profile", Label: "Profile", Content: profileMainPanel(s)},
+				{ID: "appearance", Label: "Appearance", Content: profileAppearancePanel()},
+			},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = toast.Container(toast.ContainerConfig{}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// profileMainPanel is the "Profile" tab: photos (avatar + cover, IndexedDB) and
+// identity (name + bio, cookie-backed via HTMX). It lives inside the
+// #profile-fragment x-data="profileImages" wrapper, so avatarSrc/bannerSrc and
+// the avatar <img> persist across tab switches (tab panels are x-show toggled,
+// never unmounted).
+func profileMainPanel(s profile.State) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<!-- Photos: avatar + cover, stored client-side in IndexedDB --><section id=\"profile-photos\" class=\"rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt\"><div class=\"relative\"><!-- Cover image area --><div class=\"h-40 w-full overflow-hidden rounded-t-radius bg-surface dark:bg-surface-dark\"><img x-show=\"bannerSrc\" x-bind:src=\"bannerSrc\" alt=\"Cover image\" class=\"h-40 w-full object-cover\"><div x-show=\"!bannerSrc\" class=\"flex h-40 w-full items-center justify-center text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">No cover image</div></div><!-- Avatar, overlapping the cover --><div id=\"profile-avatar\" class=\"-mt-12 flex justify-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -247,7 +303,7 @@ func ProfileApp(s profile.State) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div></div><!-- Hidden file inputs driven by the Upload buttons -->")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div><!-- Hidden file inputs driven by the Upload buttons -->")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -269,34 +325,7 @@ func ProfileApp(s profile.State) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"flex flex-wrap items-center justify-center gap-3 p-4\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Var4 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-			if !templ_7745c5c3_IsBuffer {
-				defer func() {
-					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-					if templ_7745c5c3_Err == nil {
-						templ_7745c5c3_Err = templ_7745c5c3_BufErr
-					}
-				}()
-			}
-			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "Upload avatar")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			return nil
-		})
-		templ_7745c5c3_Err = button.Button(button.Config{
-			Variant: button.Secondary,
-			Size:    button.SizeSmall,
-			Type:    "button",
-			Alpine:  &button.AlpineConfig{OnClick: "pick('avatar')"},
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"flex flex-wrap items-center justify-center gap-3 p-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -312,7 +341,7 @@ func ProfileApp(s profile.State) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "Upload cover")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "Upload avatar")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -322,7 +351,7 @@ func ProfileApp(s profile.State) templ.Component {
 			Variant: button.Secondary,
 			Size:    button.SizeSmall,
 			Type:    "button",
-			Alpine:  &button.AlpineConfig{OnClick: "pick('banner')"},
+			Alpine:  &button.AlpineConfig{OnClick: "pick('avatar')"},
 		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var5), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -339,25 +368,52 @@ func ProfileApp(s profile.State) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "Remove photos")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "Upload cover")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
 		templ_7745c5c3_Err = button.Button(button.Config{
-			Variant: button.Danger,
+			Variant: button.Secondary,
 			Size:    button.SizeSmall,
 			Type:    "button",
-			Alpine: &button.AlpineConfig{
-				OnClick: "remove('avatar'); remove('banner')",
-				Show:    "avatarSrc || bannerSrc",
-			},
+			Alpine:  &button.AlpineConfig{OnClick: "pick('banner')"},
 		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var6), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div><p class=\"px-4 pb-4 text-center text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">Images stay on this device (IndexedDB). PNG, JPG, WebP, or GIF, up to 1 MB.</p></section><!-- Identity: name + bio, cookie-backed via HTMX --><section id=\"profile-identity-section\" class=\"mt-6 rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt\"><div class=\"flex flex-col gap-4 p-4\"><h2 class=\"text-lg font-semibold text-on-surface dark:text-on-surface-dark\">Identity</h2><form class=\"flex flex-col gap-4\" hx-post=\"/api/examples/profile/identity\" hx-target=\"#profile-identity\" hx-swap=\"outerHTML\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<!-- Tooltip: upload requirements hint (hover/focus) -->")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = tooltip.Tooltip(tooltip.Config{
+			ID:          "profile-upload-hint",
+			Text:        "PNG, JPG, WebP, or GIF, up to 1 MB. Stored only in your browser.",
+			Position:    tooltip.Top,
+			TriggerText: "Upload requirements",
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<!-- Modal-confirmed photo removal; only meaningful when an image exists --><span x-show=\"avatarSrc || bannerSrc\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = modal.Modal(modal.Config{
+			ID:            "profileRemoveModal",
+			Title:         "Remove photos?",
+			Body:          "This removes your avatar and cover image from this browser. It cannot be undone.",
+			TriggerText:   "Remove photos",
+			Variant:       modal.Danger,
+			PrimaryText:   "Remove",
+			PrimaryAction: &modal.ButtonAction{OnClick: "remove('avatar'); remove('banner')"},
+			SecondaryText: "Cancel",
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</span></div><p class=\"px-4 pb-4 text-center text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">Images stay on this device (IndexedDB). PNG, JPG, WebP, or GIF, up to 1 MB.</p></section><!-- Identity: name + bio, cookie-backed via HTMX --><section id=\"profile-identity-section\" class=\"mt-6 rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt\"><div class=\"flex flex-col gap-4 p-4\"><h2 class=\"text-lg font-semibold text-on-surface dark:text-on-surface-dark\">Identity</h2><form class=\"flex flex-col gap-4\" hx-post=\"/api/examples/profile/identity\" hx-target=\"#profile-identity\" hx-swap=\"outerHTML\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -365,7 +421,7 @@ func ProfileApp(s profile.State) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"flex justify-end\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"flex justify-end\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -381,7 +437,7 @@ func ProfileApp(s profile.State) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "Save")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "Save")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -391,7 +447,38 @@ func ProfileApp(s profile.State) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></form></div></section><!-- Appearance: theme + dark mode, reusing the app's existing engine --><section id=\"profile-appearance\" class=\"mt-6 rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt\"><div class=\"flex flex-col gap-4 p-4\"><div class=\"flex items-center gap-2\"><h2 class=\"text-lg font-semibold text-on-surface dark:text-on-surface-dark\">Appearance</h2>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</div></form></div></section>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// profileAppearancePanel is the "Appearance" tab: theme Select + dark Toggle,
+// reusing the app's own theme engine (root x-data `theme` + $store.darkMode).
+func profileAppearancePanel() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<!-- Appearance: theme + dark mode, reusing the app's existing engine --><section id=\"profile-appearance\" class=\"rounded-radius border border-outline bg-surface-alt dark:border-outline-dark dark:bg-surface-dark-alt\"><div class=\"flex flex-col gap-4 p-4\"><div class=\"flex items-center gap-2\"><h2 class=\"text-lg font-semibold text-on-surface dark:text-on-surface-dark\">Appearance</h2>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -399,7 +486,7 @@ func ProfileApp(s profile.State) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">These reuse the app's own theme engine — changes apply instantly and persist in your browser.</p><div class=\"sm:w-64\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">These reuse the app's own theme engine — changes apply instantly and persist in your browser.</p><div class=\"sm:w-64\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -413,7 +500,7 @@ func ProfileApp(s profile.State) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -428,15 +515,7 @@ func ProfileApp(s profile.State) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</div></section>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = toast.Container(toast.ContainerConfig{}).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -463,9 +542,9 @@ func ProfileContent() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = ProfileApp(profile.State{}).Render(ctx, templ_7745c5c3_Buffer)

--- a/tests/e2e/profile_test.go
+++ b/tests/e2e/profile_test.go
@@ -27,6 +27,22 @@ func gotoProfile(t *testing.T, page playwright.Page, query string) {
 	}))
 }
 
+// activateAppearanceTab clicks the "Appearance" tab button (the theme/dark
+// controls live in that tab, which is NOT the default and is x-show-hidden on
+// load) and waits for the theme Select trigger to become visible. The tabs
+// component renders tab buttons as role="tab"; selecting by accessible text is
+// stable across tab markup changes.
+func activateAppearanceTab(t *testing.T, page playwright.Page) {
+	t.Helper()
+	require.NoError(t, page.Locator("button[role='tab']", playwright.PageLocatorOptions{
+		HasText: "Appearance",
+	}).Click())
+	require.NoError(t, page.Locator("#profile-theme-trigger").WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateVisible,
+		Timeout: playwright.Float(3000),
+	}))
+}
+
 // onePxPNG is a valid 1x1 PNG used as a small uploadable image.
 var onePxPNG = []byte{
 	0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
@@ -107,6 +123,7 @@ func TestProfileIdentityPersists(t *testing.T) {
 func TestProfileDarkToggle(t *testing.T) {
 	page := newIsolatedPage(t)
 	gotoProfile(t, page, "?seed=0")
+	activateAppearanceTab(t, page)
 
 	before, err := page.Evaluate("() => document.documentElement.classList.contains('dark')", nil)
 	require.NoError(t, err)
@@ -130,6 +147,7 @@ func TestProfileDarkToggle(t *testing.T) {
 func TestProfileThemePicker(t *testing.T) {
 	page := newIsolatedPage(t)
 	gotoProfile(t, page, "?seed=0")
+	activateAppearanceTab(t, page)
 
 	// Open the Select dropdown.
 	require.NoError(t, page.Locator("#profile-theme-trigger").Click())
@@ -197,4 +215,50 @@ func TestProfileOversizeRejected(t *testing.T) {
 		"() => { const img = document.querySelector('#profile-avatar img'); return !!(img && img.src.startsWith('blob:')); }", nil)
 	require.NoError(t, err)
 	require.Equal(t, false, isBlob, "oversize image must be rejected client-side (no blob: preview)")
+}
+
+// TestProfileRemoveModal uploads an avatar (so the Remove modal trigger becomes
+// visible), opens the confirm modal, clicks Remove, and asserts the avatar img
+// no longer has a blob: src. Proves the Modal PrimaryAction.OnClick
+// ("remove('avatar'); remove('banner')") resolves against the ancestor
+// profileImages x-data and clears the image.
+func TestProfileRemoveModal(t *testing.T) {
+	page := newIsolatedPage(t)
+	gotoProfile(t, page, "?seed=0")
+
+	// Upload a small PNG so an image exists → the Remove modal trigger shows.
+	require.NoError(t, page.Locator("#profile-avatar-input").SetInputFiles(playwright.InputFile{
+		Name:     "avatar.png",
+		MimeType: "image/png",
+		Buffer:   onePxPNG,
+	}))
+	_, err := page.WaitForFunction(
+		"() => { const img = document.querySelector('#profile-avatar img'); return img && img.src.startsWith('blob:'); }",
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)})
+	require.NoError(t, err, "avatar img should get a blob: src after upload")
+
+	// Open the confirm modal via its trigger button.
+	trigger := page.Locator("#profile-photos button", playwright.PageLocatorOptions{HasText: "Remove photos"})
+	require.NoError(t, trigger.WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateVisible,
+		Timeout: playwright.Float(3000),
+	}))
+	require.NoError(t, trigger.Click())
+
+	// The modal dialog (role="dialog", aria-labelledby="profile-remove-modalTitle").
+	dialog := page.Locator("div[role='dialog'][aria-labelledby='profileRemoveModalTitle']")
+	require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateVisible,
+		Timeout: playwright.Float(3000),
+	}))
+
+	// Click the modal's primary "Remove" button.
+	confirm := dialog.Locator("button", playwright.LocatorLocatorOptions{HasText: "Remove"})
+	require.NoError(t, confirm.Click())
+
+	// The avatar img should no longer have a blob: src (removed).
+	_, err = page.WaitForFunction(
+		"() => { const img = document.querySelector('#profile-avatar img'); return !img || !img.src.startsWith('blob:'); }",
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)})
+	require.NoError(t, err, "avatar img blob: src should be cleared after confirming remove in modal")
 }


### PR DESCRIPTION
## Summary

Adds the three deferred components to the `/examples/profile` page (follow-up to #6):

- **Tabs** — content split into a **Profile** panel (photos + identity) and an **Appearance** panel (theme + dark). `x-data="profileImages"` stays on the `#profile-fragment` wrapper (ancestor of the tabs), and static panels are `x-show`-toggled (never unmounted), so `avatarSrc`/`bannerSrc` and the avatar `<img>` persist across tab switches.
- **Modal** — the raw "Remove photos" button is now a `modal.Modal` (Remove / Cancel), wrapped in `x-show="avatarSrc || bannerSrc"` so it only appears when an image exists. `PrimaryAction.OnClick="remove('avatar'); remove('banner')"` resolves up the Alpine scope chain to the `profileImages` component. (Modal ID is camelCase — the component derives its state var as `<ID>Isopen` unsanitized, so a hyphen breaks the JS.)
- **Tooltip** — an "Upload requirements" tooltip near the upload buttons.

Banner was intentionally not added.

## Test Plan
- [x] `tests/e2e/profile_test.go` — `TestProfileThemePicker` + `TestProfileDarkToggle` updated to activate the Appearance tab first (controls are `x-show`-hidden by default now); new `TestProfileRemoveModal` (upload → open modal → confirm → avatar src no longer `blob:`). All profile E2E green, stable across `-count=2`.
- [x] `go build ./...`, `go build -o bin/server` clean
- [x] `golangci-lint run` — 0 issues
- [x] Rebased onto current `origin/main` (incl. #8 avatar fragment-nav fix); diff is only the 3 profile files
- [x] Codex-reviewed (no critical/major in-scope; Alpine scope chain, tab x-show hydration, and selectors confirmed sound)

🤖 Generated with [Claude Code](https://claude.com/claude-code)