### PR TITLE
fix(site): add browser storage opt-out

### DIFF
--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -1,10 +1,14 @@
 document.addEventListener('alpine:init', () => {
+    const storageAllowed = () => !window.goshtosoStorageConsent || window.goshtosoStorageConsent.allowed();
+
     Alpine.store('darkMode', {
         // Initialize from localStorage or browser preference
         on: (() => {
-            const saved = localStorage.getItem('darkMode');
-            if (saved !== null) {
-                return saved === 'true';
+            if (storageAllowed()) {
+                const saved = localStorage.getItem('darkMode');
+                if (saved !== null) {
+                    return saved === 'true';
+                }
             }
             // Default to browser preference
             return window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -21,7 +25,11 @@ document.addEventListener('alpine:init', () => {
         
         toggle() {
             this.on = !this.on;
-            localStorage.setItem('darkMode', this.on);
+            if (storageAllowed()) {
+                localStorage.setItem('darkMode', this.on);
+            } else {
+                localStorage.removeItem('darkMode');
+            }
             
             if (this.on) {
                 document.documentElement.classList.add('dark');

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -4928,6 +4928,11 @@
       width: calc(var(--spacing) * 64);
     }
   }
+  .sm\:max-w-md {
+    @media (width >= 40rem) {
+      max-width: var(--container-md);
+    }
+  }
   .sm\:max-w-sm {
     @media (width >= 40rem) {
       max-width: var(--container-sm);
@@ -4961,6 +4966,11 @@
   .sm\:justify-between {
     @media (width >= 40rem) {
       justify-content: space-between;
+    }
+  }
+  .sm\:justify-end {
+    @media (width >= 40rem) {
+      justify-content: flex-end;
     }
   }
   .sm\:p-8 {

--- a/site/internal/pages/demo/components/landing.templ
+++ b/site/internal/pages/demo/components/landing.templ
@@ -59,7 +59,8 @@ templ LandingPage() {
 			// Doing this here (not in Alpine x-init) keeps the homepage's theme in
 			// lock-step with the rest of the site and avoids a flash of the default
 			// theme on navigation. Shares localStorage key 'theme' / 'darkMode'.
-			@templ.Raw(`<script>(function(){try{var t=localStorage.getItem('theme')||'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=localStorage.getItem('darkMode');var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`)
+			@storageConsentScript()
+			@templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!c||c.allowed();var t=canStore?(localStorage.getItem('theme')||'goshtoso'):'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`)
 			<link rel="stylesheet" href="/assets/styles.css"/>
 			<link rel="preconnect" href="https://fonts.googleapis.com"/>
 			<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
@@ -118,7 +119,7 @@ templ landingContent() {
 					<button
 						type="button"
 						data-theme-key={ c.Key }
-						@click="document.documentElement.setAttribute('data-theme', $el.dataset.themeKey); localStorage.setItem('theme', $el.dataset.themeKey)"
+						@click="document.documentElement.setAttribute('data-theme', $el.dataset.themeKey); if (!window.goshtosoStorageConsent || window.goshtosoStorageConsent.allowed()) localStorage.setItem('theme', $el.dataset.themeKey)"
 						class="px-4 py-1.5 rounded-radius border border-outline dark:border-outline-dark text-sm text-on-surface dark:text-on-surface-dark hover:border-primary dark:hover:border-primary-dark hover:text-primary dark:hover:text-primary-dark transition-colors"
 					>
 						{ c.Label }
@@ -213,40 +214,46 @@ templ landingContent() {
 	</div>
 }
 
-// cookieConsent renders the functional-cookie notice. It shows until the
-// visitor acknowledges the CURRENT notice version: stored value must equal the
-// version token ('v1'), so any prior/legacy value re-shows the updated copy.
-// Bump the token here AND in layout.templ's banner whenever the copy materially
-// changes. Keep both banners in lock-step.
+// cookieConsent renders the browser-storage notice. Keep in lock-step with the
+// demo layout's banner.
 templ cookieConsent() {
 	<div
-		x-data="{ show: localStorage.getItem('cookieConsent') !== 'v1' }"
+		x-data="{ show: !window.goshtosoStorageConsent || window.goshtosoStorageConsent.shouldShow(), allow() { window.goshtosoStorageConsent.allow(); this.show = false }, deny() { window.goshtosoStorageConsent.deny(); this.show = false } }"
 		x-show="show"
 		x-cloak
 		x-transition
-		class="fixed bottom-4 right-4 z-50 flex max-w-sm flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark"
+		class="fixed bottom-4 left-4 right-4 sm:left-auto z-50 flex max-w-none sm:max-w-md flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark"
 		role="dialog"
 		aria-modal="false"
 		aria-labelledby="landing-cookie-title"
 	>
 		<div class="flex items-center gap-2 border-b border-outline px-4 py-3 dark:border-outline-dark">
-			<span class="text-2xl" aria-hidden="true">🍪</span>
-			<h3 id="landing-cookie-title" class="font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">Functional cookies</h3>
+			<h3 id="landing-cookie-title" class="font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">Browser storage</h3>
 		</div>
 		<p class="px-4 text-sm text-on-surface dark:text-on-surface-dark">
-			Goshtoso stores a few <strong>functional</strong> values in your browser — your theme
-			preference and the example apps' own state (e.g. the Todo demo). They are strictly
-			necessary to make those features work; there is no tracking, no analytics, and no
-			third&#8209;party cookies. Clearing your browser storage resets them. Details in our
+			Goshtoso can store preferences and demo state in your browser. Some examples use
+			cookies and IndexedDB to persist local demo state. There is no analytics, advertising,
+			or third-party tracking. You can use the site without storage, but preferences and
+			some examples will reset or stop persisting. Details in our
 			<a href="/privacy" class="text-primary dark:text-primary-dark underline underline-offset-2">Privacy Policy</a>.
 		</p>
-		<div class="flex justify-end gap-2 px-4 pb-4">
+		<div class="flex flex-col-reverse gap-2 px-4 pb-4 sm:flex-row sm:justify-end">
 			<button
-				@click="localStorage.setItem('cookieConsent', 'v1'); show = false"
+				@click="deny()"
+				class="px-3 py-1.5 text-xs font-medium rounded-radius border border-outline text-on-surface dark:border-outline-dark dark:text-on-surface-dark hover:border-primary dark:hover:border-primary-dark hover:text-primary dark:hover:text-primary-dark transition-colors"
+			>
+				Use without storage
+			</button>
+			<button
+				@click="allow()"
 				class="px-3 py-1.5 text-xs font-medium rounded-radius bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark hover:opacity-90 transition-opacity"
 			>
-				Got it
+				Allow browser storage
 			</button>
 		</div>
 	</div>
+}
+
+templ storageConsentScript() {
+	@templ.Raw(`<script>(function(){if(window.goshtosoStorageConsent)return;var pref='gt_storage';var maxAge=15552000;var demoCookies=['gt_todo','gt_profile','gt_chat'];var localKeys=['theme','darkMode','themeOverrides','themeTitleFont','themeBodyFont','themeRadius','themeCssMode','themeCssFilter','cookieConsent'];function cookieValue(name){var parts=document.cookie?document.cookie.split('; '):[];for(var i=0;i<parts.length;i++){var p=parts[i];var eq=p.indexOf('=');var key=eq>=0?p.slice(0,eq):p;if(key===name)return eq>=0?decodeURIComponent(p.slice(eq+1)):'';}return '';}function setCookie(name,value,age){document.cookie=name+'='+encodeURIComponent(value)+'; Path=/; Max-Age='+age+'; SameSite=Lax';}function expireCookie(name){setCookie(name,'',0);}function clearLocalStorage(){try{localKeys.forEach(function(key){localStorage.removeItem(key);});}catch(e){}}function clearIndexedDB(){try{if(window.indexedDB&&indexedDB.deleteDatabase)indexedDB.deleteDatabase('gt_profile');}catch(e){}}window.goshtosoStorageConsent={shouldShow:function(){var v=cookieValue(pref);return v!=='allowed'&&v!=='denied';},allowed:function(){return cookieValue(pref)!=='denied';},allow:function(){setCookie(pref,'allowed',maxAge);try{localStorage.setItem('cookieConsent','v2');}catch(e){}},deny:function(){setCookie(pref,'denied',maxAge);demoCookies.forEach(expireCookie);clearLocalStorage();clearIndexedDB();}};if(cookieValue(pref)==='denied'){clearLocalStorage();clearIndexedDB();}})();</script>`)
 }

--- a/site/internal/pages/demo/components/landing_templ.go
+++ b/site/internal/pages/demo/components/landing_templ.go
@@ -75,7 +75,11 @@ func LandingPage() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ.Raw(`<script>(function(){try{var t=localStorage.getItem('theme')||'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=localStorage.getItem('darkMode');var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = storageConsentScript().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!c||c.allowed();var t=canStore?(localStorage.getItem('theme')||'goshtoso'):'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -86,7 +90,7 @@ func LandingPage() templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineJSURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 67, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 68, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var2)
 		if templ_7745c5c3_Err != nil {
@@ -99,7 +103,7 @@ func LandingPage() templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.HTMXURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 68, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 69, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 		if templ_7745c5c3_Err != nil {
@@ -158,20 +162,20 @@ func landingContent() templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(c.Key)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 120, Col: 28}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 121, Col: 28}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" @click=\"document.documentElement.setAttribute('data-theme', $el.dataset.themeKey); localStorage.setItem('theme', $el.dataset.themeKey)\" class=\"px-4 py-1.5 rounded-radius border border-outline dark:border-outline-dark text-sm text-on-surface dark:text-on-surface-dark hover:border-primary dark:hover:border-primary-dark hover:text-primary dark:hover:text-primary-dark transition-colors\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" @click=\"document.documentElement.setAttribute('data-theme', $el.dataset.themeKey); if (!window.goshtosoStorageConsent || window.goshtosoStorageConsent.allowed()) localStorage.setItem('theme', $el.dataset.themeKey)\" class=\"px-4 py-1.5 rounded-radius border border-outline dark:border-outline-dark text-sm text-on-surface dark:text-on-surface-dark hover:border-primary dark:hover:border-primary-dark hover:text-primary dark:hover:text-primary-dark transition-colors\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(c.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 124, Col: 15}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 125, Col: 15}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -272,7 +276,7 @@ func landingContent() templ.Component {
 			var templ_7745c5c3_Var9 templ.SafeURL
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(a.URL))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 165, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 166, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -285,7 +289,7 @@ func landingContent() templ.Component {
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(a.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 167, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 168, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -298,7 +302,7 @@ func landingContent() templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(a.Desc)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 170, Col: 15}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 171, Col: 15}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -317,11 +321,8 @@ func landingContent() templ.Component {
 	})
 }
 
-// cookieConsent renders the functional-cookie notice. It shows until the
-// visitor acknowledges the CURRENT notice version: stored value must equal the
-// version token ('v1'), so any prior/legacy value re-shows the updated copy.
-// Bump the token here AND in layout.templ's banner whenever the copy materially
-// changes. Keep both banners in lock-step.
+// cookieConsent renders the browser-storage notice. Keep in lock-step with the
+// demo layout's banner.
 func cookieConsent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -343,7 +344,36 @@ func cookieConsent() templ.Component {
 			templ_7745c5c3_Var12 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div x-data=\"{ show: localStorage.getItem('cookieConsent') !== 'v1' }\" x-show=\"show\" x-cloak x-transition class=\"fixed bottom-4 right-4 z-50 flex max-w-sm flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark\" role=\"dialog\" aria-modal=\"false\" aria-labelledby=\"landing-cookie-title\"><div class=\"flex items-center gap-2 border-b border-outline px-4 py-3 dark:border-outline-dark\"><span class=\"text-2xl\" aria-hidden=\"true\">🍪</span><h3 id=\"landing-cookie-title\" class=\"font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Functional cookies</h3></div><p class=\"px-4 text-sm text-on-surface dark:text-on-surface-dark\">Goshtoso stores a few <strong>functional</strong> values in your browser — your theme preference and the example apps' own state (e.g. the Todo demo). They are strictly necessary to make those features work; there is no tracking, no analytics, and no third&#8209;party cookies. Clearing your browser storage resets them. Details in our <a href=\"/privacy\" class=\"text-primary dark:text-primary-dark underline underline-offset-2\">Privacy Policy</a>.</p><div class=\"flex justify-end gap-2 px-4 pb-4\"><button @click=\"localStorage.setItem('cookieConsent', 'v1'); show = false\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark hover:opacity-90 transition-opacity\">Got it</button></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div x-data=\"{ show: !window.goshtosoStorageConsent || window.goshtosoStorageConsent.shouldShow(), allow() { window.goshtosoStorageConsent.allow(); this.show = false }, deny() { window.goshtosoStorageConsent.deny(); this.show = false } }\" x-show=\"show\" x-cloak x-transition class=\"fixed bottom-4 left-4 right-4 sm:left-auto z-50 flex max-w-none sm:max-w-md flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark\" role=\"dialog\" aria-modal=\"false\" aria-labelledby=\"landing-cookie-title\"><div class=\"flex items-center gap-2 border-b border-outline px-4 py-3 dark:border-outline-dark\"><h3 id=\"landing-cookie-title\" class=\"font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Browser storage</h3></div><p class=\"px-4 text-sm text-on-surface dark:text-on-surface-dark\">Goshtoso can store preferences and demo state in your browser. Some examples use cookies and IndexedDB to persist local demo state. There is no analytics, advertising, or third-party tracking. You can use the site without storage, but preferences and some examples will reset or stop persisting. Details in our <a href=\"/privacy\" class=\"text-primary dark:text-primary-dark underline underline-offset-2\">Privacy Policy</a>.</p><div class=\"flex flex-col-reverse gap-2 px-4 pb-4 sm:flex-row sm:justify-end\"><button @click=\"deny()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius border border-outline text-on-surface dark:border-outline-dark dark:text-on-surface-dark hover:border-primary dark:hover:border-primary-dark hover:text-primary dark:hover:text-primary-dark transition-colors\">Use without storage</button> <button @click=\"allow()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark hover:opacity-90 transition-opacity\">Allow browser storage</button></div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func storageConsentScript() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templ.Raw(`<script>(function(){if(window.goshtosoStorageConsent)return;var pref='gt_storage';var maxAge=15552000;var demoCookies=['gt_todo','gt_profile','gt_chat'];var localKeys=['theme','darkMode','themeOverrides','themeTitleFont','themeBodyFont','themeRadius','themeCssMode','themeCssFilter','cookieConsent'];function cookieValue(name){var parts=document.cookie?document.cookie.split('; '):[];for(var i=0;i<parts.length;i++){var p=parts[i];var eq=p.indexOf('=');var key=eq>=0?p.slice(0,eq):p;if(key===name)return eq>=0?decodeURIComponent(p.slice(eq+1)):'';}return '';}function setCookie(name,value,age){document.cookie=name+'='+encodeURIComponent(value)+'; Path=/; Max-Age='+age+'; SameSite=Lax';}function expireCookie(name){setCookie(name,'',0);}function clearLocalStorage(){try{localKeys.forEach(function(key){localStorage.removeItem(key);});}catch(e){}}function clearIndexedDB(){try{if(window.indexedDB&&indexedDB.deleteDatabase)indexedDB.deleteDatabase('gt_profile');}catch(e){}}window.goshtosoStorageConsent={shouldShow:function(){var v=cookieValue(pref);return v!=='allowed'&&v!=='denied';},allowed:function(){return cookieValue(pref)!=='denied';},allow:function(){setCookie(pref,'allowed',maxAge);try{localStorage.setItem('cookieConsent','v2');}catch(e){}},deny:function(){setCookie(pref,'denied',maxAge);demoCookies.forEach(expireCookie);clearLocalStorage();clearIndexedDB();}};if(cookieValue(pref)==='denied'){clearLocalStorage();clearIndexedDB();}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/pages/demo/components/privacy.templ
+++ b/site/internal/pages/demo/components/privacy.templ
@@ -19,18 +19,19 @@ templ privacyContent() {
 
 		@privacySection("Information we collect", "We do not collect personal information. There is no account, no newsletter, and no server-side tracking of visitors. The site does not run Google Analytics or any other analytics service.")
 
-		@privacySection("Local storage & cookies", "The only data stored is kept locally in your browser and never leaves your device:")
+		@privacySection("Browser storage", "The only data stored is kept locally in your browser and never leaves your device:")
 		<ul class="-mt-6 space-y-2 text-on-surface dark:text-on-surface-dark">
-			<li class="flex gap-2"><span class="text-primary dark:text-primary-dark font-bold">•</span> <span><code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">theme</code> / dark-mode preference — remembers your selected theme.</span></li>
-			<li class="flex gap-2"><span class="text-primary dark:text-primary-dark font-bold">•</span> <span><code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">cookieConsent</code> — remembers that you dismissed the notice.</span></li>
-			<li class="flex gap-2"><span class="text-primary dark:text-primary-dark font-bold">•</span> <span>Example-app state (e.g. the Todo demo's <code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">gt_todo</code> cookie) — a self-contained cookie so the demo survives a refresh. Read and written only by your browser and the demo's own handlers; never shared.</span></li>
+			<li class="flex gap-2"><span class="text-primary dark:text-primary-dark font-bold">•</span> <span><code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">gt_storage</code> — remembers whether you allowed browser storage or chose Use without storage.</span></li>
+			<li class="flex gap-2"><span class="text-primary dark:text-primary-dark font-bold">•</span> <span><code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">localStorage</code> values such as theme and dark-mode preferences — remember your selected appearance when storage is allowed.</span></li>
+			<li class="flex gap-2"><span class="text-primary dark:text-primary-dark font-bold">•</span> <span>Example-app cookies such as <code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">gt_todo</code>, <code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">gt_profile</code>, and <code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">gt_chat</code> — self-contained demo state so examples can survive a refresh.</span></li>
+			<li class="flex gap-2"><span class="text-primary dark:text-primary-dark font-bold">•</span> <span><code class="bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono">IndexedDB</code> in the Profile example — stores avatar and cover image files locally on your device.</span></li>
 		</ul>
 
 		@privacySection("Third-party assets", "Bundled libraries (Alpine.js, htmx, Tailwind CSS) and icon sets (Heroicons, Bootstrap Icons) are served locally from this site, not from a CDN, so no third party sees your requests. Each retains its own license — see the Attributions and License pages.")
 
 		@privacySection("Children's privacy", "This site is a developer documentation tool and is not directed at children under 13. We do not knowingly collect any data from anyone.")
 
-		@privacySection("Your choices", "Because nothing is stored server-side, you are fully in control. Clearing your browser's local storage and cookies for this site removes every value listed above. The site keeps working — you'll just see defaults again.")
+		@privacySection("Your choices", "Choose Use without storage to clear Goshtoso's local demo storage and stop example cookies from being set. The site keeps working, but preferences and some examples reset or stop persisting.")
 
 		<div class="pb-8">
 			<h2 data-toc-heading="Contact" class="text-xl font-bold font-title text-on-surface-strong dark:text-on-surface-dark-strong mb-3">Contact</h2>

--- a/site/internal/pages/demo/components/privacy_templ.go
+++ b/site/internal/pages/demo/components/privacy_templ.go
@@ -68,11 +68,11 @@ func privacyContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = privacySection("Local storage & cookies", "The only data stored is kept locally in your browser and never leaves your device:").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = privacySection("Browser storage", "The only data stored is kept locally in your browser and never leaves your device:").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<ul class=\"-mt-6 space-y-2 text-on-surface dark:text-on-surface-dark\"><li class=\"flex gap-2\"><span class=\"text-primary dark:text-primary-dark font-bold\">•</span> <span><code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">theme</code> / dark-mode preference — remembers your selected theme.</span></li><li class=\"flex gap-2\"><span class=\"text-primary dark:text-primary-dark font-bold\">•</span> <span><code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">cookieConsent</code> — remembers that you dismissed the notice.</span></li><li class=\"flex gap-2\"><span class=\"text-primary dark:text-primary-dark font-bold\">•</span> <span>Example-app state (e.g. the Todo demo's <code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">gt_todo</code> cookie) — a self-contained cookie so the demo survives a refresh. Read and written only by your browser and the demo's own handlers; never shared.</span></li></ul>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<ul class=\"-mt-6 space-y-2 text-on-surface dark:text-on-surface-dark\"><li class=\"flex gap-2\"><span class=\"text-primary dark:text-primary-dark font-bold\">•</span> <span><code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">gt_storage</code> — remembers whether you allowed browser storage or chose Use without storage.</span></li><li class=\"flex gap-2\"><span class=\"text-primary dark:text-primary-dark font-bold\">•</span> <span><code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">localStorage</code> values such as theme and dark-mode preferences — remember your selected appearance when storage is allowed.</span></li><li class=\"flex gap-2\"><span class=\"text-primary dark:text-primary-dark font-bold\">•</span> <span>Example-app cookies such as <code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">gt_todo</code>, <code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">gt_profile</code>, and <code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">gt_chat</code> — self-contained demo state so examples can survive a refresh.</span></li><li class=\"flex gap-2\"><span class=\"text-primary dark:text-primary-dark font-bold\">•</span> <span><code class=\"bg-surface-alt dark:bg-surface-dark-alt px-1.5 py-0.5 rounded text-sm font-mono\">IndexedDB</code> in the Profile example — stores avatar and cover image files locally on your device.</span></li></ul>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -84,7 +84,7 @@ func privacyContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = privacySection("Your choices", "Because nothing is stored server-side, you are fully in control. Clearing your browser's local storage and cookies for this site removes every value listed above. The site keeps working — you'll just see defaults again.").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = privacySection("Your choices", "Choose Use without storage to clear Goshtoso's local demo storage and stop example cookies from being set. The site keeps working, but preferences and some examples reset or stop persisting.").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -124,7 +124,7 @@ func privacySection(title, body string) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/privacy.templ`, Line: 47, Col: 30}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/privacy.templ`, Line: 48, Col: 30}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
 		if templ_7745c5c3_Err != nil {
@@ -137,7 +137,7 @@ func privacySection(title, body string) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/privacy.templ`, Line: 47, Col: 138}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/privacy.templ`, Line: 48, Col: 138}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -150,7 +150,7 @@ func privacySection(title, body string) templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(body)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/privacy.templ`, Line: 48, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/privacy.templ`, Line: 49, Col: 61}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {

--- a/site/internal/pages/demo/layout.templ
+++ b/site/internal/pages/demo/layout.templ
@@ -9,14 +9,18 @@ import (
 templ Layout(title string, activeComponent string, content templ.Component) {
 	<!DOCTYPE html>
 	<html lang="en" x-data="{
-		theme: localStorage.getItem('theme') || 'goshtoso',
+		theme: (window.goshtosoStorageConsent && !window.goshtosoStorageConsent.allowed()) ? 'goshtoso' : (localStorage.getItem('theme') || 'goshtoso'),
 		sidebarOpen: false,
 		showThemeDropdown: false,
 		setTheme(name) { this.theme = name; document.documentElement.setAttribute('data-theme', name); }
 	}" 
 	x-init="
 		$watch('theme', value => {
-			localStorage.setItem('theme', value);
+			if (!window.goshtosoStorageConsent || window.goshtosoStorageConsent.allowed()) {
+				localStorage.setItem('theme', value);
+			} else {
+				localStorage.removeItem('theme');
+			}
 			document.documentElement.setAttribute('data-theme', value);
 		});
 	">
@@ -29,7 +33,8 @@ templ Layout(title string, activeComponent string, content templ.Component) {
 			<link rel="shortcut icon" href="/favicon.ico"/>
 			<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png"/>
 			<link rel="manifest" href="/site.webmanifest"/>
-			@templ.Raw(`<script>(function(){try{var t=localStorage.getItem('theme')||'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=localStorage.getItem('darkMode');var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`)
+			@storageConsentScript()
+			@templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!c||c.allowed();var t=canStore?(localStorage.getItem('theme')||'goshtoso'):'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`)
 			<link rel="stylesheet" href="/assets/styles.css"/>
 			<link rel="preconnect" href="https://fonts.googleapis.com"/>
 			<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
@@ -257,37 +262,41 @@ templ Layout(title string, activeComponent string, content templ.Component) {
 					</div>
 				</aside>
 			</div>
-			<!-- Cookie Consent — functional-cookie notice. Shows until the visitor
-			     acknowledges the CURRENT version ('v1'); any prior/legacy stored value
-			     re-shows the updated copy. Bump 'v1' here AND in landing.templ's
-			     cookieConsent() in lock-step whenever the copy materially changes. -->
+			<!-- Browser storage notice. Shows until the visitor chooses allowed or denied
+			     storage via the gt_storage preference cookie. Keep in lock-step with
+			     landing.templ's cookieConsent(). -->
 			<div
-				x-data="{ show: localStorage.getItem('cookieConsent') !== 'v1' }"
+				x-data="{ show: !window.goshtosoStorageConsent || window.goshtosoStorageConsent.shouldShow(), allow() { window.goshtosoStorageConsent.allow(); this.show = false }, deny() { window.goshtosoStorageConsent.deny(); this.show = false } }"
 				x-show="show"
 				x-cloak
 				x-transition
-				class="fixed bottom-4 left-4 right-4 sm:left-auto z-50 flex max-w-none sm:max-w-sm flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark"
+				class="fixed bottom-4 left-4 right-4 sm:left-auto z-50 flex max-w-none sm:max-w-md flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark"
 				role="dialog"
 				aria-modal="false"
 				aria-labelledby="cookie-banner-title"
 			>
 				<div class="flex items-center gap-2 border-b border-outline px-4 py-3 dark:border-outline-dark">
-					<span class="text-2xl" aria-hidden="true">🍪</span>
-					<h3 id="cookie-banner-title" class="font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">Functional cookies</h3>
+					<h3 id="cookie-banner-title" class="font-semibold text-on-surface-strong dark:text-on-surface-dark-strong">Browser storage</h3>
 				</div>
 				<p class="px-4 text-sm text-on-surface dark:text-on-surface-dark">
-					Goshtoso stores a few <strong>functional</strong> values in your browser — your theme
-					preference and the example apps' own state (e.g. the Todo demo). They are strictly
-					necessary to make those features work; there is no tracking, no analytics, and no
-					third&#8209;party cookies. Clearing your browser storage resets them. Details in our
+					Goshtoso can store preferences and demo state in your browser. Some examples use
+					cookies and IndexedDB to persist local demo state. There is no analytics, advertising,
+					or third-party tracking. You can use the site without storage, but preferences and
+					some examples will reset or stop persisting. Details in our
 					<a href="/privacy" hx-get="/privacy" hx-target="#main-content" hx-swap="innerHTML" hx-push-url="true" @click="show = false" class="text-primary dark:text-primary-dark underline underline-offset-2">Privacy Policy</a>.
 				</p>
-				<div class="flex justify-end gap-2 px-4 pb-4">
+				<div class="flex flex-col-reverse gap-2 px-4 pb-4 sm:flex-row sm:justify-end">
 					<button
-						@click="localStorage.setItem('cookieConsent', 'v1'); show = false"
+						@click="deny()"
+						class="px-3 py-1.5 text-xs font-medium rounded-radius border border-outline text-on-surface dark:border-outline-dark dark:text-on-surface-dark hover:border-primary dark:hover:border-primary-dark hover:text-primary dark:hover:text-primary-dark transition-colors"
+					>
+						Use without storage
+					</button>
+					<button
+						@click="allow()"
 						class="px-3 py-1.5 text-xs font-medium rounded-radius bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark hover:opacity-90 transition-opacity"
 					>
-						Got it
+						Allow browser storage
 					</button>
 				</div>
 			</div>
@@ -612,6 +621,10 @@ templ componentNavFooter(activeComponent string) {
 			}
 		</div>
 	}
+}
+
+templ storageConsentScript() {
+	@templ.Raw(`<script>(function(){if(window.goshtosoStorageConsent)return;var pref='gt_storage';var maxAge=15552000;var demoCookies=['gt_todo','gt_profile','gt_chat'];var localKeys=['theme','darkMode','themeOverrides','themeTitleFont','themeBodyFont','themeRadius','themeCssMode','themeCssFilter','cookieConsent'];function cookieValue(name){var parts=document.cookie?document.cookie.split('; '):[];for(var i=0;i<parts.length;i++){var p=parts[i];var eq=p.indexOf('=');var key=eq>=0?p.slice(0,eq):p;if(key===name)return eq>=0?decodeURIComponent(p.slice(eq+1)):'';}return '';}function setCookie(name,value,age){document.cookie=name+'='+encodeURIComponent(value)+'; Path=/; Max-Age='+age+'; SameSite=Lax';}function expireCookie(name){setCookie(name,'',0);}function clearLocalStorage(){try{localKeys.forEach(function(key){localStorage.removeItem(key);});}catch(e){}}function clearIndexedDB(){try{if(window.indexedDB&&indexedDB.deleteDatabase)indexedDB.deleteDatabase('gt_profile');}catch(e){}}window.goshtosoStorageConsent={shouldShow:function(){var v=cookieValue(pref);return v!=='allowed'&&v!=='denied';},allowed:function(){return cookieValue(pref)!=='denied';},allow:function(){setCookie(pref,'allowed',maxAge);try{localStorage.setItem('cookieConsent','v2');}catch(e){}},deny:function(){setCookie(pref,'denied',maxAge);demoCookies.forEach(expireCookie);clearLocalStorage();clearIndexedDB();}};if(cookieValue(pref)==='denied'){clearLocalStorage();clearIndexedDB();}})();</script>`)
 }
 
 // siteFooter renders the global footer shown beneath every page's content

--- a/site/internal/pages/demo/layout_templ.go
+++ b/site/internal/pages/demo/layout_templ.go
@@ -35,14 +35,14 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<!doctype html><html lang=\"en\" x-data=\"{\n\t\ttheme: localStorage.getItem('theme') || 'goshtoso',\n\t\tsidebarOpen: false,\n\t\tshowThemeDropdown: false,\n\t\tsetTheme(name) { this.theme = name; document.documentElement.setAttribute('data-theme', name); }\n\t}\" x-init=\"\n\t\t$watch('theme', value => {\n\t\t\tlocalStorage.setItem('theme', value);\n\t\t\tdocument.documentElement.setAttribute('data-theme', value);\n\t\t});\n\t\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<!doctype html><html lang=\"en\" x-data=\"{\n\t\ttheme: (window.goshtosoStorageConsent && !window.goshtosoStorageConsent.allowed()) ? 'goshtoso' : (localStorage.getItem('theme') || 'goshtoso'),\n\t\tsidebarOpen: false,\n\t\tshowThemeDropdown: false,\n\t\tsetTheme(name) { this.theme = name; document.documentElement.setAttribute('data-theme', name); }\n\t}\" x-init=\"\n\t\t$watch('theme', value => {\n\t\t\tif (!window.goshtosoStorageConsent || window.goshtosoStorageConsent.allowed()) {\n\t\t\t\tlocalStorage.setItem('theme', value);\n\t\t\t} else {\n\t\t\t\tlocalStorage.removeItem('theme');\n\t\t\t}\n\t\t\tdocument.documentElement.setAttribute('data-theme', value);\n\t\t});\n\t\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 26, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 30, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -52,7 +52,11 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ.Raw(`<script>(function(){try{var t=localStorage.getItem('theme')||'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=localStorage.getItem('darkMode');var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = storageConsentScript().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!c||c.allowed();var t=canStore?(localStorage.getItem('theme')||'goshtoso'):'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -63,7 +67,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineFocusURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 38, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 43, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 		if templ_7745c5c3_Err != nil {
@@ -76,7 +80,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineCollapseURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 39, Col: 47}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 44, Col: 47}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
 		if templ_7745c5c3_Err != nil {
@@ -89,7 +93,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineJSURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 40, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 45, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
 		if templ_7745c5c3_Err != nil {
@@ -102,7 +106,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.HTMXURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 41, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 46, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 		if templ_7745c5c3_Err != nil {
@@ -115,7 +119,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.HTMXExtWSURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 42, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 47, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var7)
 		if templ_7745c5c3_Err != nil {
@@ -128,7 +132,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.HTMXExtSSEURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 43, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 48, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
 		if templ_7745c5c3_Err != nil {
@@ -146,7 +150,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(t.Key)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 157, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 162, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
 			if templ_7745c5c3_Err != nil {
@@ -159,7 +163,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(t.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 162, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 167, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -221,7 +225,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div></main><!-- Right rail: \"On this page\" section nav, built from [data-toc-heading]. --><aside id=\"toc-rail\" data-boot-anim=\"main\" class=\"hidden xl:block w-60 shrink-0 overflow-y-auto border-l border-outline dark:border-outline-dark\"><div class=\"sticky top-0 px-6 py-8\"><p class=\"mb-3 text-xs font-semibold uppercase tracking-wide text-on-surface-muted dark:text-on-surface-dark-muted\">On this page</p><nav id=\"toc-list\" aria-label=\"On this page\" class=\"flex flex-col border-l border-outline dark:border-outline-dark\"></nav></div></aside></div><!-- Cookie Consent — functional-cookie notice. Shows until the visitor\n\t\t\t     acknowledges the CURRENT version ('v1'); any prior/legacy stored value\n\t\t\t     re-shows the updated copy. Bump 'v1' here AND in landing.templ's\n\t\t\t     cookieConsent() in lock-step whenever the copy materially changes. --><div x-data=\"{ show: localStorage.getItem('cookieConsent') !== 'v1' }\" x-show=\"show\" x-cloak x-transition class=\"fixed bottom-4 left-4 right-4 sm:left-auto z-50 flex max-w-none sm:max-w-sm flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark\" role=\"dialog\" aria-modal=\"false\" aria-labelledby=\"cookie-banner-title\"><div class=\"flex items-center gap-2 border-b border-outline px-4 py-3 dark:border-outline-dark\"><span class=\"text-2xl\" aria-hidden=\"true\">🍪</span><h3 id=\"cookie-banner-title\" class=\"font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Functional cookies</h3></div><p class=\"px-4 text-sm text-on-surface dark:text-on-surface-dark\">Goshtoso stores a few <strong>functional</strong> values in your browser — your theme preference and the example apps' own state (e.g. the Todo demo). They are strictly necessary to make those features work; there is no tracking, no analytics, and no third&#8209;party cookies. Clearing your browser storage resets them. Details in our <a href=\"/privacy\" hx-get=\"/privacy\" hx-target=\"#main-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" @click=\"show = false\" class=\"text-primary dark:text-primary-dark underline underline-offset-2\">Privacy Policy</a>.</p><div class=\"flex justify-end gap-2 px-4 pb-4\"><button @click=\"localStorage.setItem('cookieConsent', 'v1'); show = false\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark hover:opacity-90 transition-opacity\">Got it</button></div></div><!-- Right-rail \"On this page\" TOC: built from #main-content [data-toc-heading].\n\t\t\t     Rebuilt on every main-content HTMX swap via window.buildTOC (see head script). --><script>\n\t\t\t\t(function () {\n\t\t\t\t\tvar spy = null;\n\t\t\t\t\tfunction clearActive(nav) {\n\t\t\t\t\t\tnav.querySelectorAll('[data-toc-link]').forEach(function (a) {\n\t\t\t\t\t\t\ta.classList.remove('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t\t\ta.classList.add('border-transparent');\n\t\t\t\t\t\t});\n\t\t\t\t\t}\n\t\t\t\t\tfunction setActive(nav, id) {\n\t\t\t\t\t\tvar a = nav.querySelector('[data-toc-link=\"' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '\"]');\n\t\t\t\t\t\tif (!a) return;\n\t\t\t\t\t\tclearActive(nav);\n\t\t\t\t\t\ta.classList.remove('border-transparent');\n\t\t\t\t\t\ta.classList.add('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t}\n\t\t\t\t\twindow.buildTOC = function () {\n\t\t\t\t\t\tvar rail = document.getElementById('toc-rail');\n\t\t\t\t\t\tvar nav = document.getElementById('toc-list');\n\t\t\t\t\t\tvar main = document.getElementById('main-content');\n\t\t\t\t\t\tif (!rail || !nav || !main) return;\n\t\t\t\t\t\tif (spy) { spy.disconnect(); spy = null; }\n\t\t\t\t\t\tvar heads = Array.prototype.slice.call(main.querySelectorAll('[data-toc-heading]'));\n\t\t\t\t\t\tnav.innerHTML = '';\n\t\t\t\t\t\t// One heading (just the page title) isn't worth a rail — hide it.\n\t\t\t\t\t\tif (heads.length < 2) { rail.style.display = 'none'; return; }\n\t\t\t\t\t\trail.style.display = '';\n\t\t\t\t\t\theads.forEach(function (h) {\n\t\t\t\t\t\t\tif (!h.id) return;\n\t\t\t\t\t\t\tvar a = document.createElement('a');\n\t\t\t\t\t\t\ta.href = '#' + h.id;\n\t\t\t\t\t\t\ta.textContent = (h.textContent || '').trim();\n\t\t\t\t\t\t\ta.setAttribute('data-toc-link', h.id);\n\t\t\t\t\t\t\ta.className = 'block border-l border-transparent py-1.5 pl-4 -ml-px text-sm text-on-surface-muted transition-colors hover:text-on-surface-strong dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-strong';\n\t\t\t\t\t\t\ta.addEventListener('click', function (ev) {\n\t\t\t\t\t\t\t\tev.preventDefault();\n\t\t\t\t\t\t\t\th.scrollIntoView({ behavior: 'smooth', block: 'start' });\n\t\t\t\t\t\t\t\thistory.replaceState(null, '', '#' + h.id);\n\t\t\t\t\t\t\t\tsetActive(nav, h.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t\tnav.appendChild(a);\n\t\t\t\t\t\t});\n\t\t\t\t\t\t// Scroll-spy: main is the scroll container, so it's the observer root.\n\t\t\t\t\t\tspy = new IntersectionObserver(function (entries) {\n\t\t\t\t\t\t\tentries.forEach(function (en) {\n\t\t\t\t\t\t\t\tif (en.isIntersecting) setActive(nav, en.target.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t}, { root: main, rootMargin: '0px 0px -75% 0px', threshold: 0 });\n\t\t\t\t\t\theads.forEach(function (h) { if (h.id) spy.observe(h); });\n\t\t\t\t\t\tsetActive(nav, heads[0].id);\n\t\t\t\t\t};\n\t\t\t\t\tif (document.readyState === 'loading') {\n\t\t\t\t\t\tdocument.addEventListener('DOMContentLoaded', window.buildTOC);\n\t\t\t\t\t} else {\n\t\t\t\t\t\twindow.buildTOC();\n\t\t\t\t\t}\n\t\t\t\t})();\n\t\t\t</script></body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div></main><!-- Right rail: \"On this page\" section nav, built from [data-toc-heading]. --><aside id=\"toc-rail\" data-boot-anim=\"main\" class=\"hidden xl:block w-60 shrink-0 overflow-y-auto border-l border-outline dark:border-outline-dark\"><div class=\"sticky top-0 px-6 py-8\"><p class=\"mb-3 text-xs font-semibold uppercase tracking-wide text-on-surface-muted dark:text-on-surface-dark-muted\">On this page</p><nav id=\"toc-list\" aria-label=\"On this page\" class=\"flex flex-col border-l border-outline dark:border-outline-dark\"></nav></div></aside></div><!-- Browser storage notice. Shows until the visitor chooses allowed or denied\n\t\t\t     storage via the gt_storage preference cookie. Keep in lock-step with\n\t\t\t     landing.templ's cookieConsent(). --><div x-data=\"{ show: !window.goshtosoStorageConsent || window.goshtosoStorageConsent.shouldShow(), allow() { window.goshtosoStorageConsent.allow(); this.show = false }, deny() { window.goshtosoStorageConsent.deny(); this.show = false } }\" x-show=\"show\" x-cloak x-transition class=\"fixed bottom-4 left-4 right-4 sm:left-auto z-50 flex max-w-none sm:max-w-md flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark\" role=\"dialog\" aria-modal=\"false\" aria-labelledby=\"cookie-banner-title\"><div class=\"flex items-center gap-2 border-b border-outline px-4 py-3 dark:border-outline-dark\"><h3 id=\"cookie-banner-title\" class=\"font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Browser storage</h3></div><p class=\"px-4 text-sm text-on-surface dark:text-on-surface-dark\">Goshtoso can store preferences and demo state in your browser. Some examples use cookies and IndexedDB to persist local demo state. There is no analytics, advertising, or third-party tracking. You can use the site without storage, but preferences and some examples will reset or stop persisting. Details in our <a href=\"/privacy\" hx-get=\"/privacy\" hx-target=\"#main-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" @click=\"show = false\" class=\"text-primary dark:text-primary-dark underline underline-offset-2\">Privacy Policy</a>.</p><div class=\"flex flex-col-reverse gap-2 px-4 pb-4 sm:flex-row sm:justify-end\"><button @click=\"deny()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius border border-outline text-on-surface dark:border-outline-dark dark:text-on-surface-dark hover:border-primary dark:hover:border-primary-dark hover:text-primary dark:hover:text-primary-dark transition-colors\">Use without storage</button> <button @click=\"allow()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark hover:opacity-90 transition-opacity\">Allow browser storage</button></div></div><!-- Right-rail \"On this page\" TOC: built from #main-content [data-toc-heading].\n\t\t\t     Rebuilt on every main-content HTMX swap via window.buildTOC (see head script). --><script>\n\t\t\t\t(function () {\n\t\t\t\t\tvar spy = null;\n\t\t\t\t\tfunction clearActive(nav) {\n\t\t\t\t\t\tnav.querySelectorAll('[data-toc-link]').forEach(function (a) {\n\t\t\t\t\t\t\ta.classList.remove('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t\t\ta.classList.add('border-transparent');\n\t\t\t\t\t\t});\n\t\t\t\t\t}\n\t\t\t\t\tfunction setActive(nav, id) {\n\t\t\t\t\t\tvar a = nav.querySelector('[data-toc-link=\"' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '\"]');\n\t\t\t\t\t\tif (!a) return;\n\t\t\t\t\t\tclearActive(nav);\n\t\t\t\t\t\ta.classList.remove('border-transparent');\n\t\t\t\t\t\ta.classList.add('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t}\n\t\t\t\t\twindow.buildTOC = function () {\n\t\t\t\t\t\tvar rail = document.getElementById('toc-rail');\n\t\t\t\t\t\tvar nav = document.getElementById('toc-list');\n\t\t\t\t\t\tvar main = document.getElementById('main-content');\n\t\t\t\t\t\tif (!rail || !nav || !main) return;\n\t\t\t\t\t\tif (spy) { spy.disconnect(); spy = null; }\n\t\t\t\t\t\tvar heads = Array.prototype.slice.call(main.querySelectorAll('[data-toc-heading]'));\n\t\t\t\t\t\tnav.innerHTML = '';\n\t\t\t\t\t\t// One heading (just the page title) isn't worth a rail — hide it.\n\t\t\t\t\t\tif (heads.length < 2) { rail.style.display = 'none'; return; }\n\t\t\t\t\t\trail.style.display = '';\n\t\t\t\t\t\theads.forEach(function (h) {\n\t\t\t\t\t\t\tif (!h.id) return;\n\t\t\t\t\t\t\tvar a = document.createElement('a');\n\t\t\t\t\t\t\ta.href = '#' + h.id;\n\t\t\t\t\t\t\ta.textContent = (h.textContent || '').trim();\n\t\t\t\t\t\t\ta.setAttribute('data-toc-link', h.id);\n\t\t\t\t\t\t\ta.className = 'block border-l border-transparent py-1.5 pl-4 -ml-px text-sm text-on-surface-muted transition-colors hover:text-on-surface-strong dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-strong';\n\t\t\t\t\t\t\ta.addEventListener('click', function (ev) {\n\t\t\t\t\t\t\t\tev.preventDefault();\n\t\t\t\t\t\t\t\th.scrollIntoView({ behavior: 'smooth', block: 'start' });\n\t\t\t\t\t\t\t\thistory.replaceState(null, '', '#' + h.id);\n\t\t\t\t\t\t\t\tsetActive(nav, h.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t\tnav.appendChild(a);\n\t\t\t\t\t\t});\n\t\t\t\t\t\t// Scroll-spy: main is the scroll container, so it's the observer root.\n\t\t\t\t\t\tspy = new IntersectionObserver(function (entries) {\n\t\t\t\t\t\t\tentries.forEach(function (en) {\n\t\t\t\t\t\t\t\tif (en.isIntersecting) setActive(nav, en.target.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t}, { root: main, rootMargin: '0px 0px -75% 0px', threshold: 0 });\n\t\t\t\t\t\theads.forEach(function (h) { if (h.id) spy.observe(h); });\n\t\t\t\t\t\tsetActive(nav, heads[0].id);\n\t\t\t\t\t};\n\t\t\t\t\tif (document.readyState === 'loading') {\n\t\t\t\t\t\tdocument.addEventListener('DOMContentLoaded', window.buildTOC);\n\t\t\t\t\t} else {\n\t\t\t\t\t\twindow.buildTOC();\n\t\t\t\t\t}\n\t\t\t\t})();\n\t\t\t</script></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -589,7 +593,7 @@ func componentNavFooter(activeComponent string) templ.Component {
 				var templ_7745c5c3_Var19 templ.SafeURL
 				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(prev.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 586, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 595, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 				if templ_7745c5c3_Err != nil {
@@ -610,7 +614,7 @@ func componentNavFooter(activeComponent string) templ.Component {
 				var templ_7745c5c3_Var20 string
 				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(prev.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 593, Col: 23}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 602, Col: 23}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 				if templ_7745c5c3_Err != nil {
@@ -635,7 +639,7 @@ func componentNavFooter(activeComponent string) templ.Component {
 				var templ_7745c5c3_Var21 templ.SafeURL
 				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(next.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 601, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 610, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 				if templ_7745c5c3_Err != nil {
@@ -656,7 +660,7 @@ func componentNavFooter(activeComponent string) templ.Component {
 				var templ_7745c5c3_Var22 string
 				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(next.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 605, Col: 23}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 614, Col: 23}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 				if templ_7745c5c3_Err != nil {
@@ -681,6 +685,35 @@ func componentNavFooter(activeComponent string) templ.Component {
 	})
 }
 
+func storageConsentScript() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var23 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var23 == nil {
+			templ_7745c5c3_Var23 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templ.Raw(`<script>(function(){if(window.goshtosoStorageConsent)return;var pref='gt_storage';var maxAge=15552000;var demoCookies=['gt_todo','gt_profile','gt_chat'];var localKeys=['theme','darkMode','themeOverrides','themeTitleFont','themeBodyFont','themeRadius','themeCssMode','themeCssFilter','cookieConsent'];function cookieValue(name){var parts=document.cookie?document.cookie.split('; '):[];for(var i=0;i<parts.length;i++){var p=parts[i];var eq=p.indexOf('=');var key=eq>=0?p.slice(0,eq):p;if(key===name)return eq>=0?decodeURIComponent(p.slice(eq+1)):'';}return '';}function setCookie(name,value,age){document.cookie=name+'='+encodeURIComponent(value)+'; Path=/; Max-Age='+age+'; SameSite=Lax';}function expireCookie(name){setCookie(name,'',0);}function clearLocalStorage(){try{localKeys.forEach(function(key){localStorage.removeItem(key);});}catch(e){}}function clearIndexedDB(){try{if(window.indexedDB&&indexedDB.deleteDatabase)indexedDB.deleteDatabase('gt_profile');}catch(e){}}window.goshtosoStorageConsent={shouldShow:function(){var v=cookieValue(pref);return v!=='allowed'&&v!=='denied';},allowed:function(){return cookieValue(pref)!=='denied';},allow:function(){setCookie(pref,'allowed',maxAge);try{localStorage.setItem('cookieConsent','v2');}catch(e){}},deny:function(){setCookie(pref,'denied',maxAge);demoCookies.forEach(expireCookie);clearLocalStorage();clearIndexedDB();}};if(cookieValue(pref)==='denied'){clearLocalStorage();clearIndexedDB();}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
 // siteFooter renders the global footer shown beneath every page's content
 // (inside #main-content, so it survives fragment-swap navigation). Mirrors
 // PenguinUI's footer: brand line, legal nav, and social links.
@@ -700,9 +733,9 @@ func siteFooter() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var23 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var23 == nil {
-			templ_7745c5c3_Var23 = templ.NopComponent
+		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var24 == nil {
+			templ_7745c5c3_Var24 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		privacyAttrs := navHxAttrs("/privacy", "")

--- a/site/internal/server/chat_handler.go
+++ b/site/internal/server/chat_handler.go
@@ -54,9 +54,9 @@ func (s *Server) renderChatPage(w http.ResponseWriter, r *http.Request) {
 	// missing OR undecodable — so the page HTML and the subsequent ws upgrade
 	// resolve to the same guest instead of two different fallbacks.
 	if c, err := r.Cookie(chat.CookieName); err != nil {
-		setChatCookie(w, me)
+		setChatCookie(r, w, me)
 	} else if _, derr := chat.Decode(c.Value); derr != nil {
-		setChatCookie(w, me)
+		setChatCookie(r, w, me)
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	content := examples.ChatApp(me)
@@ -69,7 +69,10 @@ func (s *Server) renderChatPage(w http.ResponseWriter, r *http.Request) {
 
 // setChatCookie persists the visitor identity in the gt_chat cookie. HttpOnly is
 // false so the cookie is also readable client-side if ever needed; SameSite=Lax.
-func setChatCookie(w http.ResponseWriter, me chat.Identity) {
+func setChatCookie(r *http.Request, w http.ResponseWriter, me chat.Identity) {
+	if !storageAllowed(r) {
+		return
+	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     chat.CookieName,
 		Value:    me.Encode(),
@@ -90,7 +93,7 @@ func (s *Server) handleChatRename(w http.ResponseWriter, r *http.Request) {
 	if nick := strings.TrimSpace(r.FormValue("nick")); nick != "" {
 		me.Nick = truncateRunes(nick, chatMaxNickLen)
 	}
-	setChatCookie(w, me)
+	setChatCookie(r, w, me)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_ = examples.RenameResult(me).Render(r.Context(), w)
 }

--- a/site/internal/server/profile_handler.go
+++ b/site/internal/server/profile_handler.go
@@ -21,7 +21,9 @@ func (s *Server) renderProfilePage(w http.ResponseWriter, r *http.Request) {
 	var st profile.State
 	if _, err := r.Cookie(profile.CookieName); err != nil && r.URL.Query().Get("seed") != "0" {
 		st = profile.Sample()
-		profile.SetCookie(w, st)
+		if storageAllowed(r) {
+			profile.SetCookie(w, st)
+		}
 	} else {
 		st = profile.FromRequest(r)
 	}
@@ -43,7 +45,9 @@ func (s *Server) handleProfileIdentity(w http.ResponseWriter, r *http.Request) {
 	var st profile.State
 	st.SetName(strings.TrimSpace(r.FormValue("name")))
 	st.SetBio(strings.TrimSpace(r.FormValue("bio")))
-	profile.SetCookie(w, st)
+	if storageAllowed(r) {
+		profile.SetCookie(w, st)
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_ = examples.IdentityFields(st).Render(r.Context(), w)
 	_ = toast.OOBToast(toast.Config{

--- a/site/internal/server/storage_consent.go
+++ b/site/internal/server/storage_consent.go
@@ -1,0 +1,13 @@
+package server
+
+import "net/http"
+
+const (
+	storagePreferenceCookie = "gt_storage"
+	storagePreferenceDenied = "denied"
+)
+
+func storageAllowed(r *http.Request) bool {
+	c, err := r.Cookie(storagePreferenceCookie)
+	return err != nil || c.Value != storagePreferenceDenied
+}

--- a/site/internal/server/storage_consent_test.go
+++ b/site/internal/server/storage_consent_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/araihu/goshtoso/site/internal/examples/todo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderTodoPageDoesNotSetDemoCookieWhenStorageDenied(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/examples/todo", nil)
+	req.AddCookie(&http.Cookie{Name: "gt_storage", Value: "denied"})
+	rec := httptest.NewRecorder()
+
+	s := &Server{}
+	s.renderTodoPage(rec, req)
+
+	for _, c := range rec.Result().Cookies() {
+		require.NotEqual(t, todo.CookieName, c.Name, "storage opt-out should prevent demo persistence cookies")
+	}
+}

--- a/site/internal/server/todo_handler.go
+++ b/site/internal/server/todo_handler.go
@@ -24,6 +24,12 @@ func writeClearButton(r *http.Request, w http.ResponseWriter, st todo.State) {
 	_ = examples.ClearButton(st.DoneCount(), true).Render(r.Context(), w)
 }
 
+func persistTodo(r *http.Request, w http.ResponseWriter, st todo.State) {
+	if storageAllowed(r) {
+		todo.SetCookie(w, st)
+	}
+}
+
 // registerTodoRoutes wires all /api/examples/todo/* endpoints.
 func (s *Server) registerTodoRoutes() {
 	s.mux.HandleFunc("/api/examples/todo/add", s.handleTodoAdd)
@@ -45,7 +51,7 @@ func (s *Server) renderTodoPage(w http.ResponseWriter, r *http.Request) {
 		// First visit (no cookie): seed a small starter list so the example
 		// never opens empty, and persist it. `?seed=0` opts out (used by e2e).
 		st = todo.Sample()
-		todo.SetCookie(w, st)
+		persistTodo(r, w, st)
 	} else {
 		st = todo.FromRequest(r)
 	}
@@ -154,7 +160,7 @@ func (s *Server) handleTodoAdd(w http.ResponseWriter, r *http.Request) {
 	priority := r.FormValue("priority")
 	due := r.FormValue("due")
 	st.Add(title, priority, due)
-	todo.SetCookie(w, st)
+	persistTodo(r, w, st)
 	writeHTML(w)
 	writeListAndCount(r, w, st)
 	writeClearButton(r, w, st)
@@ -188,7 +194,7 @@ func (s *Server) handleTodoToggle(w http.ResponseWriter, r *http.Request) {
 		st.Filter = "all"
 	}
 	st.Toggle(idParam(r))
-	todo.SetCookie(w, st)
+	persistTodo(r, w, st)
 	writeHTML(w)
 	writeListAndCount(r, w, st)
 	writeClearButton(r, w, st)
@@ -213,7 +219,7 @@ func (s *Server) handleTodoDelete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	st.Delete(id)
-	todo.SetCookie(w, st)
+	persistTodo(r, w, st)
 	writeHTML(w)
 	writeListAndCount(r, w, st)
 	writeClearButton(r, w, st)
@@ -239,7 +245,7 @@ func (s *Server) handleTodoEdit(w http.ResponseWriter, r *http.Request) {
 		st.Filter = "all"
 	}
 	st.Edit(idParam(r), r.FormValue("title"), r.FormValue("priority"), r.FormValue("due"))
-	todo.SetCookie(w, st)
+	persistTodo(r, w, st)
 	writeHTML(w)
 	writeListAndCount(r, w, st)
 	writeClearButton(r, w, st)
@@ -254,7 +260,7 @@ func (s *Server) handleTodoFilter(w http.ResponseWriter, r *http.Request) {
 		st.Filter = "all"
 	}
 	st.SetFilter(r.URL.Query().Get("f"))
-	todo.SetCookie(w, st)
+	persistTodo(r, w, st)
 	writeHTML(w)
 	_ = examples.TodoList(st).Render(r.Context(), w)
 }
@@ -269,7 +275,7 @@ func (s *Server) handleTodoMove(w http.ResponseWriter, r *http.Request) {
 	}
 	dir := r.URL.Query().Get("dir")
 	moveByButton(&st, idParam(r), dir)
-	todo.SetCookie(w, st)
+	persistTodo(r, w, st)
 	writeHTML(w)
 	_ = examples.TodoList(st).Render(r.Context(), w)
 }
@@ -283,7 +289,7 @@ func (s *Server) handleTodoClearCompleted(w http.ResponseWriter, r *http.Request
 		st.Filter = "all"
 	}
 	st.ClearCompleted()
-	todo.SetCookie(w, st)
+	persistTodo(r, w, st)
 	writeHTML(w)
 	writeListAndCount(r, w, st)
 	writeClearButton(r, w, st)
@@ -325,7 +331,7 @@ func (s *Server) handleTodoRestore(w http.ResponseWriter, r *http.Request) {
 		Order:    intParam(r, "order", 0),
 	}
 	st.Restore(t)
-	todo.SetCookie(w, st)
+	persistTodo(r, w, st)
 	writeHTML(w)
 	writeListAndCount(r, w, st)
 	writeClearButton(r, w, st)

--- a/site/tests/e2e/chat_test.go
+++ b/site/tests/e2e/chat_test.go
@@ -15,7 +15,7 @@ import (
 func gotoChat(t *testing.T, page playwright.Page) {
 	t.Helper()
 	require.NoError(t, page.AddInitScript(playwright.Script{
-		Content: new("try{localStorage.setItem('cookieConsent','v1')}catch(e){}"),
+		Content: new("try{document.cookie='gt_storage=allowed; Path=/; SameSite=Lax'}catch(e){}"),
 	}))
 	_, err := page.Goto(baseURL + "/examples/chat")
 	require.NoError(t, err)
@@ -229,6 +229,7 @@ func TestChat_Rename(t *testing.T) {
 // or page errors — the load-bearing regression guard.
 func TestChat_FragmentNavNoErrors(t *testing.T) {
 	page := newIsolatedPage(t)
+	dismissCookieBanner(t, page)
 
 	var jsErrors []string
 	page.On("pageerror", func(err error) { jsErrors = append(jsErrors, err.Error()) })

--- a/site/tests/e2e/legal_pages_test.go
+++ b/site/tests/e2e/legal_pages_test.go
@@ -24,8 +24,58 @@ var legalPages = []struct {
 func dismissCookieBanner(t *testing.T, page playwright.Page) {
 	t.Helper()
 	require.NoError(t, page.AddInitScript(playwright.Script{
-		Content: new("try{localStorage.setItem('cookieConsent','v1')}catch(e){}"),
+		Content: new("try{document.cookie='gt_storage=allowed; Path=/; SameSite=Lax'}catch(e){}"),
 	}))
+}
+
+func TestBrowserStorageNoticeOffersChoice(t *testing.T) {
+	page := newIsolatedPage(t)
+
+	_, err := page.Goto(baseURL + "/getting-started")
+	require.NoError(t, err)
+	_, err = page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, page.GetByRole("heading", playwright.PageGetByRoleOptions{
+		Name: "Browser storage",
+	}).WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+	require.NoError(t, page.GetByRole("button", playwright.PageGetByRoleOptions{
+		Name: "Allow browser storage",
+	}).WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+	require.NoError(t, page.GetByRole("button", playwright.PageGetByRoleOptions{
+		Name: "Use without storage",
+	}).WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+	require.NoError(t, page.GetByText("Some examples use cookies and IndexedDB to persist local demo state.").WaitFor(
+		playwright.LocatorWaitForOptions{State: playwright.WaitForSelectorStateVisible}))
+}
+
+func TestBrowserStorageNoticeCanDisableDemoCookies(t *testing.T) {
+	page := newIsolatedPage(t)
+
+	_, err := page.Goto(baseURL + "/getting-started")
+	require.NoError(t, err)
+	_, err = page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, page.GetByRole("button", playwright.PageGetByRoleOptions{
+		Name: "Use without storage",
+	}).Click())
+
+	pref, err := page.Evaluate(`() => document.cookie`, nil)
+	require.NoError(t, err)
+	require.Contains(t, pref, "gt_storage=denied")
+
+	_, err = page.Goto(baseURL + "/examples/todo")
+	require.NoError(t, err)
+	cookies, err := page.Evaluate(`() => document.cookie`, nil)
+	require.NoError(t, err)
+	require.NotContains(t, cookies, "gt_todo=")
 }
 
 // TestLegalPages_DirectLoad asserts each page loads, shows its heading and the
@@ -64,6 +114,25 @@ func TestLegalPages_DirectLoad(t *testing.T) {
 
 			require.Empty(t, jsErrors, "no JS console/page errors on %s: %v", p.path, jsErrors)
 		})
+	}
+}
+
+func TestPrivacyPageExplainsBrowserStorageChoices(t *testing.T) {
+	page := newIsolatedPage(t)
+	dismissCookieBanner(t, page)
+
+	_, err := page.Goto(baseURL + "/privacy")
+	require.NoError(t, err)
+
+	for _, text := range []string{
+		"Browser storage",
+		"localStorage",
+		"cookies such as gt_todo",
+		"IndexedDB",
+		"Use without storage",
+	} {
+		require.NoError(t, page.GetByText(text).First().WaitFor(
+			playwright.LocatorWaitForOptions{State: playwright.WaitForSelectorStateVisible}), text)
 	}
 }
 

--- a/site/tests/e2e/logs_test.go
+++ b/site/tests/e2e/logs_test.go
@@ -27,7 +27,7 @@ func gotoLogs(t *testing.T, page playwright.Page) {
 	t.Helper()
 	// Dismiss the first-run cookie banner so it can't intercept control clicks.
 	require.NoError(t, page.AddInitScript(playwright.Script{
-		Content: new("try{localStorage.setItem('cookieConsent','v1')}catch(e){}"),
+		Content: new("try{document.cookie='gt_storage=allowed; Path=/; SameSite=Lax'}catch(e){}"),
 	}))
 	_, err := page.Goto(baseURL + "/examples/logs?interval=50ms")
 	require.NoError(t, err)
@@ -58,6 +58,7 @@ func TestLogFeed_StreamsRows(t *testing.T) {
 // page errors — the regression guard for Alpine.data registering on fragment-nav.
 func TestLogFeed_FragmentNavNoErrors(t *testing.T) {
 	page := newIsolatedPage(t)
+	dismissCookieBanner(t, page)
 
 	var jsErrors []string
 	page.On("pageerror", func(err error) { jsErrors = append(jsErrors, err.Error()) })

--- a/site/tests/e2e/profile_test.go
+++ b/site/tests/e2e/profile_test.go
@@ -15,7 +15,7 @@ func gotoProfile(t *testing.T, page playwright.Page, query string) {
 	// Suppress the first-run cookie/localStorage notice so its fixed banner can
 	// never intercept clicks on the appearance controls.
 	require.NoError(t, page.AddInitScript(playwright.Script{
-		Content: new("try{localStorage.setItem('cookieConsent','v1')}catch(e){}"),
+		Content: new("try{document.cookie='gt_storage=allowed; Path=/; SameSite=Lax'}catch(e){}"),
 	}))
 	_, err := page.Goto(baseURL + "/examples/profile" + query)
 	require.NoError(t, err)
@@ -52,6 +52,24 @@ var onePxPNG = []byte{
 	0x42, 0x60, 0x82,
 }
 
+func waitForProfileImageStored(t *testing.T, page playwright.Page, kind string) {
+	t.Helper()
+	_, err := page.WaitForFunction(
+		`kind => new Promise(resolve => {
+			const open = indexedDB.open('gt_profile', 1);
+			open.onerror = () => resolve(false);
+			open.onsuccess = () => {
+				const db = open.result;
+				const tx = db.transaction('images', 'readonly');
+				const req = tx.objectStore('images').get(kind);
+				req.onsuccess = () => resolve(!!req.result);
+				req.onerror = () => resolve(false);
+			};
+		})`,
+		kind, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(10000)})
+	require.NoError(t, err, "%s image should be stored in IndexedDB before reload", kind)
+}
+
 // TestProfileFragmentNavNoConsoleErrors lands on the examples gallery, then
 // navigates to the profile app via the gallery card (htmx fragment swap), and
 // asserts there are zero console/page errors. This guards the examples mandate:
@@ -69,7 +87,7 @@ func TestProfileFragmentNavNoConsoleErrors(t *testing.T) {
 	})
 
 	require.NoError(t, page.AddInitScript(playwright.Script{
-		Content: new("try{localStorage.setItem('cookieConsent','v1')}catch(e){}"),
+		Content: new("try{document.cookie='gt_storage=allowed; Path=/; SameSite=Lax'}catch(e){}"),
 	}))
 	// Land on the examples gallery first (seed=0 keeps state out of it).
 	_, err := page.Goto(baseURL + "/examples?seed=0")
@@ -182,6 +200,7 @@ func TestProfileAvatarUploadPersists(t *testing.T) {
 		"() => { const img = document.querySelector('#profile-avatar img'); return img && img.src.startsWith('blob:'); }",
 		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)})
 	require.NoError(t, err, "avatar img should get a blob: src after upload")
+	waitForProfileImageStored(t, page, "avatar")
 
 	// Reload (same browser context → same IndexedDB) and verify rehydration.
 	gotoProfile(t, page, "")

--- a/site/tests/e2e/ticker_test.go
+++ b/site/tests/e2e/ticker_test.go
@@ -128,6 +128,7 @@ func TestTicker_PauseStopsUpdates(t *testing.T) {
 // cell update — the SPA path a direct load can't catch.
 func TestTicker_FragmentNavNoErrors(t *testing.T) {
 	page := newPage(t, sharedBrowser)
+	dismissCookieBanner(t, page)
 
 	var jsErrors []string
 	page.On("pageerror", func(err error) { jsErrors = append(jsErrors, err.Error()) })

--- a/site/tests/e2e/todo_example_test.go
+++ b/site/tests/e2e/todo_example_test.go
@@ -44,7 +44,7 @@ func gotoTodo(t *testing.T, page playwright.Page) {
 	// would overlap the right-hand row controls (move/delete) and intercept
 	// their clicks; a returning user has already dismissed it.
 	require.NoError(t, page.AddInitScript(playwright.Script{
-		Content: new("try{localStorage.setItem('cookieConsent','v1')}catch(e){}"),
+		Content: new("try{document.cookie='gt_storage=allowed; Path=/; SameSite=Lax'}catch(e){}"),
 	}))
 	// seed=0 opts out of the first-visit sample data so tests start with an
 	// empty list and assert exact counts.
@@ -127,6 +127,7 @@ func TestTodoExample_Filters(t *testing.T) {
 // takes, which a direct-load test cannot catch.
 func TestTodoExample_FragmentNavNoErrors(t *testing.T) {
 	page := newIsolatedPage(t)
+	dismissCookieBanner(t, page)
 
 	var jsErrors []string
 	page.On("pageerror", func(err error) { jsErrors = append(jsErrors, err.Error()) })


### PR DESCRIPTION
## Summary
- Replace the acknowledge-only cookie notice with a browser-storage choice.
- Add a real storage opt-out via gt_storage=denied and skip example cookies when denied.
- Update privacy copy and e2e coverage for cookies, localStorage, and IndexedDB behavior.

## Test Plan
- templ generate
- go test ./site/internal/server -count=1
- cd site && go test ./internal/examples/... -count=1
- go build -o bin/server ./site/cmd/server
- go test ./site/tests/e2e/... -count=1 -timeout 15m