### PR TITLE
chore(site): pin library to v0.0.2

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.0.0-20260602052940-39b8ee3cd7b1
+	github.com/araihu/goshtoso v0.0.2
 	github.com/coder/websocket v1.8.14
 	github.com/playwright-community/playwright-go v0.5700.1
 	github.com/stretchr/testify v1.11.1
@@ -17,6 +17,7 @@ require (
 	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.4 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,10 +6,11 @@ github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6
 github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.0.0-20260602052940-39b8ee3cd7b1 h1:wlI/D/9aur2d9KTEtMAq41jCmVvkgYFCxBDe96OHDjM=
-github.com/araihu/goshtoso v0.0.0-20260602052940-39b8ee3cd7b1/go.mod h1:2Mtkql7G0hHS5IqQF1nT/pctarPoPfHXy6fKZTZOtOY=
+github.com/araihu/goshtoso v0.0.2 h1:7G06yStM4AojpBRW5m8L4zT9jOL69C1/691UBCuSfEY=
+github.com/araihu/goshtoso v0.0.2/go.mod h1:pEJfw8LGHQpyX60yGckzuxog5XwwtGfvKI7Y8f7PP24=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary
- Pin the site module to the released `github.com/araihu/goshtoso v0.0.2` tag
- Preserve the release workflow's intended post-release site module update via PR because main requires PRs

## Verification
- `GOWORK=off go test $(GOWORK=off go list ./... | grep -v /tests/e2e) -count=1` from `site/`

## Release Context
- `v0.0.2` tag was pushed at `25b1f6c`
- GitHub release was created by the Release workflow
- The workflow failed only when pushing this same site-pin commit directly to protected `main`
