### PR TITLE
test(e2e): harden component-nav test against HTMX rebind race

### DIFF
--- a/site/tests/e2e/components_test.go
+++ b/site/tests/e2e/components_test.go
@@ -626,14 +626,13 @@ func TestIntegration(t *testing.T) {
 		title, _ := page.Title()
 		assert.Contains(t, title, "Accordion")
 
-		// Navigate to button
+		// Navigate to button. Sidebar links are htmx fragment-nav: the swapped-in
+		// link is re-bound a beat after it appears, so a plain Click can be lost
+		// under full-suite load (the documented HTMX rebind race — see CLAUDE.md).
+		// clickUntil re-fires until the title actually flips; htmx updates
+		// document.title from the swapped fragment's <title>.
 		buttonLink := page.Locator("a:has-text('Button')")
-		err = buttonLink.Click()
-		require.NoError(t, err)
-
-		_ = page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
-			State: playwright.LoadStateNetworkidle,
-		})
+		clickUntil(t, page, buttonLink, "() => document.title.includes('Button')")
 
 		title, _ = page.Title()
 		assert.Contains(t, title, "Button")


### PR DESCRIPTION
## Problem
`TestIntegration/User_Can_Navigate_Between_Components` flaked in CI on the Goshtoso theme PR (#22): it clicked a sidebar fragment-nav link with a plain `Click()` + `networkidle` wait, then asserted the page title contained `Button`. Under full-suite browser load the swapped-in link re-binds a beat after it appears, so the click is silently lost — no swap, title stays `Accordion - Goshtoso`. This is the **HTMX rebind race** already documented in CLAUDE.md and fixed elsewhere via `clickUntil`.

## Fix
Replace the plain click with `clickUntil`, which re-fires the click until `document.title.includes('Button')` (htmx updates `document.title` from the swapped fragment's `<title>`).

## Verification
- `go test -run TestIntegration/User_Can_Navigate_Between_Components -count=3` — green
- `go vet ./site/tests/e2e/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)