### PR TITLE
fix(getting-started): correct guide asset story + templ pin

### DIFF
--- a/examples/getting-started/go.mod
+++ b/examples/getting-started/go.mod
@@ -3,7 +3,7 @@ module github.com/araihu/goshtoso/examples/getting-started
 go 1.26.1
 
 require (
-	github.com/a-h/templ v0.3.1001
+	github.com/a-h/templ v0.3.1020
 	github.com/araihu/goshtoso v0.0.0-00010101000000-000000000000
 )
 

--- a/examples/getting-started/go.sum
+++ b/examples/getting-started/go.sum
@@ -1,4 +1,4 @@
-github.com/a-h/templ v0.3.1001 h1:yHDTgexACdJttyiyamcTHXr2QkIeVF1MukLy44EAhMY=
-github.com/a-h/templ v0.3.1001/go.mod h1:oCZcnKRf5jjsGpf2yELzQfodLphd2mwecwG4Crk5HBo=
+github.com/a-h/templ v0.3.1020 h1:ypAT/L5ySWEnZ6Zft/5yfoWXYYkhFNvEFOeeqecg4tw=
+github.com/a-h/templ v0.3.1020/go.mod h1:A2DlK61v+K+NRoGnhmYbNYVmtYHcFO5/AisMvBdDxTM=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/examples/getting-started/page.templ
+++ b/examples/getting-started/page.templ
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/araihu/goshtoso/components/table"
+import (
+	"github.com/araihu/goshtoso/components/head"
+	"github.com/araihu/goshtoso/components/table"
+)
 
 // Page renders the dog breeds page using the Goshtoso table component.
 // Filtering, sorting, and pagination are all built into the component —
@@ -19,12 +22,10 @@ templ Page(cfg table.Config) {
 			<meta charset="UTF-8"/>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 			<title>Dog Breeds — Goshtoso Getting Started</title>
-			<!-- Embedded Goshtoso assets (CSS with themes + JS) -->
-			<link rel="stylesheet" href="/assets/styles.css"/>
-			<script defer src="/assets/js/vendor/alpine-collapse.min.js"></script>
-			<script defer src="/assets/js/vendor/alpine-focus.min.js"></script>
-			<script defer src="/assets/js/vendor/alpine.min.js"></script>
-			<script src="/assets/js/vendor/htmx.min.js"></script>
+			<!-- Goshtoso runtime assets: CSS (themes) + Alpine + collapse/focus + HTMX.
+			     Served from /assets/ by assets.Handler() (mounted in main.go) — no CDN. -->
+			@head.Dependencies()
+			<!-- darkmode.js drives the theme/dark toggle; not part of Dependencies(). -->
 			<script src="/assets/js/darkmode.js"></script>
 			<style>[x-cloak] { display: none !important; }</style>
 		</head>

--- a/examples/getting-started/page_templ.go
+++ b/examples/getting-started/page_templ.go
@@ -8,7 +8,10 @@ package main
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import "github.com/araihu/goshtoso/components/table"
+import (
+	"github.com/araihu/goshtoso/components/head"
+	"github.com/araihu/goshtoso/components/table"
+)
 
 // Page renders the dog breeds page using the Goshtoso table component.
 // Filtering, sorting, and pagination are all built into the component —
@@ -37,7 +40,15 @@ func Page(cfg table.Config) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<!doctype html><html lang=\"en\" x-data x-init=\"\n\t\tconst t = localStorage.getItem('theme') || 'goshtoso';\n\t\tdocument.documentElement.setAttribute('data-theme', t);\n\t\tif (localStorage.getItem('darkMode') === 'true') document.documentElement.classList.add('dark');\n\t\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>Dog Breeds — Goshtoso Getting Started</title><!-- Embedded Goshtoso assets (CSS with themes + JS) --><link rel=\"stylesheet\" href=\"/assets/styles.css\"><script defer src=\"/assets/js/vendor/alpine-collapse.min.js\"></script><script defer src=\"/assets/js/vendor/alpine-focus.min.js\"></script><script defer src=\"/assets/js/vendor/alpine.min.js\"></script><script src=\"/assets/js/vendor/htmx.min.js\"></script><script src=\"/assets/js/darkmode.js\"></script><style>[x-cloak] { display: none !important; }</style></head><body class=\"min-h-screen bg-surface text-on-surface dark:bg-surface-dark dark:text-on-surface-dark\"><div class=\"max-w-5xl mx-auto px-6 py-12\"><h1 class=\"text-3xl font-bold font-title mb-2 text-on-surface-strong dark:text-on-surface-dark-strong\">Dog Breeds</h1><p class=\"text-on-surface-muted dark:text-on-surface-dark-muted mb-8\">A filterable, sortable, paginated table built with <a href=\"https://github.com/araihu/goshtoso\" class=\"underline text-primary dark:text-primary-dark\">Goshtoso</a> — Go + Alpine.js + Tailwind CSS + Templ + HTMX.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<!doctype html><html lang=\"en\" x-data x-init=\"\n\t\tconst t = localStorage.getItem('theme') || 'goshtoso';\n\t\tdocument.documentElement.setAttribute('data-theme', t);\n\t\tif (localStorage.getItem('darkMode') === 'true') document.documentElement.classList.add('dark');\n\t\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>Dog Breeds — Goshtoso Getting Started</title><!-- Goshtoso runtime assets: CSS (themes) + Alpine + collapse/focus + HTMX.\n\t\t\t     Served from /assets/ by assets.Handler() (mounted in main.go) — no CDN. -->")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = head.Dependencies().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<!-- darkmode.js drives the theme/dark toggle; not part of Dependencies(). --><script src=\"/assets/js/darkmode.js\"></script><style>[x-cloak] { display: none !important; }</style></head><body class=\"min-h-screen bg-surface text-on-surface dark:bg-surface-dark dark:text-on-surface-dark\"><div class=\"max-w-5xl mx-auto px-6 py-12\"><h1 class=\"text-3xl font-bold font-title mb-2 text-on-surface-strong dark:text-on-surface-dark-strong\">Dog Breeds</h1><p class=\"text-on-surface-muted dark:text-on-surface-dark-muted mb-8\">A filterable, sortable, paginated table built with <a href=\"https://github.com/araihu/goshtoso\" class=\"underline text-primary dark:text-primary-dark\">Goshtoso</a> — Go + Alpine.js + Tailwind CSS + Templ + HTMX.</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -45,7 +56,7 @@ func Page(cfg table.Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<p class=\"mt-6 text-xs text-on-surface-muted dark:text-on-surface-dark-muted text-center\">Built with <a href=\"https://github.com/araihu/goshtoso\" class=\"underline\">Goshtoso</a></p></div></body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<p class=\"mt-6 text-xs text-on-surface-muted dark:text-on-surface-dark-muted text-center\">Built with <a href=\"https://github.com/araihu/goshtoso\" class=\"underline\">Goshtoso</a></p></div></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/pages/demo/components/getting_started.templ
+++ b/site/internal/pages/demo/components/getting_started.templ
@@ -48,7 +48,9 @@ templ gettingStartedContent() {
 			<h2 class="text-xl font-bold font-title text-on-surface-strong dark:text-on-surface-dark-strong mb-3">3. Create the server</h2>
 			<p class="text-on-surface dark:text-on-surface-dark mb-3">
 				Create <code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">main.go</code> —
-				serves the page and handles the HTMX API endpoint for filtering, searching, and sorting:
+				it mounts <code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">assets.Handler()</code> to
+				serve the bundled CSS + JS from <code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">/assets/</code>
+				(no CDN, works offline), serves the page, and handles the HTMX API endpoint for filtering, searching, and sorting:
 			</p>
 			@codeblock.CodeBlock(codeblock.Config{Language: "go", Label: "main.go", Code: readExampleFile("main.go"), MaxHeight: "400px"})
 		</div>
@@ -84,10 +86,7 @@ func step1Code() string {
 	return `mkdir dog-breeds && cd dog-breeds
 go mod init dog-breeds
 go get github.com/a-h/templ@latest
-go get github.com/araihu/goshtoso@latest
-
-# Extract Goshtoso CSS (themes, component styles, utilities)
-go run github.com/araihu/goshtoso/cmd/goshtoso@latest -out=goshtoso.css`
+go get github.com/araihu/goshtoso@latest`
 }
 
 // readExampleFile reads a source file from examples/getting-started/

--- a/site/internal/pages/demo/components/getting_started_templ.go
+++ b/site/internal/pages/demo/components/getting_started_templ.go
@@ -83,7 +83,7 @@ func gettingStartedContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><!-- Step 3 --><div><h2 class=\"text-xl font-bold font-title text-on-surface-strong dark:text-on-surface-dark-strong mb-3\">3. Create the server</h2><p class=\"text-on-surface dark:text-on-surface-dark mb-3\">Create <code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">main.go</code> — serves the page and handles the HTMX API endpoint for filtering, searching, and sorting:</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><!-- Step 3 --><div><h2 class=\"text-xl font-bold font-title text-on-surface-strong dark:text-on-surface-dark-strong mb-3\">3. Create the server</h2><p class=\"text-on-surface dark:text-on-surface-dark mb-3\">Create <code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">main.go</code> — it mounts <code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">assets.Handler()</code> to serve the bundled CSS + JS from <code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">/assets/</code> (no CDN, works offline), serves the page, and handles the HTMX API endpoint for filtering, searching, and sorting:</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -111,10 +111,7 @@ func step1Code() string {
 	return `mkdir dog-breeds && cd dog-breeds
 go mod init dog-breeds
 go get github.com/a-h/templ@latest
-go get github.com/araihu/goshtoso@latest
-
-# Extract Goshtoso CSS (themes, component styles, utilities)
-go run github.com/araihu/goshtoso/cmd/goshtoso@latest -out=goshtoso.css`
+go get github.com/araihu/goshtoso@latest`
 }
 
 // readExampleFile reads a source file from examples/getting-started/


### PR DESCRIPTION
## Summary
Verified the Getting Started guide end-to-end from a clean module and fixed every divergence:

- **Drop the orphan `-out=goshtoso.css` extraction** from Step 1 — the example serves bundled assets via `assets.Handler()` and never references that file (matches `docs/USAGE.md` Path A). The extraction belongs only to the advanced "own Tailwind build" path.
- **Make the `assets.Handler()` mount explicit** in the Step 3 prose (no CDN, works offline) — previously it was only buried in the `main.go` dump.
- **Switch `examples/getting-started/page.templ` to `@head.Dependencies()`** + an explicit `darkmode.js` — dogfoods the PR #17 helper and matches USAGE.md's blessed path. (`Dependencies()` omits `darkmode.js`, which the theme/dark toggle needs; it covers the `alpine-collapse` plugin the filter bar requires.)
- **Pin the example's templ to `v0.3.1020`** to match the generated `page_templ.go` header (was `v0.3.1001`).

## Test Plan
- [x] Fresh `/tmp` module follows the guide verbatim → builds, runs, fully styled, works offline.
- [x] All 5 "What you get" interactions fire (sort, search, group filter, pagination, server fragments).
- [x] Browser console clean (Playwright: 0 errors) — the Alpine silent-parse-failure check.
- [x] Versioned/bundled assets 200; example builds (`GOWORK=off go build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)