### PR TITLE
docs: OSS community-health files + README badges

### DIFF
--- a/.claude/skills/alpinejs/SKILL.md
+++ b/.claude/skills/alpinejs/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: alpinejs
+description: Use when writing, debugging, or reviewing Alpine.js markup — any x-* directive (x-data, x-init, x-show, x-bind/`:`, x-on/`@`, x-text, x-html, x-model, x-modelable, x-for, x-transition, x-effect, x-ignore, x-ref, x-cloak, x-teleport, x-if, x-id), magics ($el, $refs, $store, $watch, $dispatch, $nextTick, $root, $data, $id), globals (Alpine.data, Alpine.store, Alpine.bind), the init()/destroy() lifecycle, alpine:init, Alpine plugins (persist, intersect, collapse, focus, mask, morph), extending via Alpine.directive/Alpine.magic, the CSP build, or Alpine interacting with templ attribute escaping / htmx swaps.
+---
+
+# Alpine.js
+
+## Overview
+
+Alpine is a lightweight declarative framework: you sprinkle reactive behavior onto plain HTML via `x-*` attributes — no build step, no virtual DOM. Mental model: "Tailwind for JavaScript." Expressions in attributes are evaluated against the nearest `x-data` scope, which cascades to descendants.
+
+Reference crawled from alpinejs.dev (Alpine v3.x).
+
+## When to use
+
+- Writing/editing any element with `x-data`, `x-show`, `x-on`/`@`, `x-bind`/`:`, `x-model`, `x-for`, `x-if`, `x-transition`, etc.
+- Registering reusable behavior with `Alpine.data()`, global state with `Alpine.store()`, or attribute bundles with `Alpine.bind()`.
+- Using magics (`$refs`, `$dispatch`, `$watch`, `$nextTick`, `$store`, `$id`) or the `init()` / `destroy()` lifecycle.
+- Adding an Alpine plugin (persist, intersect, collapse, focus, mask, morph) or extending Alpine (`Alpine.directive`, `Alpine.magic`).
+- Debugging why a component silently does nothing (Alpine swallows expression parse failures with no console error — usually attribute escaping; see gotchas).
+
+**This repo (Goshtoso) uses Alpine v3 + templ + htmx.** Alpine is bundled locally at `assets/js/vendor/`. Read `reference/gotchas.md` whenever Alpine markup is generated through templ or combined with htmx — templ escaping and fragment-nav registration silently break Alpine.
+
+## The core: data + behavior on one element
+
+```html
+<div x-data="{ open: false }">
+    <button @click="open = ! open">Toggle</button>
+    <div x-show="open" @click.outside="open = false" x-transition>Contents…</div>
+</div>
+```
+
+`x-data` holds reactive state (and can hold methods, getters, and an `init()`). Everything inside reads that scope. Nested `x-data` inherits the parent scope and may shadow same-named keys.
+
+## Directive quick reference
+
+| Directive | Does | Note |
+|-----------|------|------|
+| `x-data` | Declare component + reactive scope | Supports methods, `get` getters, `init()` |
+| `x-init` | Run expression on element init | Works without `x-data`; async OK |
+| `x-show` | Toggle CSS `display` | `.important`; pair `x-cloak` if start hidden |
+| `x-bind` / `:` | Set attribute from expression | `:class="{ 'hidden': !open }"`, `:style="{…}"`, bind whole object |
+| `x-on` / `@` | Run code on a DOM event | `@click`, `@keyup.enter`; rich modifiers (below) |
+| `x-text` | Set `textContent` | Plain text only |
+| `x-html` | Set `innerHTML` | XSS risk — trusted content only |
+| `x-model` | Two-way bind a form input | `.lazy .number .boolean .debounce .throttle .fill` |
+| `x-modelable` | Expose an internal prop as an `x-model` target | For reusable components |
+| `x-for` | Loop list/object/range | On `<template>`, single root, use `:key` |
+| `x-if` | Add/remove DOM by condition | On `<template>`, single root, **no** `x-transition` |
+| `x-transition` | Animate show/hide | `.duration.Nms .delay .opacity .scale .origin.*` |
+| `x-effect` | Re-run expression when its deps change | Implicit watcher |
+| `x-ignore` | Skip Alpine init for a subtree | — |
+| `x-ref` | Tag element for `$refs.name` | Static only in v3 |
+| `x-cloak` | Hide until Alpine inits | Needs `[x-cloak]{display:none!important}` CSS |
+| `x-teleport` | Move `<template>` content elsewhere | `x-teleport="body"`, `.prepend/.append` |
+| `x-id` | Scoped namespace for `$id()` | `x-id="['foo']"` → matching `$id('foo')` |
+
+Most directives (except `x-data`, `x-init`, `x-ignore`) require a parent `x-data`.
+
+## `x-on` / `x-model` modifiers (the ones you reach for)
+
+- **Events:** `.prevent` `.stop` `.self` `.outside` `.window` `.document` `.once` `.passive` `.capture` `.camel` `.dot`
+- **Debounce/throttle:** `.debounce` (250ms default, `.debounce.500ms`) · `.throttle`
+- **Keys:** `.enter` `.escape` `.tab` `.space` `.up/.down/.left/.right` + chords `.shift` `.ctrl` `.cmd` `.alt` `.meta` (e.g. `@keyup.shift.enter`)
+- **`x-model`:** `.lazy` `.number` `.boolean` `.debounce` `.throttle` `.fill` (seed from the input's `value`)
+
+## Magics & globals
+
+| Magic | Use |
+|-------|-----|
+| `$el` | Current DOM element |
+| `$refs` | Elements tagged with `x-ref` |
+| `$store` | Access an `Alpine.store()` |
+| `$watch('prop', (v,old)=>…)` | React to a property change |
+| `$dispatch('evt', detail)` | Fire a custom event (bubbles; use `.window` to catch across components) |
+| `$nextTick(cb)` | Run after Alpine flushes DOM updates (awaitable) |
+| `$root` | Nearest `x-data` ancestor element |
+| `$data` | Current scope as an object (pass to external fns) |
+| `$id('name')` | Collision-free scoped IDs |
+
+```js
+document.addEventListener('alpine:init', () => {
+    Alpine.data('dropdown', () => ({
+        open: false,
+        init() { /* before first render */ },
+        toggle() { this.open = ! this.open },
+        destroy() { /* on teardown — clear timers/listeners */ },
+    }))
+    Alpine.store('darkMode', { on: false, toggle() { this.on = !this.on } })
+})
+```
+
+`Alpine.bind('Name', () => ({...}))` defines a reusable attribute bundle applied via `x-bind="Name"`.
+
+## Detailed references (load when needed)
+
+- **`reference/directives.md`** — every directive with full syntax, all modifiers, and gotchas.
+- **`reference/magics-globals.md`** — every magic, the three globals, and the full lifecycle (`alpine:init`, `alpine:initialized`, `init()`, `destroy()`, `x-init`, manual `Alpine.start()`).
+- **`reference/plugins.md`** — persist, intersect, collapse, focus, mask, morph (install + usage), plus extending (`Alpine.directive`/`Alpine.magic`), reactivity primitives, async expressions, and the CSP build.
+- **`reference/gotchas.md`** — templ attribute escaping, null-array crashes, fragment-nav `Alpine.data` registration, htmx-inserted nodes needing `htmx.process()`, `x-cloak` FOUC. **Read this before generating Alpine through templ or mixing with htmx.**
+
+## Common mistakes
+
+- **Silent dead component, no console error.** Alpine swallows expression parse failures. #1 cause in this repo: templ escapes `"`/`'`/`&` inside `x-data` (`&quot;`). Inspect rendered HTML in devtools. See `reference/gotchas.md`.
+- **`json.Marshal` into an HTML attribute.** Produces double-quoted JSON; templ escapes the quotes; Alpine sees broken syntax. Build single-quoted JS, or register via `Alpine.data()` in a `<script>`.
+- **`null` arrays.** `json.Marshal([]T(nil))` → `null`; Alpine `.includes()` throws. Guard to `[]`.
+- **`x-for` / `x-if` not on `<template>`,** or with more than one root element — won't work. Add `:key` to `x-for`.
+- **Forgetting `x-cloak`** on initially-hidden elements → flash of content before Alpine boots.
+- **`Alpine.data()` registered only on `alpine:init`** — undefined when the node arrives via an htmx fragment swap after Alpine already started. Register immediately too, and call `htmx.process()` on Alpine-inserted nodes. See `reference/gotchas.md`.
+- **`$dispatch` to a sibling** — events bubble to ancestors, not siblings; listen with `@evt.window`.

--- a/.claude/skills/alpinejs/reference/directives.md
+++ b/.claude/skills/alpinejs/reference/directives.md
@@ -1,0 +1,162 @@
+# Alpine.js Directives — full reference
+
+Every directive with syntax, modifiers, and gotchas. Crawled from alpinejs.dev (v3.x).
+Most directives require a parent `x-data`; exceptions noted.
+
+## x-data
+Defines an HTML chunk as an Alpine component and supplies its reactive data.
+```html
+<div x-data="{ open: false }">
+    <button @click="open = ! open">Toggle</button>
+    <div x-show="open">Content...</div>
+</div>
+```
+- Supports methods (`toggle() { this.open = !this.open }`), getters (`get isOpen() {...}`), and an `init()` method (auto-runs on init).
+- Scope cascades to children; reusable via `Alpine.data('name', () => ({...}))`.
+- **Gotcha:** Properties in nested `x-data` shadow same-named parent properties (inner overrides outer).
+
+## x-init
+Hooks into an element's initialization phase. (No `x-data` required.)
+```html
+<div x-init="console.log('Initializing!')"></div>
+```
+- Supports async (`await`); pair with `$nextTick()` for post-render work.
+- **Gotcha:** When both exist, the `x-data` object's `init()` runs first, then the `x-init` directive.
+
+## x-show
+Shows/hides an element via CSS `display`.
+```html
+<div x-show="open">Content</div>
+```
+- Modifier: `.important` — applies `display: none !important`.
+- **Gotcha:** If initial state is `false`, add `x-cloak` to prevent flicker before Alpine loads.
+
+## x-bind
+Sets HTML attributes dynamically. **Shorthand `:`**.
+```html
+<input type="text" :placeholder="placeholderText">
+<div :class="{ 'hidden': !show }"></div>      <!-- class object syntax, merges -->
+<div :style="{ color: 'red', display: 'flex' }"></div>
+<button x-bind="trigger"></button>            <!-- bind a whole object of attrs -->
+```
+- **Gotcha:** Requires a parent `x-data`.
+
+## x-on
+Runs code on a DOM event. **Shorthand `@`**.
+```html
+<button @click="alert('Hi')">Say Hi</button>
+```
+- Modifiers: `.prevent` `.stop` `.outside` `.window` `.document` `.once` `.self` `.camel` `.dot` `.passive` `.passive.false` `.capture`; `.debounce` (default 250ms, e.g. `.debounce.500ms`); `.throttle`.
+- Keyboard: `.enter` `.space` `.escape` `.tab` `.up` `.down` `.left` `.right` `.page-down` …; chords `.shift` `.ctrl` `.cmd` `.alt` `.meta` (e.g. `@keyup.shift.enter`).
+- **Gotcha:** Requires a parent `x-data`.
+
+## x-text
+Sets `textContent`.
+```html
+<strong x-text="username"></strong>
+```
+- **Gotcha:** Plain text only; HTML tags render as literal text (use `x-html` otherwise).
+
+## x-html
+Sets `innerHTML`.
+```html
+<span x-html="username"></span>
+```
+- **Gotcha:** XSS risk — trusted content only, never user input.
+
+## x-model
+Two-way binds a form input to a data property.
+```html
+<input type="text" x-model="message">
+```
+- Works with text/textarea/checkbox/radio/select/range.
+- Modifiers: `.lazy` (sync on change), `.change`, `.blur`, `.enter`, `.number` (cast to number), `.boolean` (cast to boolean), `.debounce` (250ms default), `.throttle`, `.fill` (seed property from the input's `value` attribute).
+- Programmatic: `el._x_model.get()` / `el._x_model.set(value)`.
+- **Gotcha:** Requires a parent `x-data`. (In E2E: Playwright `Fill()` does not fire a native `input` event, so `x-model` won't update — dispatch `input` manually.)
+
+## x-modelable
+Exposes a component's internal property as an `x-model` target.
+```html
+<div x-data="{ count: 0 }" x-modelable="count" x-model="number">
+    <button @click="count++">Increment</button>
+</div>
+```
+- Use case: reusable components exposing internal state like a native input.
+
+## x-for
+Renders elements by iterating lists, objects, or ranges. **Must be on a `<template>` with one root element.**
+```html
+<template x-for="item in items" :key="item.id">
+    <li x-text="item.name"></li>
+</template>
+```
+- With index: `x-for="(item, index) in items"`. Object: `x-for="(value, key) in object"`. Range: `x-for="i in 10"`.
+- **Gotcha:** Without a unique `:key`, reorder/remove causes odd side-effects. Requires parent `x-data`.
+
+## x-transition
+Animates show/hide.
+```html
+<div x-show="open" x-transition>Content</div>
+```
+- Modifiers: `.duration.{ms}` (default 150ms enter / 75ms leave), `.delay.{ms}`, `.opacity`, `.scale` / `.scale.{n}`, `.origin.{top|bottom|left|right|combos}`. Target enter/leave separately: `x-transition:enter.duration.500ms`.
+- CSS class helpers: `:enter`, `:enter-start`, `:enter-end`, `:leave`, `:leave-start`, `:leave-end`.
+- **Gotcha:** Does NOT work with `x-if` (only `x-show`). Requires parent `x-data`.
+
+## x-effect
+Re-runs an expression whenever its tracked dependencies change (implicit watcher).
+```html
+<div x-data="{ label: 'Hello' }" x-effect="console.log(label)"></div>
+```
+- Runs once on init, then on any referenced-property change; deps auto-detected.
+
+## x-ignore
+Stops Alpine from processing a DOM subtree.
+```html
+<div x-ignore><span x-text="label"></span></div>   <!-- x-text is skipped -->
+```
+
+## x-ref + $refs
+Tags a DOM element for direct access.
+```html
+<button @click="$refs.text.remove()">Remove</button>
+<span x-ref="text">Hello 👋</span>
+```
+- **Gotcha:** v3 supports static refs only (no dynamic `:x-ref`). Requires parent `x-data`.
+
+## x-cloak
+Hides elements until Alpine initializes (prevents FOUC). **Requires the CSS rule.**
+```html
+<style>[x-cloak] { display: none !important; }</style>
+<span x-cloak x-show="false">Hidden until Alpine loads</span>
+```
+- Alpine removes the attribute once initialized. No-CSS alternative: wrap in `<template x-if="true">`.
+
+## x-teleport
+Moves `<template>` content to another DOM location (modals, z-index escapes).
+```html
+<template x-teleport="body">
+  <div x-show="open">Modal contents...</div>
+</template>
+```
+- Selector = any CSS query. Teleported content keeps parent scope, `$refs`, `$root`.
+- Modifiers: `.prepend`, `.append`.
+- **Gotcha:** Must be on a `<template>`. Alpine re-dispatches forwarded events to avoid double-bubbling.
+
+## x-if
+Adds/removes DOM by condition (vs `x-show` which only CSS-hides). **Must be on a `<template>` with one root element.**
+```html
+<template x-if="open">
+    <div>Contents...</div>
+</template>
+```
+- **Gotcha:** Does NOT support `x-transition`. Requires parent `x-data`.
+
+## x-id + $id
+Scoped namespace for generating unique IDs across repeated instances.
+```html
+<div x-id="['text-input']">
+    <label :for="$id('text-input')">Username</label>
+    <input type="text" :id="$id('text-input')">
+</div>
+```
+- Same name within a scope yields the same ID (for label/input pairing); different instances get unique suffixes.

--- a/.claude/skills/alpinejs/reference/gotchas.md
+++ b/.claude/skills/alpinejs/reference/gotchas.md
@@ -1,0 +1,87 @@
+# Alpine.js Gotchas (Goshtoso: Alpine + templ + htmx)
+
+The failure mode that wastes the most time: **Alpine swallows expression parse failures with no console error.** A component just silently does nothing. Always inspect the *rendered* HTML in devtools before debugging logic.
+
+## 1. templ attribute escaping — the #1 bug
+
+templ's `EscapeString` converts `"` → `&quot;`, `'` → `&#39;`, `&` → `&amp;` inside HTML attributes. That breaks the JS Alpine parses out of `x-data`/`x-bind`/`@`.
+
+**Symptom:** dropdown/combobox options missing, toggles dead — no console error, unit tests pass, browser fails. Look for `&quot;` inside `x-data` in devtools.
+
+**Simple `x-data` (data only):** use unquoted keys, avoid quoted string literals.
+```go
+return fmt.Sprintf(`{ opened: [false,false], count: 0 }`) // GOOD — nothing to escape
+```
+
+**Complex Alpine (functions/strings):** register via `<script>` + `Alpine.data()`, reference by name.
+```go
+func myAlpineScript(cfg Config) string {
+    return fmt.Sprintf(`document.addEventListener('alpine:init', () => {
+        Alpine.data('myComponent', () => ({
+            value: '%s',
+            doThing() { htmx.ajax('GET', '/api/data', {target: '#target'}); }
+        }));
+    });`, cfg.DefaultValue)
+}
+```
+```templ
+templ myScript(cfg Config) {
+    @templ.Raw("<script>" + myAlpineScript(cfg) + "</script>")
+}
+// then: <div x-data="myComponent">
+```
+
+## 2. NEVER json.Marshal into an HTML attribute
+
+`json.Marshal` emits double-quoted strings → templ escapes the quotes → Alpine sees broken syntax. Build single-quoted JS instead.
+```go
+func optionsToJS(options []Option) string {
+    result := "["
+    for i, opt := range options {
+        if i > 0 { result += "," }
+        result += fmt.Sprintf("{value:'%s',label:'%s'}",
+            jsEscapeSingle(opt.Value), jsEscapeSingle(opt.Label))
+    }
+    return result + "]"
+}
+```
+
+## 3. null arrays crash Alpine
+
+`json.Marshal([]string(nil))` → `null`, not `[]`. Alpine `selectedValues.includes(...)` throws on null. Guard:
+```go
+if string(selectedJSON) == "null" {
+    selectedJSON = []byte("[]")
+}
+```
+
+## 4. Fragment-nav: register Alpine.data immediately, not only on alpine:init
+
+Alpine is already running when a page/fragment arrives via an htmx (sidebar) swap. A component registered ONLY inside an `alpine:init` listener is **undefined** for the swapped-in node. Register immediately if Alpine is already up:
+```js
+function register() { Alpine.data('logFeed', () => ({ /* … */ })) }
+if (window.Alpine) register()                                  // fragment-nav path
+else document.addEventListener('alpine:init', register)        // first paint
+```
+
+## 5. htmx-inserted nodes aren't auto-processed by Alpine
+
+When Alpine (or your own JS) inserts nodes, htmx won't bind them automatically — call `htmx.process(el)` on the new subtree. (Conversely, htmx-swapped HTML containing Alpine directives is initialized by Alpine's mutation observer.)
+
+## 6. hx-swap-oob on first paint → htmx:oobErrorNoTarget
+
+An element carrying `hx-swap-oob` on its *first* render makes htmx attempt an OOB swap (with no target) when it arrives via fragment nav. Gate the attribute to update-only (an `oob bool` that's false on first paint).
+
+## 7. x-cloak FOUC
+
+Initially-hidden (`x-show="false"`) elements flash before Alpine boots unless they carry `x-cloak` AND the page has `[x-cloak]{display:none!important}`.
+
+## 8. E2E: Alpine state in Playwright
+
+- `GetAttribute("aria-expanded")` returns the *static* HTML attribute, not the Alpine-bound live value. Use `Evaluate("el => el.getAttribute('aria-expanded')", nil)`.
+- Wait for Alpine: `WaitForFunction("() => typeof Alpine !== 'undefined'")`.
+- `Locator.Fill()` does NOT fire a native `input` event → `x-model` won't update. Dispatch `input` manually (the `fillSearchInput` helper).
+
+## 9. $dispatch reaches ancestors, not siblings
+
+Custom events bubble up. To catch a sibling component's event, listen at window: `@my-event.window="..."`.

--- a/.claude/skills/alpinejs/reference/magics-globals.md
+++ b/.claude/skills/alpinejs/reference/magics-globals.md
@@ -1,0 +1,144 @@
+# Alpine.js Magics, Globals & Lifecycle
+
+Crawled from alpinejs.dev (v3.x).
+
+## Magics
+
+### $el
+Current DOM node.
+```html
+<button @click="$el.innerHTML = 'Hello'">Replace me</button>
+```
+
+### $refs
+Elements tagged with `x-ref`.
+```html
+<button @click="$refs.text.remove()">Remove</button>
+<span x-ref="text">Hello 👋</span>
+```
+- **Gotcha:** v3 supports static refs only; dynamic `:x-ref="item.name"` yields the literal string.
+
+### $store
+Access a global store registered with `Alpine.store()`.
+```html
+<button x-data @click="$store.darkMode.toggle()">Toggle</button>
+<div x-data :class="$store.darkMode.on && 'bg-black'">Content</div>
+```
+- Stores can be primitives, not just objects.
+
+### $watch
+Run a callback when a watched property changes.
+```html
+<div x-data="{ open: false }" x-init="$watch('open', (value, old) => console.log(value))">
+    <button @click="open = ! open">Toggle</button>
+</div>
+```
+- Can watch nested props: `$watch('foo.bar', …)`.
+- **Gotcha:** Mutating a property of the watched object inside the callback can cause an infinite loop.
+
+### $dispatch
+Shortcut for `el.dispatchEvent(new CustomEvent(...))`.
+```html
+<button @click="$dispatch('notify', { id: 1 })">Notify</button>
+```
+- **Gotcha:** Events bubble to ancestors, NOT siblings. To catch a sibling's event, listen at window: `@notify.window="..."`. Read detail via `$event.detail`.
+
+### $nextTick
+Run AFTER Alpine has applied its reactive DOM updates. Returns a Promise (awaitable).
+```js
+title = 'Hello World!'
+$nextTick(() => { console.log($el.innerText) })   // reads updated DOM
+```
+
+### $root
+Root element of the component (closest `x-data` ancestor).
+```html
+<div x-data data-message="Hi">
+    <button @click="alert($root.dataset.message)">Say Hi</button>
+</div>
+```
+
+### $data
+Current scope as a plain object — pass an entire scope to an external function.
+```html
+<div x-data="{ greeting: 'Hello' }">
+    <button @click="sayHello($data)">Say Hello</button>
+</div>
+```
+- Usually unnecessary — access data directly in expressions.
+
+### $id
+Collision-free scoped IDs (pair with the `x-id` directive — see directives.md).
+```html
+<input :id="$id('text-input')">   <!-- id="text-input-1", "-2", … per instance -->
+```
+
+## Globals
+
+### Alpine.data — reusable `x-data` contexts
+```js
+document.addEventListener('alpine:init', () => {
+    Alpine.data('dropdown', () => ({
+        open: false,
+        toggle() { this.open = ! this.open },
+    }))
+})
+```
+Bundled/module form:
+```js
+import Alpine from 'alpinejs'
+import dropdown from './dropdown.js'
+Alpine.data('dropdown', dropdown)
+Alpine.start()
+```
+Use in markup: `<div x-data="dropdown">`.
+
+### Alpine.store — global reactive state
+```js
+document.addEventListener('alpine:init', () => {
+    Alpine.store('darkMode', {
+        on: false,
+        toggle() { this.on = ! this.on },
+    })
+})
+```
+- `init()` inside a store runs immediately after registration, before any render:
+```js
+Alpine.store('darkMode', {
+    init() { this.on = window.matchMedia('(prefers-color-scheme: dark)').matches },
+    on: false,
+})
+```
+- Read/write from JS: `Alpine.store('darkMode').on = true`.
+
+### Alpine.bind — reusable attribute bundles
+```js
+Alpine.bind('SomeButton', () => ({
+    type: 'button',
+    '@click'() { this.doSomething() },
+    ':disabled'() { return this.shouldDisable },
+}))
+```
+```html
+<button x-bind="SomeButton"></button>
+```
+
+## Lifecycle
+
+Order: `alpine:init` → each component's `init()` / `x-init` → `alpine:initialized`.
+
+- **`alpine:init`** (on `document`) — fires before Alpine boots; register `Alpine.data`/`Alpine.store`/`Alpine.bind` here.
+- **`alpine:initialized`** — fires after Alpine finishes initializing the page.
+- **`init()`** — method on an `x-data` / `Alpine.data` object; runs before that element initializes.
+- **`destroy()`** — method on the data object; runs on teardown (element removed via `x-if`/`x-for`, etc.). Clear timers/listeners here to avoid leaks.
+  ```js
+  Alpine.data('timer', () => ({
+      timer: null,
+      init() { this.timer = setInterval(() => {/*…*/}, 1000) },
+      destroy() { clearInterval(this.timer) },
+  }))
+  ```
+- **`x-init`** — attribute form to run an expression on element init.
+- **`Alpine.start()`** — call once after import when NOT using the auto-starting CDN build.
+
+> **In this repo:** Alpine is bundled and already running by the time fragments arrive via htmx/fragment-nav. Registering `Alpine.data()` ONLY inside an `alpine:init` listener leaves it undefined for later-loaded fragments — register immediately as well. See `gotchas.md`.

--- a/.claude/skills/alpinejs/reference/plugins.md
+++ b/.claude/skills/alpinejs/reference/plugins.md
@@ -1,0 +1,120 @@
+# Alpine.js Plugins & Advanced
+
+Crawled from alpinejs.dev (v3.x). For CDN use, **plugin script tags must load BEFORE the core Alpine script.** Versions below are illustrative — treat as latest 3.x.
+
+## Plugins
+
+### persist — state survives page loads (localStorage)
+```html
+<script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/persist@3.x.x/dist/cdn.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+```
+```bash
+npm install @alpinejs/persist
+```
+```html
+<div x-data="{ count: $persist(0) }">
+    <button @click="count++">Increment</button>
+    <span x-text="count"></span>
+</div>
+```
+- Custom key: `$persist(0).as('my-key')`. Other storage: `.using(sessionStorage)`.
+
+### intersect — run on viewport enter/leave (IntersectionObserver)
+```html
+<div x-intersect="shown = true">Triggers when visible</div>
+<div x-intersect.once="shown = true">Fires only once</div>
+<div x-intersect:enter="shown = true">On entering</div>
+<div x-intersect:leave="shown = true">On leaving</div>
+<div x-intersect.half="shown = true">50% visible</div>
+<div x-intersect.full="shown = true">99% visible</div>
+<div x-intersect.threshold.50="shown = true">custom threshold %</div>
+<div x-intersect.margin.200px="loaded = true">200px buffer</div>
+```
+- Common use: lazy-load / infinite scroll sentinel.
+
+### collapse — animate height on show/hide
+```html
+<div x-data="{ expanded: false }">
+    <button @click="expanded = ! expanded">Toggle</button>
+    <p x-show="expanded" x-collapse>Content</p>
+</div>
+```
+- `x-collapse.min.50px` keeps a minimum visible height when collapsed.
+
+### focus — focus trapping (`x-trap`) + `$focus` magic
+```html
+<div x-data="{ open: false }">
+    <button @click="open = true">Open</button>
+    <span x-show="open" x-trap="open">
+        <input type="text">
+        <button @click="open = false">Close</button>
+    </span>
+</div>
+
+<div @keydown.right="$focus.next()" @keydown.left="$focus.previous()">
+    <button>First</button><button>Second</button>
+</div>
+```
+
+### mask — auto-format input as the user types
+```html
+<input x-mask="99/99/9999" placeholder="MM/DD/YYYY">
+<input x-mask:dynamic="$input.startsWith('34') ? '9999 999999 99999' : '9999 9999 9999 9999'">
+<input x-mask:dynamic="$money($input)">
+```
+- Wildcards: `*` any char, `a` letters, `9` numbers.
+
+### morph — morph an element into new HTML, preserving DOM + Alpine state
+```js
+Alpine.morph(el, `
+    <div x-data="{ message: 'hi' }">
+        <input type="text" x-model="message">
+        <span x-text="message"></span>
+    </div>
+`)
+```
+- Keeps focus, scroll, and component state — useful for server-rendered HTML diffing.
+
+## Reactivity primitives
+```js
+let data = Alpine.reactive({ count: 1 })   // tracking proxy
+Alpine.effect(() => console.log(data.count)) // runs now + on each dep change
+data.count = 2 // logs "2"
+```
+These are what Alpine is built on; `effect` auto-tracks reactive props read inside it.
+
+## Extending Alpine
+
+Directive — `name` → `x-name`:
+```js
+Alpine.directive('uppercase', (el, { value, modifiers, expression }, { Alpine, effect, cleanup }) => {
+    el.textContent = el.textContent.toUpperCase()
+})
+```
+- `value` = colon part (`x-foo:bar` → `'bar'`); `modifiers` = dot array (`x-foo.baz` → `['baz']`); `expression` = the attribute value. `effect` = auto-cleaning reactive runner; `cleanup` = register teardown.
+
+Magic — `name` → `$name`:
+```js
+Alpine.magic('now', () => (new Date).toLocaleTimeString())          // $now
+Alpine.magic('clipboard', () => subject => navigator.clipboard.writeText(subject)) // $clipboard(x)
+```
+
+## Async expressions
+Alpine awaits async functions anywhere it accepts sync ones:
+```html
+<span x-text="await getLabel()"></span>
+<span x-text="getLabel"></span>   <!-- reference w/o parens: auto-detected & awaited -->
+```
+
+## CSP build
+The CSP-friendly build forbids `eval`-style inline evaluation: **no arrow functions, destructuring, template literals, or global access in attributes.** Move all logic into `Alpine.data()` components (getters/methods); keep attributes to plain property references.
+```html
+<div x-data="userManager" x-show="hasActiveAdmins"></div>
+<script nonce="...">
+  Alpine.data('userManager', () => ({
+    users: [],
+    get hasActiveAdmins() { return this.users.some(u => u.active && u.role === 'admin') },
+  }))
+</script>
+```

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for everything in the repo.
+* @araihu

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Report a defect or visual-parity issue in a component
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear description of what's wrong.
+
+## Component affected
+
+Which component (e.g. Table, Combobox, Dropdown)? Which variant?
+
+## Reproduction steps
+
+1.
+2.
+3.
+
+## Expected vs actual
+
+- **Expected:**
+- **Actual:**
+
+## Environment
+
+- **Theme:** (e.g. Minimal, ...)
+- **Mode:** light / dark
+- **Browser:** (E2E runs Chromium via Playwright)
+- **Go version:** `go version`
+- **templ version:**
+- **Goshtoso version / commit:**
+
+## Screenshots
+
+If a visual-parity issue, attach Goshtoso vs PenguinUI screenshots.
+
+## Notes
+
+Did you check the rendered HTML in devtools for `&quot;` inside an `x-data`
+(templ-escaping bug)?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/araihu/goshtoso/discussions
+    about: Ask questions, share ideas, or get help here instead of opening an issue.
+  - name: Security vulnerability
+    url: https://github.com/araihu/goshtoso/security/advisories/new
+    about: Report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature request
+about: Suggest a new component, variant, or capability
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem does this solve? What's missing today?
+
+## Proposed solution
+
+What you'd like to see. For a new component or variant, describe the API
+(config struct fields, variants).
+
+## PenguinUI parity reference
+
+If this replicates a PenguinUI component, link it:
+https://penguinui.com/components/...
+
+## Alternatives
+
+Other approaches you considered.
+
+## Additional context
+
+Anything else (mockups, related issues).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Related issue
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New component / variant
+- [ ] Visual-parity fix
+- [ ] Docs
+- [ ] Tests / CI
+- [ ] Refactor / chore
+
+## Checklist
+
+- [ ] Ran `templ generate` after editing `.templ` files
+- [ ] Rebuilt Tailwind (`tailwindcss -i css/main.css -o assets/styles.css`) if CSS changed
+- [ ] `golangci-lint run` is clean (cyclomatic-complexity ceiling 20)
+- [ ] `go fix ./...` applied (pre-commit hook enabled via `git config core.hooksPath .githooks`)
+- [ ] Unit + E2E tests pass (`go test ./... -count=1` and `go test ./tests/e2e/... -count=1 -timeout 15m`)
+- [ ] New/changed component demo page follows the docs-page pattern and has an API reference
+- [ ] Regenerated the usage skill reference (`go run ./scripts/skillgen`) if a component changed
+- [ ] Tested in light **and** dark mode across themes (especially Minimal — no border-radius)
+- [ ] Did **not** hand-edit generated files (`*_templ.go`, `assets/styles.css`)
+
+## Screenshots
+
+<!-- For visual changes: before/after, light + dark. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,34 @@ runtime starts on demand on the first review/task command.
 
 ## Critical Rules
 
+### Frontend interactivity hierarchy: htmx → Alpine.js → vanilla JS
+
+When adding any client behavior, pick the **highest** tier that solves the
+problem, never a lower one for convenience:
+
+1. **Server-side rendering driven by htmx (default, idiomatic).** Prefer a
+   server round-trip that returns rendered HTML (templ) swapped by htmx over
+   holding state or building markup on the client. Reach first for `hx-get`/
+   `hx-post`, swaps, OOB swaps, and `HX-*` response headers. Most "interactive"
+   needs (filtering, pagination, inline edit, lazy load, validation, toasts)
+   are SSR + htmx, not JavaScript.
+2. **Alpine.js — only for genuinely client-side interactivity.** Use Alpine
+   when the behavior is **not achievable via SSR, or a server round-trip would
+   be too expensive / too laggy** for the interaction: purely local UI state
+   (open/closed, tabs, hover, focus traps), instant input feedback, and
+   transitions where a network hop would feel wrong. Don't use Alpine to do
+   what htmx already does.
+3. **Vanilla JS — last resort.** Only when neither htmx nor Alpine fits (a niche
+   browser API, a one-off integration). Justify it; prefer wrapping it in an
+   `Alpine.directive`/`Alpine.magic` so it composes with the rest.
+
+**Solutions must play nicely with htmx first.** Anything you add has to survive
+htmx swaps and fragment-nav: register `Alpine.data()` immediately (not only on
+`alpine:init`) so swapped-in nodes can find it, call `htmx.process()` on nodes
+you insert yourself, and gate `hx-swap-oob` to update-only so first paint
+doesn't error. See the **`htmx`** and **`alpinejs`** skills (and
+`alpinejs/reference/gotchas.md`) for the escaping and swap pitfalls.
+
 ### Always work in a git worktree
 
 Make changes in an isolated git worktree, never directly on a shared branch in

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@araihu.dev. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+# Contributing to Goshtoso
+
+Thanks for your interest! Goshtoso is an alpha-stage, MIT-licensed UI component
+library (Go + templ + Tailwind CSS v4 + HTMX + Alpine.js) — a hard fork of
+[PenguinUI](https://penguinui.com) targeting 99.99% visual parity.
+
+Contributions of all kinds are welcome: bug reports, new components, parity
+fixes, docs, and tests.
+
+## Code of Conduct
+
+This project ships a [Code of Conduct](CODE_OF_CONDUCT.md). By participating you
+agree to uphold it.
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Go | 1.26+ | https://go.dev/dl |
+| templ | v0.3.x | `go install github.com/a-h/templ/cmd/templ@latest` |
+| Tailwind CSS | v4 | standalone CLI or `npm i` |
+| golangci-lint | latest | https://golangci-lint.run |
+| Playwright (E2E) | v0.5700.1 | resolved by `go test ./tests/e2e/...` |
+
+## Getting started
+
+```bash
+git clone https://github.com/araihu/goshtoso
+cd goshtoso
+
+# enable the pre-commit hook (runs go fix + regenerates skill reference)
+git config core.hooksPath .githooks
+
+# run the dev server (port 8090)
+go run cmd/server/main.go
+```
+
+## Development workflow
+
+Generated artifacts are checked in but **must never be hand-edited**
+(`*_templ.go`, `assets/styles.css`). Regenerate them:
+
+```bash
+# after editing any .templ file
+templ generate
+
+# after editing CSS / introducing a new Tailwind utility class
+tailwindcss -i css/main.css -o assets/styles.css
+
+go build -o bin/server ./cmd/server
+```
+
+### Adding a component
+
+See `CLAUDE.md` (the full agent/contributor guide) and the `component-docs`
+convention. Every component lives in `components/<name>/` (`types.go` +
+`<name>.templ`) and ships a demo page that follows the docs-page pattern
+(one preview + code box per variant, an API reference table, the right-rail
+TOC). After changing a component, regenerate the usage reference:
+
+```bash
+go run ./scripts/skillgen
+```
+
+### Frontend interactivity hierarchy
+
+Pick the **highest** tier that solves the problem: **htmx (SSR) → Alpine.js →
+vanilla JS**. Most "interactive" needs (filtering, pagination, inline edit,
+lazy load, validation, toasts) are SSR + htmx, not JavaScript. Anything you add
+must survive HTMX swaps and fragment navigation.
+
+> ⚠️ **Templ + Alpine escaping is the #1 source of bugs.** Never use
+> `json.Marshal` for data that lands inside an HTML attribute — templ escapes
+> the quotes and Alpine silently fails. See `CLAUDE.md` for the safe patterns.
+
+## Before you open a PR
+
+Run the full gate locally — CI enforces all of it:
+
+```bash
+templ generate
+golangci-lint run                                   # cyclomatic ceiling: 20
+go fix ./...                                         # also runs via pre-commit hook
+go build -o bin/server ./cmd/server
+go test ./... -count=1                               # unit tests
+go test ./tests/e2e/... -count=1 -timeout 15m        # full E2E (~2.5 min)
+```
+
+Test components in **both light and dark mode** across themes (especially
+**Minimal**, which has no border-radius).
+
+## Pull requests
+
+1. Fork and branch from `main` (`fix/...`, `feat/...`).
+2. Keep PRs focused; one logical change per PR.
+3. Fill out the PR template checklist.
+4. A Codex review and CI (`lint-build` + E2E) must pass before merge.
+
+## Reporting bugs / requesting features
+
+Use the [issue templates](.github/ISSUE_TEMPLATE). For questions, open a
+[Discussion](https://github.com/araihu/goshtoso/discussions). For security
+issues, see [SECURITY.md](SECURITY.md) — do **not** file a public issue.
+
+## License
+
+By contributing, you agree your contributions are licensed under the
+[MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
   <img src="assets/images/goshtoso-art.png" alt="Goshtoso mascot" width="320" />
 </p>
 
+<p align="center">
+  <a href="https://github.com/araihu/goshtoso/actions/workflows/ci.yml"><img src="https://github.com/araihu/goshtoso/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://pkg.go.dev/github.com/araihu/goshtoso"><img src="https://pkg.go.dev/badge/github.com/araihu/goshtoso.svg" alt="Go Reference" /></a>
+  <a href="https://goreportcard.com/report/github.com/araihu/goshtoso"><img src="https://goreportcard.com/badge/github.com/araihu/goshtoso" alt="Go Report Card" /></a>
+  <a href="https://github.com/araihu/goshtoso/releases"><img src="https://img.shields.io/github/v/tag/araihu/goshtoso?label=release&sort=semver" alt="Latest tag" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
+</p>
+
 ⚠️ Work-In-Progress
 
 There is still lots of rough edeges to iron out, most related to preserving Alpine.js state when a wired component is swapped in by HTMX.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+Goshtoso is alpha-stage software. We take security seriously and appreciate
+responsible disclosure.
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| `v0.0.x` (alpha) | ✅ latest tag only |
+| older | ❌ |
+
+During alpha, only the most recent tagged release receives fixes.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security problems.**
+
+Report privately via GitHub's
+[**Report a vulnerability**](https://github.com/araihu/goshtoso/security/advisories/new)
+(Security → Advisories), or email **security@araihu.dev**.
+
+Please include:
+
+- affected component / endpoint and version (tag or commit),
+- a description and impact assessment,
+- reproduction steps or a proof of concept,
+- any suggested remediation.
+
+## What to expect
+
+- **Acknowledgement** within 5 business days.
+- An initial assessment and severity rating shortly after.
+- Coordinated disclosure: we'll agree on a timeline and credit you (unless you
+  prefer to remain anonymous) once a fix is released.
+
+## Scope notes
+
+Goshtoso renders HTML via templ and wires Alpine.js / HTMX. Of particular
+interest: HTML/attribute injection through component config, unsafe
+`templ.Raw` usage, and the table/example HTTP endpoints
+(`/api/components/...`, `/api/examples/...`). The demo server is for local
+development and is not hardened for untrusted public deployment.


### PR DESCRIPTION
Scaffolds standard open-source repo hygiene (follow-up to the `v0.0.1` alpha tag).

## What's added
- **CONTRIBUTING.md** — prerequisites, dev workflow, `templ generate`/Tailwind/lint gate, frontend interactivity hierarchy, PR checklist
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1
- **SECURITY.md** — private disclosure policy + alpha support window
- **.github/ISSUE_TEMPLATE/** — bug report, feature request, config (Discussions + Security advisory links)
- **.github/pull_request_template.md** — repo-specific gate checklist
- **.github/CODEOWNERS** — `* @araihu`
- **README** — CI / pkg.go.dev / Go Report Card / release / MIT badges

## Notes
- Placeholder contact emails: `conduct@araihu.dev`, `security@araihu.dev` — replace with real addresses (or GitHub-native flows) before relying on them.
- Code of Conduct uses the canonical Contributor Covenant 2.1 text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)