### PR TITLE
fix(theme): separate Goshtoso semantic colors

### DIFF
--- a/all-themes.css
+++ b/all-themes.css
@@ -603,7 +603,7 @@
         --color-outline-strong: #3a4b5f;         /* blue-slate-700 */
         /* Dark */
         --color-surface-dark: #131920;           /* blue-slate-900 */
-        --color-surface-dark-alt: #06151e;       /* yale-blue-950 */
+        --color-surface-dark-alt: #263847;       /* raised blue-slate */
         --color-on-surface-dark: #c0cbd8;        /* blue-slate-200 */
         --color-on-surface-dark-strong: #ffffff;
         --color-primary-dark: #3bcef7;           /* sky-aqua-400 */
@@ -613,12 +613,12 @@
         --color-outline-dark: #3a4b5f;           /* blue-slate-700 */
         --color-outline-dark-strong: #a0b1c5;    /* blue-slate-300 */
         /* Status */
-        --color-info: #0ac2f5;                   /* sky-aqua-500 */
-        --color-on-info: #000000;
-        --color-success: #4b7d1c;                /* forest-moss-700 */
-        --color-on-success: #ffffff;
-        --color-warning: #d3d75b;                /* lime-moss-400 */
-        --color-on-warning: #000000;
+        --color-info: #0f766e;                   /* teal */
+        --color-on-info: #f5fcff;
+        --color-success: #047857;                /* emerald */
+        --color-on-success: #f0fdf4;
+        --color-warning: #f59e0b;                /* amber */
+        --color-on-warning: #211606;
         --color-danger: #dc2626;                 /* no red in palette */
         --color-on-danger: #ffffff;
         /* Border */

--- a/assets/goshtoso-theme.css
+++ b/assets/goshtoso-theme.css
@@ -646,7 +646,7 @@
         --color-outline-strong: #3a4b5f;         /* blue-slate-700 */
         /* Dark */
         --color-surface-dark: #131920;           /* blue-slate-900 */
-        --color-surface-dark-alt: #06151e;       /* yale-blue-950 */
+        --color-surface-dark-alt: #263847;       /* raised blue-slate */
         --color-on-surface-dark: #c0cbd8;        /* blue-slate-200 */
         --color-on-surface-dark-strong: #ffffff;
         --color-primary-dark: #3bcef7;           /* sky-aqua-400 */
@@ -656,12 +656,12 @@
         --color-outline-dark: #3a4b5f;           /* blue-slate-700 */
         --color-outline-dark-strong: #a0b1c5;    /* blue-slate-300 */
         /* Status */
-        --color-info: #0ac2f5;                   /* sky-aqua-500 */
-        --color-on-info: #000000;
-        --color-success: #4b7d1c;                /* forest-moss-700 */
-        --color-on-success: #ffffff;
-        --color-warning: #d3d75b;                /* lime-moss-400 */
-        --color-on-warning: #000000;
+        --color-info: #0f766e;                   /* teal */
+        --color-on-info: #f5fcff;
+        --color-success: #047857;                /* emerald */
+        --color-on-success: #f0fdf4;
+        --color-warning: #f59e0b;                /* amber */
+        --color-on-warning: #211606;
         --color-danger: #dc2626;                 /* no red in palette */
         --color-on-danger: #ffffff;
         /* Border */

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -7131,7 +7131,7 @@
     --color-outline: #c0cbd8;
     --color-outline-strong: #3a4b5f;
     --color-surface-dark: #131920;
-    --color-surface-dark-alt: #06151e;
+    --color-surface-dark-alt: #263847;
     --color-on-surface-dark: #c0cbd8;
     --color-on-surface-dark-strong: #ffffff;
     --color-primary-dark: #3bcef7;
@@ -7140,12 +7140,12 @@
     --color-on-secondary-dark: #131920;
     --color-outline-dark: #3a4b5f;
     --color-outline-dark-strong: #a0b1c5;
-    --color-info: #0ac2f5;
-    --color-on-info: #000000;
-    --color-success: #4b7d1c;
-    --color-on-success: #ffffff;
-    --color-warning: #d3d75b;
-    --color-on-warning: #000000;
+    --color-info: #0f766e;
+    --color-on-info: #f5fcff;
+    --color-success: #047857;
+    --color-on-success: #f0fdf4;
+    --color-warning: #f59e0b;
+    --color-on-warning: #211606;
     --color-danger: #dc2626;
     --color-on-danger: #ffffff;
     --radius-radius: var(--radius-lg);

--- a/site/internal/pages/demo/components/theme.templ
+++ b/site/internal/pages/demo/components/theme.templ
@@ -764,7 +764,7 @@ func getThemeCSSBlocks() map[string]string {
     --color-outline: #c0cbd8;
     --color-outline-strong: #3a4b5f;
     --color-surface-dark: #131920;
-    --color-surface-dark-alt: #06151e;
+    --color-surface-dark-alt: #263847;
     --color-on-surface-dark: #c0cbd8;
     --color-on-surface-dark-strong: #ffffff;
     --color-primary-dark: #3bcef7;
@@ -773,12 +773,12 @@ func getThemeCSSBlocks() map[string]string {
     --color-on-secondary-dark: #131920;
     --color-outline-dark: #3a4b5f;
     --color-outline-dark-strong: #a0b1c5;
-    --color-info: #0ac2f5;
-    --color-on-info: #000000;
-    --color-success: #4b7d1c;
-    --color-on-success: #ffffff;
-    --color-warning: #d3d75b;
-    --color-on-warning: #000000;
+    --color-info: #0f766e;
+    --color-on-info: #f5fcff;
+    --color-success: #047857;
+    --color-on-success: #f0fdf4;
+    --color-warning: #f59e0b;
+    --color-on-warning: #211606;
     --color-danger: #dc2626;
     --color-on-danger: #ffffff;
     --radius-radius: var(--radius-lg);

--- a/site/internal/pages/demo/components/theme_templ.go
+++ b/site/internal/pages/demo/components/theme_templ.go
@@ -772,7 +772,7 @@ func getThemeCSSBlocks() map[string]string {
     --color-outline: #c0cbd8;
     --color-outline-strong: #3a4b5f;
     --color-surface-dark: #131920;
-    --color-surface-dark-alt: #06151e;
+    --color-surface-dark-alt: #263847;
     --color-on-surface-dark: #c0cbd8;
     --color-on-surface-dark-strong: #ffffff;
     --color-primary-dark: #3bcef7;
@@ -781,12 +781,12 @@ func getThemeCSSBlocks() map[string]string {
     --color-on-secondary-dark: #131920;
     --color-outline-dark: #3a4b5f;
     --color-outline-dark-strong: #a0b1c5;
-    --color-info: #0ac2f5;
-    --color-on-info: #000000;
-    --color-success: #4b7d1c;
-    --color-on-success: #ffffff;
-    --color-warning: #d3d75b;
-    --color-on-warning: #000000;
+    --color-info: #0f766e;
+    --color-on-info: #f5fcff;
+    --color-success: #047857;
+    --color-on-success: #f0fdf4;
+    --color-warning: #f59e0b;
+    --color-on-warning: #211606;
     --color-danger: #dc2626;
     --color-on-danger: #ffffff;
     --radius-radius: var(--radius-lg);


### PR DESCRIPTION
## Summary
- Separate Goshtoso status colors from brand primary/secondary colors
- Give dark alternate surfaces a clearer raised layer
- Regenerate theme export and embedded CSS assets

## Test Plan
- templ generate
- just css
- go build -o bin/server ./site/cmd/server
- go test ./site/tests/e2e/... -count=1 -timeout 5m -run 'TestTheme'
- git diff --check