### PR TITLE
fix(example): refresh filtered paginator

### DIFF
--- a/examples/getting-started/main.go
+++ b/examples/getting-started/main.go
@@ -44,6 +44,8 @@ var breeds = []Dog{
 	{Breed: "Chihuahua", Group: "Toy", Origin: "Mexico", Size: "Small", Temperament: "Charming"},
 }
 
+const perPage = 5
+
 // columns defines the table headers
 func columns() []table.Column {
 	return []table.Column{
@@ -141,9 +143,7 @@ func filterAndSort(search, group, orderBy, orderDir string) []Dog {
 	return filtered
 }
 
-func main() {
-	const perPage = 5
-
+func appMux() *http.ServeMux {
 	mux := http.NewServeMux()
 
 	// Serve embedded Goshtoso assets (CSS with themes, Alpine.js, HTMX, fonts)
@@ -156,7 +156,7 @@ func main() {
 			return
 		}
 		dogs := filterAndSort("", "", "breed", "asc")
-		totalPages := (len(dogs) + perPage - 1) / perPage
+		totalPages := max(1, (len(dogs)+perPage-1)/perPage)
 		pageRows := dogsToRows(dogs[:min(perPage, len(dogs))])
 
 		Page(table.Config{
@@ -199,7 +199,7 @@ func main() {
 				pp = p
 			}
 		}
-		totalPages := (len(dogs) + pp - 1) / pp
+		totalPages := max(1, (len(dogs)+pp-1)/pp)
 		start := (page - 1) * pp
 		if start >= len(dogs) {
 			start = 0
@@ -225,16 +225,19 @@ func main() {
 			table.TableRow(cfg, row).Render(r.Context(), w)
 		}
 
-		// OOB: update pagination controls
-		if totalPages > 1 {
-			fmt.Fprintf(w, `<div id="%s" hx-swap-oob="true" class="flex items-center justify-between border-t border-gray-200 px-4 py-3">`, cfg.PaginationID())
-			fmt.Fprintf(w, `<div class="text-sm text-gray-500">Page %d of %d</div>`, page, totalPages)
-			table.TablePaginationNav(cfg).Render(r.Context(), w)
-			fmt.Fprintf(w, `</div>`)
-		}
+		// OOB: always update pagination controls so filtered one-page results
+		// clear any stale paginator from the previous unfiltered table state.
+		fmt.Fprintf(w, `<div id="%s" hx-swap-oob="true" class="flex items-center justify-between border-t border-gray-200 px-4 py-3">`, cfg.PaginationID())
+		fmt.Fprintf(w, `<div class="text-sm text-gray-500">Page %d of %d</div>`, page, totalPages)
+		table.TablePaginationNav(cfg).Render(r.Context(), w)
+		fmt.Fprintf(w, `</div>`)
 	})
 
+	return mux
+}
+
+func main() {
 	addr := ":3000"
 	log.Printf("Dog breeds app running at http://localhost%s", addr)
-	log.Fatal(http.ListenAndServe(addr, mux))
+	log.Fatal(http.ListenAndServe(addr, appMux()))
 }

--- a/examples/getting-started/main_test.go
+++ b/examples/getting-started/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBreedsAPIUpdatesPaginatorForOnePageFilter(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/breeds?search=USA&order_by=breed&order_dir=asc&page=1&per_page=5", nil)
+	rec := httptest.NewRecorder()
+
+	appMux().ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `hx-swap-oob="true"`) {
+		t.Fatalf("filtered response must include paginator OOB replacement:\n%s", body)
+	}
+	if !strings.Contains(body, "Page 1 of 1") {
+		t.Fatalf("filtered response paginator = %q, want Page 1 of 1", body)
+	}
+	if strings.Contains(body, "page 2") || strings.Contains(body, `page=2`) {
+		t.Fatalf("one-page filtered response must not keep stale page 2 controls:\n%s", body)
+	}
+}


### PR DESCRIPTION
## Summary
- always return a paginator OOB replacement from the getting-started `/api/breeds` endpoint
- clamp filtered page counts to at least `Page 1 of 1`
- add a regression test for one-page filtered results clearing stale page links

## Why
Filtering from the full table to a single page updated the rows but left the old `Page 1 of 4` paginator in place because the endpoint skipped paginator OOB output when `totalPages <= 1`.

## Verification
- `go test ./... -count=1` from `examples/getting-started`
- `go test ./components/table ./components/head ./assets`
- `go test ./... -count=1` from the root module
- `cd site && go test ./internal/server ./internal/pages/demo/components -count=1`
- browser check on `localhost:3000`: typing `USA` shows one row, `Page 1 of 1`, and no page links
