### PR TITLE
Harden legacy component interfaces

### DIFF
--- a/components/banner/banner.templ
+++ b/components/banner/banner.templ
@@ -48,7 +48,7 @@ templ simpleBanner(cfg Config) {
 			<div class="mx-auto flex flex-wrap items-center gap-2 px-6">
 				<p class={ cfg.TextClasses() }>{ cfg.Text }</p>
 				if cfg.CTA.Href != "" {
-					<a href={ templ.SafeURL(cfg.CTA.Href) } class={ cfg.CTAClasses() }>
+					<a href={ templ.URL(cfg.CTA.Href) } class={ cfg.CTAClasses() }>
 						{ cfg.CTA.Text }
 					</a>
 				} else {

--- a/components/banner/banner_hardening_test.go
+++ b/components/banner/banner_hardening_test.go
@@ -1,0 +1,36 @@
+package banner
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderBanner(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, Banner(cfg).Render(context.Background(), &buf))
+	return buf.String()
+}
+
+func TestBannerCTA_SanitizesUnsafeHref(t *testing.T) {
+	rendered := renderBanner(t, Config{
+		Text: "Notice",
+		CTA:  &CTAConfig{Text: "Open", Href: "javascript:alert(1)"},
+	})
+
+	assert.NotContains(t, rendered, `href="javascript:alert`)
+	assert.Contains(t, rendered, `href="about:invalid#TemplFailedSanitizationURL"`)
+}
+
+func TestBannerCTA_PreservesRelativeHref(t *testing.T) {
+	rendered := renderBanner(t, Config{
+		Text: "Notice",
+		CTA:  &CTAConfig{Text: "Open", Href: "/docs?tab=api"},
+	})
+
+	assert.Contains(t, rendered, `href="/docs?tab=api"`)
+}

--- a/components/banner/banner_templ.go
+++ b/components/banner/banner_templ.go
@@ -167,9 +167,9 @@ func simpleBanner(cfg Config) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var9 templ.SafeURL
-				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(cfg.CTA.Href))
+				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(cfg.CTA.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/banner/banner.templ`, Line: 51, Col: 42}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/banner/banner.templ`, Line: 51, Col: 38}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {

--- a/components/breadcrumbs/breadcrumbs.templ
+++ b/components/breadcrumbs/breadcrumbs.templ
@@ -20,7 +20,7 @@ templ Breadcrumbs(cfg Config) {
 			for _, item := range cfg.Items {
 				<li class={ itemClasses(cfg.Separator) }>
 					<a
-						href={ templ.SafeURL(item.Href) }
+						href={ templ.URL(item.Href) }
 						{ item.LinkAttrs... }
 						class="flex items-center gap-1 hover:text-on-surface-strong dark:hover:text-on-surface-dark-strong"
 					>

--- a/components/breadcrumbs/breadcrumbs_hardening_test.go
+++ b/components/breadcrumbs/breadcrumbs_hardening_test.go
@@ -1,0 +1,34 @@
+package breadcrumbs
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderBreadcrumbs(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, Breadcrumbs(cfg).Render(context.Background(), &buf))
+	return buf.String()
+}
+
+func TestBreadcrumbs_SanitizesUnsafeHref(t *testing.T) {
+	rendered := renderBreadcrumbs(t, Config{
+		Items: []Item{{Label: "Bad", Href: "javascript:alert(1)"}},
+	})
+
+	assert.NotContains(t, rendered, `href="javascript:alert`)
+	assert.Contains(t, rendered, `href="about:invalid#TemplFailedSanitizationURL"`)
+}
+
+func TestBreadcrumbs_PreservesRelativeHref(t *testing.T) {
+	rendered := renderBreadcrumbs(t, Config{
+		Items: []Item{{Label: "Docs", Href: "/docs?tab=api"}},
+	})
+
+	assert.Contains(t, rendered, `href="/docs?tab=api"`)
+}

--- a/components/breadcrumbs/breadcrumbs_templ.go
+++ b/components/breadcrumbs/breadcrumbs_templ.go
@@ -115,9 +115,9 @@ func Breadcrumbs(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var8 templ.SafeURL
-			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(item.Href))
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/breadcrumbs/breadcrumbs.templ`, Line: 23, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/breadcrumbs/breadcrumbs.templ`, Line: 23, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {

--- a/components/dropdown/dropdown.templ
+++ b/components/dropdown/dropdown.templ
@@ -219,7 +219,7 @@ templ menuItem(cfg Config, item Item) {
 // menuItemLink renders a single menu item as an anchor
 templ menuItemLink(cfg Config, item Item) {
 	<a
-		href={ templ.SafeURL(item.Href) }
+		href={ templ.URL(item.Href) }
 		if item.Tooltip != "" {
 			title={ item.Tooltip }
 		}

--- a/components/dropdown/dropdown_hardening_test.go
+++ b/components/dropdown/dropdown_hardening_test.go
@@ -1,0 +1,40 @@
+package dropdown
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderDropdown(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, Dropdown(cfg).Render(context.Background(), &buf))
+	return buf.String()
+}
+
+func TestDropdownLink_SanitizesUnsafeHref(t *testing.T) {
+	rendered := renderDropdown(t, Config{
+		ID: "menu",
+		Sections: []Section{{Items: []Item{
+			{Label: "Bad", Href: "javascript:alert(1)"},
+		}}},
+	})
+
+	assert.NotContains(t, rendered, `href="javascript:alert`)
+	assert.Contains(t, rendered, `href="about:invalid#TemplFailedSanitizationURL"`)
+}
+
+func TestDropdownLink_PreservesRelativeHref(t *testing.T) {
+	rendered := renderDropdown(t, Config{
+		ID: "menu",
+		Sections: []Section{{Items: []Item{
+			{Label: "Docs", Href: "/docs?tab=api"},
+		}}},
+	})
+
+	assert.Contains(t, rendered, `href="/docs?tab=api"`)
+}

--- a/components/dropdown/dropdown_templ.go
+++ b/components/dropdown/dropdown_templ.go
@@ -735,9 +735,9 @@ func menuItemLink(cfg Config, item Item) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var30 templ.SafeURL
-		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(item.Href))
+		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/dropdown/dropdown.templ`, Line: 222, Col: 33}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/dropdown/dropdown.templ`, Line: 222, Col: 29}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 		if templ_7745c5c3_Err != nil {

--- a/components/pagination/pagination.templ
+++ b/components/pagination/pagination.templ
@@ -44,7 +44,7 @@ templ Pagination(cfg Config) {
 				if cfg.HasPrevious() {
 					if cfg.HTMXTarget != "" {
 						<a
-							href={ templ.SafeURL(cfg.PageURL(cfg.PreviousPage())) }
+							href={ templ.URL(cfg.PageURL(cfg.PreviousPage())) }
 							class={ cfg.PrevNextClasses(true) }
 							aria-label="previous page"
 							hx-get={ cfg.PageURL(cfg.PreviousPage()) }
@@ -56,7 +56,7 @@ templ Pagination(cfg Config) {
 						</a>
 					} else {
 						<a
-							href={ templ.SafeURL(cfg.PageURL(cfg.PreviousPage())) }
+							href={ templ.URL(cfg.PageURL(cfg.PreviousPage())) }
 							class={ cfg.PrevNextClasses(true) }
 							aria-label="previous page"
 						>
@@ -83,7 +83,7 @@ templ Pagination(cfg Config) {
 					} else if item.IsCurrent {
 						<li>
 							<a
-								href={ templ.SafeURL(cfg.PageURL(item.Page)) }
+								href={ templ.URL(cfg.PageURL(item.Page)) }
 								class={ cfg.PageClasses(true) }
 								aria-current="page"
 								aria-label={ "page " + itoa(item.Page) }
@@ -95,7 +95,7 @@ templ Pagination(cfg Config) {
 						<li>
 							if cfg.HTMXTarget != "" {
 								<a
-									href={ templ.SafeURL(cfg.PageURL(item.Page)) }
+									href={ templ.URL(cfg.PageURL(item.Page)) }
 									class={ cfg.PageClasses(false) }
 									aria-label={ "page " + itoa(item.Page) }
 									hx-get={ cfg.PageURL(item.Page) }
@@ -106,7 +106,7 @@ templ Pagination(cfg Config) {
 								</a>
 							} else {
 								<a
-									href={ templ.SafeURL(cfg.PageURL(item.Page)) }
+									href={ templ.URL(cfg.PageURL(item.Page)) }
 									class={ cfg.PageClasses(false) }
 									aria-label={ "page " + itoa(item.Page) }
 								>
@@ -122,7 +122,7 @@ templ Pagination(cfg Config) {
 				if cfg.HasNext() {
 					if cfg.HTMXTarget != "" {
 						<a
-							href={ templ.SafeURL(cfg.PageURL(cfg.NextPage())) }
+							href={ templ.URL(cfg.PageURL(cfg.NextPage())) }
 							class={ cfg.PrevNextClasses(true) }
 							aria-label="next page"
 							hx-get={ cfg.PageURL(cfg.NextPage()) }
@@ -134,7 +134,7 @@ templ Pagination(cfg Config) {
 						</a>
 					} else {
 						<a
-							href={ templ.SafeURL(cfg.PageURL(cfg.NextPage())) }
+							href={ templ.URL(cfg.PageURL(cfg.NextPage())) }
 							class={ cfg.PrevNextClasses(true) }
 							aria-label="next page"
 						>

--- a/components/pagination/pagination_hardening_test.go
+++ b/components/pagination/pagination_hardening_test.go
@@ -1,0 +1,41 @@
+package pagination
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderPagination(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, Pagination(cfg).Render(context.Background(), &buf))
+	return buf.String()
+}
+
+func TestPageURL_PreservesQueryAndFragment(t *testing.T) {
+	got := Config{BaseURL: "/items?filter=active&page=1#results"}.PageURL(3)
+
+	assert.Equal(t, "/items?filter=active&page=3#results", got)
+}
+
+func TestPageURL_EncodesPageParamWithoutStringConcatenation(t *testing.T) {
+	got := Config{BaseURL: "/items?search=two words&tag=a/b"}.PageURL(12)
+
+	assert.Equal(t, "/items?page=12&search=two+words&tag=a%2Fb", got)
+}
+
+func TestPagination_RenderedHrefSanitizesUnsafeBaseURL(t *testing.T) {
+	rendered := renderPagination(t, Config{
+		Variant:     Simple,
+		CurrentPage: 1,
+		TotalPages:  2,
+		BaseURL:     "javascript:alert(1)",
+	})
+
+	assert.NotContains(t, rendered, `href="javascript:alert`)
+	assert.Contains(t, rendered, `href="about:invalid#TemplFailedSanitizationURL"`)
+}

--- a/components/pagination/pagination_templ.go
+++ b/components/pagination/pagination_templ.go
@@ -138,9 +138,9 @@ func Pagination(cfg Config) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var8 templ.SafeURL
-				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(cfg.PageURL(cfg.PreviousPage())))
+				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(cfg.PageURL(cfg.PreviousPage())))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 47, Col: 60}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 47, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
@@ -221,9 +221,9 @@ func Pagination(cfg Config) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var14 templ.SafeURL
-				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(cfg.PageURL(cfg.PreviousPage())))
+				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(cfg.PageURL(cfg.PreviousPage())))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 59, Col: 60}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 59, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -343,9 +343,9 @@ func Pagination(cfg Config) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var21 templ.SafeURL
-					templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(cfg.PageURL(item.Page)))
+					templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(cfg.PageURL(item.Page)))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 86, Col: 52}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 86, Col: 48}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 					if templ_7745c5c3_Err != nil {
@@ -410,9 +410,9 @@ func Pagination(cfg Config) templ.Component {
 							return templ_7745c5c3_Err
 						}
 						var templ_7745c5c3_Var26 templ.SafeURL
-						templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(cfg.PageURL(item.Page)))
+						templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(cfg.PageURL(item.Page)))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 98, Col: 53}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 98, Col: 49}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 						if templ_7745c5c3_Err != nil {
@@ -511,9 +511,9 @@ func Pagination(cfg Config) templ.Component {
 							return templ_7745c5c3_Err
 						}
 						var templ_7745c5c3_Var34 templ.SafeURL
-						templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(cfg.PageURL(item.Page)))
+						templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(cfg.PageURL(item.Page)))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 109, Col: 53}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 109, Col: 49}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 						if templ_7745c5c3_Err != nil {
@@ -586,9 +586,9 @@ func Pagination(cfg Config) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var39 templ.SafeURL
-				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(cfg.PageURL(cfg.NextPage())))
+				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(cfg.PageURL(cfg.NextPage())))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 125, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 125, Col: 52}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 				if templ_7745c5c3_Err != nil {
@@ -669,9 +669,9 @@ func Pagination(cfg Config) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var45 templ.SafeURL
-				templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(cfg.PageURL(cfg.NextPage())))
+				templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(cfg.PageURL(cfg.NextPage())))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 137, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/pagination/pagination.templ`, Line: 137, Col: 52}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 				if templ_7745c5c3_Err != nil {

--- a/components/pagination/types.go
+++ b/components/pagination/types.go
@@ -1,5 +1,7 @@
 package pagination
 
+import "net/url"
+
 // Variant represents pagination style variants
 type Variant string
 
@@ -73,21 +75,14 @@ func (cfg Config) PageURL(page int) string {
 	if cfg.BaseURL == "" {
 		return "#"
 	}
-	url := cfg.BaseURL
-	// Check if URL already has query params
-	hasQuery := false
-	for _, c := range url {
-		if c == '?' {
-			hasQuery = true
-			break
-		}
+	u, err := url.Parse(cfg.BaseURL)
+	if err != nil {
+		return "#"
 	}
-	if hasQuery {
-		url += "&page=" + itoa(page)
-	} else {
-		url += "?page=" + itoa(page)
-	}
-	return url
+	q := u.Query()
+	q.Set("page", itoa(page))
+	u.RawQuery = q.Encode()
+	return u.String()
 }
 
 // SwapStrategy returns the HTMX swap strategy, defaulting to innerHTML

--- a/components/select/select.templ
+++ b/components/select/select.templ
@@ -117,7 +117,7 @@ templ Select(cfg Config) {
 								class="combobox-option inline-flex justify-between items-center gap-4 bg-surface-alt px-4 py-2 text-sm text-on-surface hover:bg-surface-dark-alt/5 hover:text-on-surface-strong focus-visible:bg-surface-dark-alt/5 focus-visible:text-on-surface-strong focus-visible:outline-hidden dark:bg-surface-dark-alt dark:text-on-surface-dark dark:hover:bg-surface-alt/5 dark:hover:text-on-surface-dark-strong dark:focus-visible:bg-surface-alt/10 dark:focus-visible:text-on-surface-dark-strong cursor-pointer"
 								x-on:click="selectOption(item)"
 								x-on:keydown.enter.prevent="selectOption(item)"
-								x-bind:id={ "'" + cfg.ID + "-option-' + index" }
+								x-bind:id={ jsStringLiteral(cfg.ID+"-option-") + " + index" }
 								tabindex="0"
 								x-on:keydown.down.prevent="$focus.wrap().next()"
 								x-on:keydown.up.prevent="$focus.wrap().previous()"
@@ -178,6 +178,10 @@ func jsEscapeSingle(s string) string {
 		}
 	}
 	return result
+}
+
+func jsStringLiteral(s string) string {
+	return "'" + jsEscapeSingle(s) + "'"
 }
 
 func optionsToJS(options []Option) string {

--- a/components/select/select_hardening_test.go
+++ b/components/select/select_hardening_test.go
@@ -1,0 +1,40 @@
+package selectfield
+
+import (
+	"html"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectData_EscapesOptionAndPlaceholderStrings(t *testing.T) {
+	cfg := Config{
+		Placeholder: `Pick Bob's \ region & team`,
+		Options: []Option{
+			{Value: `us'east\1`, Label: `Bob's \ Team & Co.`},
+			{Value: `eu-west`, Label: `Europe`},
+		},
+	}
+
+	data := selectData(cfg)
+
+	assert.Contains(t, data, `placeholder: 'Pick Bob\'s \\ region & team'`)
+	assert.Contains(t, data, `{value:'us\'east\\1',label:'Bob\'s \\ Team & Co.'}`)
+	assert.Contains(t, data, "selectedValues: []")
+	assert.NotContains(t, data, "selectedValues: null")
+}
+
+func TestSelectedValueJS_EmptySelectionIsArray(t *testing.T) {
+	assert.Equal(t, "[]", selectedValueJS(nil))
+	assert.Equal(t, "[]", selectedValueJS([]Option{{Value: "a", Label: "A"}}))
+}
+
+func TestSelect_RenderedOptionIDExpressionEscapesConfigID(t *testing.T) {
+	rendered := renderSelect(t, Config{
+		ID:      `choice'\x`,
+		Options: []Option{{Value: "a", Label: "A"}},
+	}, nil)
+	browserHTML := html.UnescapeString(rendered)
+
+	assert.Contains(t, browserHTML, `x-bind:id="'choice\'\\x-option-' + index"`)
+}

--- a/components/select/select_templ.go
+++ b/components/select/select_templ.go
@@ -405,9 +405,9 @@ func Select(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var22 string
-			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue("'" + cfg.ID + "-option-' + index")
+			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(jsStringLiteral(cfg.ID+"-option-") + " + index")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 120, Col: 54}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 120, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
 			if templ_7745c5c3_Err != nil {
@@ -491,6 +491,10 @@ func jsEscapeSingle(s string) string {
 		}
 	}
 	return result
+}
+
+func jsStringLiteral(s string) string {
+	return "'" + jsEscapeSingle(s) + "'"
 }
 
 func optionsToJS(options []Option) string {

--- a/components/tabs/tabs_hardening_test.go
+++ b/components/tabs/tabs_hardening_test.go
@@ -1,0 +1,49 @@
+package tabs
+
+import (
+	"bytes"
+	"context"
+	"html"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderTabs(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, Tabs(cfg).Render(context.Background(), &buf))
+	return buf.String()
+}
+
+func TestTabsData_EscapesDefaultAndSyncHashTabIDs(t *testing.T) {
+	cfg := Config{
+		DefaultTab: `billing'\x`,
+		SyncHash:   true,
+		Tabs: []Tab{
+			{ID: `billing'\x`, Label: "Billing"},
+			{ID: `usage'\x`, Label: "Usage"},
+		},
+	}
+
+	data := tabsData(cfg)
+
+	assert.Contains(t, data, `selectedTab:'billing\'\\x'`)
+	assert.Contains(t, data, `var v=['billing\'\\x','usage\'\\x'];`)
+}
+
+func TestTabs_RenderedAlpineExpressionsEscapeTabID(t *testing.T) {
+	rendered := renderTabs(t, Config{
+		ID:         "account",
+		DefaultTab: `billing'\x`,
+		Tabs: []Tab{
+			{ID: `billing'\x`, Label: "Billing"},
+		},
+	})
+	browserHTML := html.UnescapeString(rendered)
+
+	assert.Contains(t, browserHTML, `x-on:click="selectedTab = 'billing\'\\x'"`)
+	assert.Contains(t, browserHTML, `x-bind:aria-selected="selectedTab === 'billing\'\\x'"`)
+	assert.Contains(t, browserHTML, `x-show="selectedTab === 'billing\'\\x'"`)
+}

--- a/components/toast/toast_hardening_test.go
+++ b/components/toast/toast_hardening_test.go
@@ -1,0 +1,65 @@
+package toast
+
+import (
+	"bytes"
+	"context"
+	"html"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderToast(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, Toast(cfg).Render(context.Background(), &buf))
+	return buf.String()
+}
+
+func TestToast_UniqueIDIsConcurrencySafe(t *testing.T) {
+	idCounter.Store(0)
+	const count = 64
+	ids := make(chan int64, count)
+	var wg sync.WaitGroup
+
+	for range count {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ids <- uniqueID()
+		}()
+	}
+	wg.Wait()
+	close(ids)
+
+	seen := make(map[int64]bool, count)
+	for id := range ids {
+		assert.False(t, seen[id], "duplicate toast ID %d", id)
+		seen[id] = true
+	}
+	require.Len(t, seen, count)
+}
+
+func TestToast_RenderedDismissExpressionsUseGeneratedSafeID(t *testing.T) {
+	idCounter.Store(0)
+	rendered := renderToast(t, Config{
+		Variant: Success,
+		Title:   "Saved",
+		Message: "Done",
+	})
+	browserHTML := html.UnescapeString(rendered)
+
+	assert.Contains(t, browserHTML, `id="server-toast-1"`)
+	assert.Contains(t, browserHTML, `data-toast-id="server-toast-1"`)
+	assert.Contains(t, browserHTML, `x-on:toast-dismiss.window="if ($event.detail.id === 'server-toast-1') { $el.remove() }"`)
+	assert.Contains(t, browserHTML, `x-on:click="isVisible = false; $dispatch('toast-dismiss', { id: 'server-toast-1' })"`)
+}
+
+func TestSingleToastAlpineData_UsesNumericDuration(t *testing.T) {
+	data := singleToastAlpineData(1250)
+
+	assert.Contains(t, data, "}, 1250);")
+	assert.NotContains(t, data, "}, '1250');")
+}


### PR DESCRIPTION
## Summary
- Escape caller-provided values in legacy Alpine expressions for select, combobox, triplet, keyvalue, tabs, and toast coverage
- Replace JSON-in-attribute Alpine data builders in keyvalue/triplet with single-quoted JS literals
- Use net/url and templ URL sanitization for pagination/dropdown/breadcrumbs/banner links

## Test Plan
- [x] templ generate && go run ./scripts/skillgen && go test ./components/... -count=1