### PR TITLE
chore(site): pin library to v0.0.3

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.0.2
+	github.com/araihu/goshtoso v0.0.3
 	github.com/coder/websocket v1.8.14
 	github.com/playwright-community/playwright-go v0.5700.1
 	github.com/stretchr/testify v1.11.1

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6
 github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.0.2 h1:7G06yStM4AojpBRW5m8L4zT9jOL69C1/691UBCuSfEY=
-github.com/araihu/goshtoso v0.0.2/go.mod h1:pEJfw8LGHQpyX60yGckzuxog5XwwtGfvKI7Y8f7PP24=
+github.com/araihu/goshtoso v0.0.3 h1:C4UXjT2JdksjgHeOs+ti0rOszSiMGWlNF9vyHJQeQEs=
+github.com/araihu/goshtoso v0.0.3/go.mod h1:pEJfw8LGHQpyX60yGckzuxog5XwwtGfvKI7Y8f7PP24=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
## Summary
- update site module pin from v0.0.2 to v0.0.3
- refresh go.sum for the released module

## Verification
- GOWORK=off go test -C site $(GOWORK=off go list -C site ./... | grep -v /tests/e2e) -count=1