### PR TITLE
fix(logs): keep stream pinned to bottom

### DIFF
--- a/site/internal/pages/demo/examples/logs.templ
+++ b/site/internal/pages/demo/examples/logs.templ
@@ -63,8 +63,13 @@ templ logFeedScript() {
 				connected: false,
 				minLevel: 'all',
 				init() {
+					this.handleAfterSwap = (e) => this.onSwap(e);
+					this.$root.addEventListener('htmx:afterSwap', this.handleAfterSwap);
 					this.$watch('minLevel', (v) => this.applyFilter(v));
 					this.applyFilter(this.minLevel);
+				},
+				destroy() {
+					if (this.handleAfterSwap) this.$root.removeEventListener('htmx:afterSwap', this.handleAfterSwap);
 				},
 				applyFilter(v) {
 					const wrap = this.$refs.feedWrap;
@@ -73,11 +78,15 @@ templ logFeedScript() {
 					wrap.classList.add('flt-' + v);
 				},
 				onSwap(e) {
-					if (!e.detail || !e.detail.target || e.detail.target.id !== 'log-feed') return;
+					const swapTarget = e.detail && e.detail.target;
+					const eventTarget = e.target instanceof Element ? e.target : null;
+					const affectedFeed = (swapTarget && swapTarget.id === 'log-feed') ||
+						(eventTarget && (eventTarget.id === 'log-feed' || eventTarget.closest('#log-feed')));
+					if (!affectedFeed) return;
 					const feed = document.getElementById('log-feed');
 					if (!feed) return;
 					while (feed.children.length > this.cap) feed.removeChild(feed.firstElementChild);
-					if (this.autoScroll) feed.scrollTop = feed.scrollHeight;
+					if (this.autoScroll) requestAnimationFrame(() => { feed.scrollTop = feed.scrollHeight; });
 				},
 				togglePause() {
 						this.paused = !this.paused;
@@ -175,7 +184,6 @@ templ LogsApp() {
 				<!-- Persistent feed + filter wrapper -->
 				<div
 					x-ref="feedWrap"
-					x-on:htmx:after-swap="onSwap($event)"
 					class="flt-all rounded-radius border border-outline dark:border-outline-dark"
 				>
 					<div id="log-feed" class="h-80 overflow-y-auto"></div>

--- a/site/internal/pages/demo/examples/logs_templ.go
+++ b/site/internal/pages/demo/examples/logs_templ.go
@@ -172,8 +172,13 @@ func logFeedScript() templ.Component {
 				connected: false,
 				minLevel: 'all',
 				init() {
+					this.handleAfterSwap = (e) => this.onSwap(e);
+					this.$root.addEventListener('htmx:afterSwap', this.handleAfterSwap);
 					this.$watch('minLevel', (v) => this.applyFilter(v));
 					this.applyFilter(this.minLevel);
+				},
+				destroy() {
+					if (this.handleAfterSwap) this.$root.removeEventListener('htmx:afterSwap', this.handleAfterSwap);
 				},
 				applyFilter(v) {
 					const wrap = this.$refs.feedWrap;
@@ -182,11 +187,15 @@ func logFeedScript() templ.Component {
 					wrap.classList.add('flt-' + v);
 				},
 				onSwap(e) {
-					if (!e.detail || !e.detail.target || e.detail.target.id !== 'log-feed') return;
+					const swapTarget = e.detail && e.detail.target;
+					const eventTarget = e.target instanceof Element ? e.target : null;
+					const affectedFeed = (swapTarget && swapTarget.id === 'log-feed') ||
+						(eventTarget && (eventTarget.id === 'log-feed' || eventTarget.closest('#log-feed')));
+					if (!affectedFeed) return;
 					const feed = document.getElementById('log-feed');
 					if (!feed) return;
 					while (feed.children.length > this.cap) feed.removeChild(feed.firstElementChild);
-					if (this.autoScroll) feed.scrollTop = feed.scrollHeight;
+					if (this.autoScroll) requestAnimationFrame(() => { feed.scrollTop = feed.scrollHeight; });
 				},
 				togglePause() {
 						this.paused = !this.paused;
@@ -352,7 +361,7 @@ func LogsApp() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div><!-- Persistent feed + filter wrapper --><div x-ref=\"feedWrap\" x-on:htmx:after-swap=\"onSwap($event)\" class=\"flt-all rounded-radius border border-outline dark:border-outline-dark\"><div id=\"log-feed\" class=\"h-80 overflow-y-auto\"></div></div><!-- SSE connector: removed on pause (closes EventSource), targets the persistent feed --><template x-if=\"!paused\"><div hx-ext=\"sse\" sse-connect=\"/api/examples/logs/stream\"><div sse-swap=\"message\" hx-target=\"#log-feed\" hx-swap=\"beforeend\" hidden></div></div></template></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div><!-- Persistent feed + filter wrapper --><div x-ref=\"feedWrap\" class=\"flt-all rounded-radius border border-outline dark:border-outline-dark\"><div id=\"log-feed\" class=\"h-80 overflow-y-auto\"></div></div><!-- SSE connector: removed on pause (closes EventSource), targets the persistent feed --><template x-if=\"!paused\"><div hx-ext=\"sse\" sse-connect=\"/api/examples/logs/stream\"><div sse-swap=\"message\" hx-target=\"#log-feed\" hx-swap=\"beforeend\" hidden></div></div></template></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/tests/e2e/logs_test.go
+++ b/site/tests/e2e/logs_test.go
@@ -53,6 +53,32 @@ func TestLogFeed_StreamsRows(t *testing.T) {
 	require.Equal(t, true, hasBadge)
 }
 
+// TestLogFeed_AutoScrollFollowsStream verifies the checked Auto-scroll control
+// keeps the persistent feed pinned to the newest streamed rows.
+func TestLogFeed_AutoScrollFollowsStream(t *testing.T) {
+	page := newIsolatedPage(t)
+	gotoLogs(t, page)
+	_, err := page.Evaluate("() => { document.getElementById('log-feed').style.height = '64px'; }")
+	require.NoError(t, err)
+	waitForRows(t, page)
+
+	_, err = page.WaitForFunction(
+		`() => {
+			const feed = document.getElementById('log-feed');
+			return feed && feed.children.length >= 4 && feed.scrollHeight > feed.clientHeight;
+		}`,
+		nil)
+	require.NoError(t, err)
+
+	atBottom, err := page.Evaluate(
+		`() => {
+			const feed = document.getElementById('log-feed');
+			return (feed.scrollHeight - feed.clientHeight - feed.scrollTop) <= 2;
+		}`)
+	require.NoError(t, err)
+	require.Equal(t, true, atBottom, "auto-scroll should keep the log feed pinned to the newest rows")
+}
+
 // TestLogFeed_FragmentNavNoErrors lands elsewhere, navigates to the feed via the
 // sidebar (htmx fragment swap), and asserts the stream connects with no console/
 // page errors — the regression guard for Alpine.data registering on fragment-nav.


### PR DESCRIPTION
## Summary
- register the log feed's htmx afterSwap listener from Alpine so SSE swaps are observed reliably
- scroll the log feed after layout updates when auto-scroll is enabled
- add an E2E regression that verifies streamed rows keep the feed pinned to the bottom

## Test Plan
- templ generate
- git diff --check
- go test ./... -count=1
- cd site && go test ./... -count=1
- cd site && go test ./tests/e2e -count=1 -timeout 5m -run 'TestLogFeed' -v