### PR TITLE
test(accordion): fix intersect-lazy-load flake (restore 5s wait)

### DIFF
--- a/tests/e2e/components_test.go
+++ b/tests/e2e/components_test.go
@@ -114,7 +114,7 @@ func TestAccordion_ServerLoadedContent(t *testing.T) {
 		// Wait for HTMX to fetch content (max 5 seconds)
 		err = page.Locator("text=Server Response A").WaitFor(playwright.LocatorWaitForOptions{
 			State:   playwright.WaitForSelectorStateVisible,
-			Timeout: playwright.Float(2000),
+			Timeout: playwright.Float(5000),
 		})
 		require.NoError(t, err, "server-loaded content should appear")
 
@@ -156,7 +156,7 @@ func TestAccordion_ServerLoadedContent(t *testing.T) {
 		// Wait for content to load
 		err = page.Locator("text=Server Response B").WaitFor(playwright.LocatorWaitForOptions{
 			State:   playwright.WaitForSelectorStateVisible,
-			Timeout: playwright.Float(2000),
+			Timeout: playwright.Float(5000),
 		})
 		require.NoError(t, err)
 
@@ -653,7 +653,7 @@ func TestIntegration(t *testing.T) {
 		// Wait for content
 		err = page.Locator("text=Server Response A").WaitFor(playwright.LocatorWaitForOptions{
 			State:   playwright.WaitForSelectorStateVisible,
-			Timeout: playwright.Float(2000),
+			Timeout: playwright.Float(5000),
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure in `TestAccordion_ServerLoadedContent` (and the same pattern in `TestIntegration/Full_Workflow_Expand_Load_Interact`):

```
playwright: timeout: Timeout 2000ms exceeded.
server-loaded content should appear   (components_test.go:119)
```

**Root cause:** the accordion lazy body loads via `hx-trigger="intersect once"` (IntersectionObserver → GET → `innerHTML` swap). Commit `d3d5cf3` tightened the `WaitFor` timeout from **5000ms → 2000ms** while leaving the `// max 5 seconds` comment stale. 2s is too tight for the intersect-latency + network round-trip + swap chain under full-suite browser contention; it passed in isolation but flaked under load (this is what slipped PR #10 through a red E2E).

**Fix:** restore all three lazy-load `WaitFor` timeouts to 5000ms (two `Server Response A` waits incl. the integration test, one `Server Response B`). 5s was empirically stable for months before the regression. Test-only change; no product code touched.

## Test Plan
- [x] `go vet ./tests/e2e/` clean, `golangci-lint run` 0 issues
- [x] `TestAccordion_ServerLoadedContent` + `TestIntegration` pass `-count=3` in isolation
- [x] Full E2E suite green under load (`ok ./tests/e2e 183s`, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)