### PR TITLE
fix(toast): harden docs examples

### DIFF
--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -1452,7 +1452,7 @@ import "github.com/araihu/goshtoso/components/toast"  // package toast
 | `Title` | `string` | Title is the notification heading (not used for Message variant) |
 | `Message` | `string` | Message is the notification body text |
 | `Sender` | `*Sender` | Sender is used only for the Message variant |
-| `DisplayDuration` | `int` | DisplayDuration in milliseconds (default 8000) |
+| `DisplayDuration` | `int` | DisplayDuration in milliseconds (default 8000); negative keeps a server-rendered toast visible until dismissed manually. |
 | `ActionText` | `string` | ActionText, when set, renders an inline action button in the toast (e.g. |
 | `ActionHxGet` | `string` | ActionHxGet / ActionHxPost is the HTMX request URL the action button fires. |
 | `ActionHxPost` | `string` |  |

--- a/components/toast/toast.templ
+++ b/components/toast/toast.templ
@@ -51,7 +51,7 @@ templ Container(cfg ContainerConfig) {
 				</div>
 			</template>
 			<!-- OOB server-rendered toasts get appended here -->
-			<div id={ cfg.effectiveID() + "-oob" }></div>
+			<div id={ cfg.effectiveID() + "-oob" } class="flex flex-col gap-2"></div>
 		</div>
 	</div>
 }
@@ -223,7 +223,7 @@ templ serverVariantToast(cfg Config, durationStr string) {
 	<div
 		id={ toastID }
 		data-toast-id={ toastID }
-		x-data={ singleToastAlpineData(cfg.effectiveDuration()) }
+		x-data={ singleToastAlpineData(cfg.effectiveDuration(), cfg.DisplayDuration < 0) }
 		x-cloak
 		x-show="isVisible"
 		x-on:toast-dismiss.window={ fmt.Sprintf("if ($event.detail.id === '%s') { $el.remove() }", jsEscapeSingle(toastID)) }
@@ -300,7 +300,7 @@ templ serverMessageToast(cfg Config, durationStr string) {
 	<div
 		id={ toastID }
 		data-toast-id={ toastID }
-		x-data={ singleToastAlpineData(cfg.effectiveDuration()) }
+		x-data={ singleToastAlpineData(cfg.effectiveDuration(), cfg.DisplayDuration < 0) }
 		x-cloak
 		x-show="isVisible"
 		x-on:toast-dismiss.window={ fmt.Sprintf("if ($event.detail.id === '%s') { $el.remove() }", jsEscapeSingle(toastID)) }

--- a/components/toast/toast_hardening_test.go
+++ b/components/toast/toast_hardening_test.go
@@ -58,8 +58,16 @@ func TestToast_RenderedDismissExpressionsUseGeneratedSafeID(t *testing.T) {
 }
 
 func TestSingleToastAlpineData_UsesNumericDuration(t *testing.T) {
-	data := singleToastAlpineData(1250)
+	data := singleToastAlpineData(1250, false)
 
 	assert.Contains(t, data, "}, 1250);")
 	assert.NotContains(t, data, "}, '1250');")
+}
+
+func TestSingleToastAlpineData_PersistentHasNoAutoDismiss(t *testing.T) {
+	data := singleToastAlpineData(1250, true)
+
+	assert.Contains(t, data, "isVisible: true")
+	assert.NotContains(t, data, "setTimeout")
+	assert.NotContains(t, data, "toast-dismiss")
 }

--- a/components/toast/toast_templ.go
+++ b/components/toast/toast_templ.go
@@ -122,7 +122,7 @@ func Container(cfg ContainerConfig) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\"></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" class=\"flex flex-col gap-2\"></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -474,9 +474,9 @@ func serverVariantToast(cfg Config, durationStr string) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var21 string
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(singleToastAlpineData(cfg.effectiveDuration()))
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(singleToastAlpineData(cfg.effectiveDuration(), cfg.DisplayDuration < 0))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 226, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 226, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 		if templ_7745c5c3_Err != nil {
@@ -807,9 +807,9 @@ func serverMessageToast(cfg Config, durationStr string) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var41 string
-		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.ResolveAttributeValue(singleToastAlpineData(cfg.effectiveDuration()))
+		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.ResolveAttributeValue(singleToastAlpineData(cfg.effectiveDuration(), cfg.DisplayDuration < 0))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 303, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 303, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var41)
 		if templ_7745c5c3_Err != nil {

--- a/components/toast/types.go
+++ b/components/toast/types.go
@@ -43,7 +43,7 @@ type Config struct {
 	Message string
 	// Sender is used only for the Message variant
 	Sender *Sender
-	// DisplayDuration in milliseconds (default 8000)
+	// DisplayDuration in milliseconds (default 8000); negative keeps a server-rendered toast visible until dismissed manually.
 	DisplayDuration int
 	// ActionText, when set, renders an inline action button in the toast (e.g.
 	// "Undo"). Clicking it fires the configured HTMX request and dismisses the
@@ -188,7 +188,10 @@ func containerAlpineData(cfg ContainerConfig) string {
 }
 
 // singleToastAlpineData returns the Alpine.js x-data for an individual toast item
-func singleToastAlpineData(duration int) string {
+func singleToastAlpineData(duration int, persistent bool) string {
+	if persistent {
+		return `{ isVisible: true }`
+	}
 	return fmt.Sprintf(`{
         isVisible: false,
         timeout: null,

--- a/site/internal/pages/demo/components/toast.templ
+++ b/site/internal/pages/demo/components/toast.templ
@@ -81,7 +81,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		{Name: "Title", Type: "string", Default: `""`, Description: "Toast heading (omitted by the message variant)."},
 		{Name: "Message", Type: "string", Default: `""`, Description: "Toast body text."},
 		{Name: "Sender", Type: "*Sender", Default: "nil", Description: "Message-variant sender (Name + Avatar); adds avatar and reply button."},
-		{Name: "DisplayDuration", Type: "int", Default: "0", Description: "Auto-dismiss delay in ms (0 uses the container default)."},
+		{Name: "DisplayDuration", Type: "int", Default: "0", Description: "Auto-dismiss delay in ms (0 uses the container default; negative keeps a server-rendered toast visible until dismissed)."},
 	})
 }
 
@@ -115,7 +115,7 @@ templ toastAlpinePreview() {
 				</button>
 				<!-- Danger Trigger -->
 				<button
-					x-on:click="$dispatch('notify', { variant: 'danger', title: 'Oops!', message: 'Something went wrong. Please try again. If the problem persists, we&#39;re here to help!' })"
+					x-on:click="$dispatch('notify', { variant: 'danger', title: 'Oops!', message: 'Something went wrong. Please try again. If the problem persists, we are here to help!' })"
 					type="button"
 					class="whitespace-nowrap rounded-radius bg-danger px-4 py-2 text-center text-sm font-medium tracking-wide text-on-danger transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger active:opacity-100 active:outline-offset-0"
 				>
@@ -173,28 +173,33 @@ templ toastStaticPreview() {
 	<div id="toast-static" class="w-full max-w-2xl mx-auto">
 		<div class="space-y-3">
 				@toast.Toast(toast.Config{
-					Variant: toast.Info,
-					Title:   "Update Available",
-					Message: "A new version of the app is ready.",
+					Variant:         toast.Info,
+					Title:           "Update Available",
+					Message:         "A new version of the app is ready.",
+					DisplayDuration: -1,
 				})
 				@toast.Toast(toast.Config{
-					Variant: toast.Success,
-					Title:   "Success!",
-					Message: "Your changes have been saved.",
+					Variant:         toast.Success,
+					Title:           "Success!",
+					Message:         "Your changes have been saved.",
+					DisplayDuration: -1,
 				})
 				@toast.Toast(toast.Config{
-					Variant: toast.Warning,
-					Title:   "Action Needed",
-					Message: "Your storage is getting low.",
+					Variant:         toast.Warning,
+					Title:           "Action Needed",
+					Message:         "Your storage is getting low.",
+					DisplayDuration: -1,
 				})
 				@toast.Toast(toast.Config{
-					Variant: toast.Danger,
-					Title:   "Oops!",
-					Message: "Something went wrong.",
+					Variant:         toast.Danger,
+					Title:           "Oops!",
+					Message:         "Something went wrong.",
+					DisplayDuration: -1,
 				})
 				@toast.Toast(toast.Config{
-					Variant: toast.Message,
-					Message: "Hey, can you review the PR I just submitted?",
+					Variant:         toast.Message,
+					Message:         "Hey, can you review the PR I just submitted?",
+					DisplayDuration: -1,
 					Sender: &toast.Sender{
 						Name:   "Jack Ellis",
 						Avatar: "/assets/images/avatars/avatar-2.webp",

--- a/site/internal/pages/demo/components/toast_templ.go
+++ b/site/internal/pages/demo/components/toast_templ.go
@@ -148,7 +148,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 			{Name: "Title", Type: "string", Default: `""`, Description: "Toast heading (omitted by the message variant)."},
 			{Name: "Message", Type: "string", Default: `""`, Description: "Toast body text."},
 			{Name: "Sender", Type: "*Sender", Default: "nil", Description: "Message-variant sender (Name + Avatar); adds avatar and reply button."},
-			{Name: "DisplayDuration", Type: "int", Default: "0", Description: "Auto-dismiss delay in ms (0 uses the container default)."},
+			{Name: "DisplayDuration", Type: "int", Default: "0", Description: "Auto-dismiss delay in ms (0 uses the container default; negative keeps a server-rendered toast visible until dismissed)."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -179,7 +179,7 @@ func toastAlpinePreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"toast-alpine\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-3\"><!-- Message Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'message', sender: { name: 'Jack Ellis', avatar: '/assets/images/avatars/avatar-2.webp' }, message: 'Hey, can you review the PR I just submitted? Let me know if you spot any issues!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-primary px-4 py-2 text-center text-sm font-medium tracking-wide text-on-primary transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:opacity-100 active:outline-offset-0 dark:bg-primary-dark dark:text-on-primary-dark dark:focus-visible:outline-primary-dark\">Message</button><!-- Info Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'info', title: 'Update Available', message: 'A new version of the app is ready for you. Update now to enjoy the latest features!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-info px-4 py-2 text-center text-sm font-medium tracking-wide text-on-info transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-info active:opacity-100 active:outline-offset-0\">Info</button><!-- Success Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'success', title: 'Success!', message: 'Your changes have been saved. Keep up the great work!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-success px-4 py-2 text-center text-sm font-medium tracking-wide text-on-success transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-success active:opacity-100 active:outline-offset-0\">Success</button><!-- Danger Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'danger', title: 'Oops!', message: 'Something went wrong. Please try again. If the problem persists, we&#39;re here to help!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-danger px-4 py-2 text-center text-sm font-medium tracking-wide text-on-danger transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger active:opacity-100 active:outline-offset-0\">Danger</button><!-- Warning Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'warning', title: 'Action Needed', message: 'Your storage is getting low. Consider upgrading your plan.' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-warning px-4 py-2 text-center text-sm font-medium tracking-wide text-on-warning transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-warning active:opacity-100 active:outline-offset-0\">Warning</button></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"toast-alpine\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap gap-3\"><!-- Message Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'message', sender: { name: 'Jack Ellis', avatar: '/assets/images/avatars/avatar-2.webp' }, message: 'Hey, can you review the PR I just submitted? Let me know if you spot any issues!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-primary px-4 py-2 text-center text-sm font-medium tracking-wide text-on-primary transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:opacity-100 active:outline-offset-0 dark:bg-primary-dark dark:text-on-primary-dark dark:focus-visible:outline-primary-dark\">Message</button><!-- Info Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'info', title: 'Update Available', message: 'A new version of the app is ready for you. Update now to enjoy the latest features!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-info px-4 py-2 text-center text-sm font-medium tracking-wide text-on-info transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-info active:opacity-100 active:outline-offset-0\">Info</button><!-- Success Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'success', title: 'Success!', message: 'Your changes have been saved. Keep up the great work!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-success px-4 py-2 text-center text-sm font-medium tracking-wide text-on-success transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-success active:opacity-100 active:outline-offset-0\">Success</button><!-- Danger Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'danger', title: 'Oops!', message: 'Something went wrong. Please try again. If the problem persists, we are here to help!' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-danger px-4 py-2 text-center text-sm font-medium tracking-wide text-on-danger transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger active:opacity-100 active:outline-offset-0\">Danger</button><!-- Warning Trigger --><button x-on:click=\"$dispatch('notify', { variant: 'warning', title: 'Action Needed', message: 'Your storage is getting low. Consider upgrading your plan.' })\" type=\"button\" class=\"whitespace-nowrap rounded-radius bg-warning px-4 py-2 text-center text-sm font-medium tracking-wide text-on-warning transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-warning active:opacity-100 active:outline-offset-0\">Warning</button></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -244,40 +244,45 @@ func toastStaticPreview() templ.Component {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = toast.Toast(toast.Config{
-			Variant: toast.Info,
-			Title:   "Update Available",
-			Message: "A new version of the app is ready.",
+			Variant:         toast.Info,
+			Title:           "Update Available",
+			Message:         "A new version of the app is ready.",
+			DisplayDuration: -1,
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = toast.Toast(toast.Config{
-			Variant: toast.Success,
-			Title:   "Success!",
-			Message: "Your changes have been saved.",
+			Variant:         toast.Success,
+			Title:           "Success!",
+			Message:         "Your changes have been saved.",
+			DisplayDuration: -1,
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = toast.Toast(toast.Config{
-			Variant: toast.Warning,
-			Title:   "Action Needed",
-			Message: "Your storage is getting low.",
+			Variant:         toast.Warning,
+			Title:           "Action Needed",
+			Message:         "Your storage is getting low.",
+			DisplayDuration: -1,
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = toast.Toast(toast.Config{
-			Variant: toast.Danger,
-			Title:   "Oops!",
-			Message: "Something went wrong.",
+			Variant:         toast.Danger,
+			Title:           "Oops!",
+			Message:         "Something went wrong.",
+			DisplayDuration: -1,
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = toast.Toast(toast.Config{
-			Variant: toast.Message,
-			Message: "Hey, can you review the PR I just submitted?",
+			Variant:         toast.Message,
+			Message:         "Hey, can you review the PR I just submitted?",
+			DisplayDuration: -1,
 			Sender: &toast.Sender{
 				Name:   "Jack Ellis",
 				Avatar: "/assets/images/avatars/avatar-2.webp",

--- a/site/tests/e2e/toast_test.go
+++ b/site/tests/e2e/toast_test.go
@@ -1,0 +1,108 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToastDangerTriggerCreatesToast(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+	var jsErrors []string
+	page.On("pageerror", func(err error) { jsErrors = append(jsErrors, err.Error()) })
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			jsErrors = append(jsErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/toast", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	_, err = page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("#toast-alpine button", playwright.PageLocatorOptions{HasText: "Danger"}).Click())
+	_, err = page.WaitForFunction(
+		`() => Array.from(document.querySelectorAll('#toast-container [role="alert"]')).some(el => el.textContent.includes('Oops!'))`,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Empty(t, jsErrors, "no JS console/page errors when creating the danger toast: %v", jsErrors)
+}
+
+func TestToastServerToastsHaveStackGap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+	_, err := page.Goto(baseURL+"/components/toast", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("#toast-htmx button", playwright.PageLocatorOptions{HasText: "Server Success Toast"}).Click())
+	require.NoError(t, page.Locator("#toast-htmx button", playwright.PageLocatorOptions{HasText: "Server Danger Toast"}).Click())
+	_, err = page.WaitForFunction(
+		`() => document.querySelectorAll('#toast-container-oob [role="alert"]').length >= 2`,
+		nil,
+	)
+	require.NoError(t, err)
+	_, err = page.WaitForFunction(
+		`() => {
+			const style = getComputedStyle(document.querySelector('#toast-container-oob'));
+			return style.display === 'flex' && style.flexDirection === 'column' && parseFloat(style.rowGap) >= 8;
+		}`,
+		nil,
+	)
+	require.NoError(t, err)
+}
+
+func TestToastStaticExamplesStayVisible(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+	_, err := page.Goto(baseURL+"/components/toast", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+
+	staticAlerts := page.Locator("#toast-static [role='alert']")
+	count, err := staticAlerts.Count()
+	require.NoError(t, err)
+	require.Equal(t, 5, count, "static docs preview should render all toast examples")
+
+	time.Sleep(8500 * time.Millisecond)
+
+	count, err = staticAlerts.Count()
+	require.NoError(t, err)
+	require.Equal(t, 5, count, "static docs preview toasts should not auto-dismiss")
+}


### PR DESCRIPTION
## Summary
- fix the Toast docs danger trigger by avoiding an escaped apostrophe inside Alpine inline JS
- add proper stack spacing for server-generated HTMX/OOB toasts
- keep static server-rendered docs examples visible with persistent DisplayDuration behavior

## Test Plan
- [x] templ generate
- [x] go run ./scripts/skillgen
- [x] go build -o bin/server ./site/cmd/server
- [x] go test ./site/tests/e2e/... -count=1 -timeout 5m -run 'TestToast(DangerTriggerCreatesToast|ServerToastsHaveStackGap|StaticExamplesStayVisible)'
- [x] curl -fsS http://localhost:8090/components/toast >/dev/null
- [x] git diff --check