### PR TITLE
feat(avatar): match PenguinUI docs

### DIFF
--- a/.agents/skills/using-goshtoso/components-reference.md
+++ b/.agents/skills/using-goshtoso/components-reference.md
@@ -83,8 +83,9 @@ import "github.com/araihu/goshtoso/components/alert"  // package alert
 import "github.com/araihu/goshtoso/components/avatar"  // package avatar
 ```
 
-**Entry points:** `Avatar(cfg Config)` · `UserIcon()`
+**Entry points:** `Avatar(cfg Config)` · `AvatarStack(cfg StackConfig)` · `UserIcon()`
 
+- **Radius** — RadiusDefault = "", RadiusNone = "none", RadiusXS = "xs", RadiusSM = "sm", RadiusMD = "md", RadiusLG = "lg"
 - **Shape** — ShapeCircle = "circle", ShapeSquare = "square"
 - **Size** — SizeXS = "xs", SizeSM = "sm", SizeMD = "md", SizeLG = "lg", SizeXL = "xl", Size2XL = "2xl"
 - **Status** — StatusOffline = "offline", StatusInfo = "info", StatusSuccess = "success", StatusWarning = "warning", StatusDanger = "danger"
@@ -101,6 +102,7 @@ import "github.com/araihu/goshtoso/components/avatar"  // package avatar
 | `Size` | `Size` | Size of the avatar |
 | `Variant` | `Variant` | Variant determines the color scheme (for initials/icon placeholders) |
 | `Shape` | `Shape` | Shape of the avatar (circle or square) |
+| `Radius` | `Radius` | Radius controls the corner radius for square avatars. |
 | `Border` | `bool` | Border adds a colored border (for image avatars) |
 | `BorderColor` | `string` | BorderColor is the border color (defaults to variant color if empty) |
 | `Status` | `Status` | Status adds a status indicator dot |
@@ -108,6 +110,16 @@ import "github.com/araihu/goshtoso/components/avatar"  // package avatar
 | `Class` | `string` | Class allows additional CSS classes |
 | `SrcExpr` | `string` | SrcExpr is an Alpine expression evaluated in the parent scope that yields |
 | `Reactive` | `bool` | Reactive defers the size + status-indicator size classes to the parent |
+| `ReactiveRadius` | `bool` | ReactiveRadius defers square-avatar radius classes to the parent Alpine |
+
+**StackConfig**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Items` | `[]Config` | Items are rendered as overlapping avatars from left to right. |
+| `Label` | `string` | Label describes the group for assistive technology. |
+| `Class` | `string` | Class allows additional CSS classes on the stack root. |
+| `Reactive` | `bool` | Reactive defers each avatar's size classes to the parent Alpine scope. |
 
 ## badge
 

--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -83,8 +83,9 @@ import "github.com/araihu/goshtoso/components/alert"  // package alert
 import "github.com/araihu/goshtoso/components/avatar"  // package avatar
 ```
 
-**Entry points:** `Avatar(cfg Config)` · `UserIcon()`
+**Entry points:** `Avatar(cfg Config)` · `AvatarStack(cfg StackConfig)` · `UserIcon()`
 
+- **Radius** — RadiusDefault = "", RadiusNone = "none", RadiusXS = "xs", RadiusSM = "sm", RadiusMD = "md", RadiusLG = "lg"
 - **Shape** — ShapeCircle = "circle", ShapeSquare = "square"
 - **Size** — SizeXS = "xs", SizeSM = "sm", SizeMD = "md", SizeLG = "lg", SizeXL = "xl", Size2XL = "2xl"
 - **Status** — StatusOffline = "offline", StatusInfo = "info", StatusSuccess = "success", StatusWarning = "warning", StatusDanger = "danger"
@@ -101,6 +102,7 @@ import "github.com/araihu/goshtoso/components/avatar"  // package avatar
 | `Size` | `Size` | Size of the avatar |
 | `Variant` | `Variant` | Variant determines the color scheme (for initials/icon placeholders) |
 | `Shape` | `Shape` | Shape of the avatar (circle or square) |
+| `Radius` | `Radius` | Radius controls the corner radius for square avatars. |
 | `Border` | `bool` | Border adds a colored border (for image avatars) |
 | `BorderColor` | `string` | BorderColor is the border color (defaults to variant color if empty) |
 | `Status` | `Status` | Status adds a status indicator dot |
@@ -108,6 +110,16 @@ import "github.com/araihu/goshtoso/components/avatar"  // package avatar
 | `Class` | `string` | Class allows additional CSS classes |
 | `SrcExpr` | `string` | SrcExpr is an Alpine expression evaluated in the parent scope that yields |
 | `Reactive` | `bool` | Reactive defers the size + status-indicator size classes to the parent |
+| `ReactiveRadius` | `bool` | ReactiveRadius defers square-avatar radius classes to the parent Alpine |
+
+**StackConfig**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Items` | `[]Config` | Items are rendered as overlapping avatars from left to right. |
+| `Label` | `string` | Label describes the group for assistive technology. |
+| `Class` | `string` | Class allows additional CSS classes on the stack root. |
+| `Reactive` | `bool` | Reactive defers each avatar's size classes to the parent Alpine scope. |
 
 ## badge
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -298,6 +298,7 @@
     --tracking-widest: 0.1em;
     --leading-tight: 1.25;
     --leading-relaxed: 1.625;
+    --radius-xs: 0.125rem;
     --radius-sm: 0.25rem;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
@@ -795,6 +796,9 @@
   .mb-8 {
     margin-bottom: calc(var(--spacing) * 8);
   }
+  .-ml-3 {
+    margin-left: calc(var(--spacing) * -3);
+  }
   .-ml-px {
     margin-left: -1px;
   }
@@ -913,6 +917,10 @@
   .size-32 {
     width: calc(var(--spacing) * 32);
     height: calc(var(--spacing) * 32);
+  }
+  .size-full {
+    width: 100%;
+    height: 100%;
   }
   .h-0\.5 {
     height: calc(var(--spacing) * 0.5);
@@ -1611,11 +1619,17 @@
   .rounded-md {
     border-radius: var(--radius-md);
   }
+  .rounded-none {
+    border-radius: 0;
+  }
   .rounded-radius {
     border-radius: var(--radius-radius);
   }
   .rounded-sm {
     border-radius: var(--radius-sm);
+  }
+  .rounded-xs {
+    border-radius: var(--radius-xs);
   }
   .rounded-es-none {
     border-end-start-radius: 0;

--- a/components/avatar/avatar.templ
+++ b/components/avatar/avatar.templ
@@ -40,6 +40,31 @@ templ Avatar(cfg Config) {
 	}
 }
 
+// AvatarStack renders an overlapping group of avatars.
+templ AvatarStack(cfg StackConfig) {
+	{{
+		label := cfg.Label
+		if label == "" {
+			label = "Avatar group"
+		}
+		rootClasses := "flex items-center " + cfg.Class
+	}}
+	<div class={ rootClasses } role="list" aria-label={ label }>
+		for i, item := range cfg.Items {
+			{{
+				item.Reactive = item.Reactive || cfg.Reactive
+				item.Class = "ring-2 ring-surface dark:ring-surface-dark " + item.Class
+				if i > 0 {
+					item.Class = "-ml-3 " + item.Class
+				}
+			}}
+			<div role="listitem">
+				@Avatar(item)
+			</div>
+		}
+	</div>
+}
+
 // avatarLayers renders the 3-layer stack.
 //
 // When cfg.Reactive is true, the size classes (size-X text-Y) are omitted
@@ -51,28 +76,61 @@ templ avatarLayers(cfg Config) {
 		if cfg.Reactive {
 			sizePart = ""
 		}
-		containerClasses := "relative inline-flex " + sizePart + " " + cfg.ShapeClasses() + " overflow-hidden " + cfg.VariantClasses() + " " + cfg.Class
+		radiusPart := cfg.ShapeClasses()
+		if cfg.ReactiveRadius {
+			radiusPart = ""
+		}
+		bindClass := ""
+		if cfg.Reactive && cfg.ReactiveRadius {
+			bindClass = "[avatarSizeClass, avatarRadiusClass]"
+		} else if cfg.Reactive {
+			bindClass = "avatarSizeClass"
+		} else if cfg.ReactiveRadius {
+			bindClass = "avatarRadiusClass"
+		}
+		rootSkinClasses := cfg.VariantClasses()
+		layerSkinClasses := ""
+		if cfg.Border {
+			rootSkinClasses = ""
+			layerSkinClasses = cfg.VariantFillClasses()
+		}
+		containerClasses := "relative inline-flex " + sizePart + " " + radiusPart + " " + rootSkinClasses + " " + cfg.BorderClasses() + " " + cfg.Class
+		layerBoxClasses := "relative block size-full overflow-hidden " + radiusPart + " " + layerSkinClasses
 	}}
 	if cfg.HasImage() {
 		<div
 			x-data="{ imgLoaded: false, imgError: false }"
 			class={ containerClasses }
-			if cfg.Reactive {
-				x-bind:class="avatarSizeClass"
+			if bindClass != "" {
+				x-bind:class={ bindClass }
 			}
 		>
-			@layerInitials(cfg, true)
-			@layerLoading(cfg)
-			@layerImage(cfg)
+			<span
+				class={ layerBoxClasses }
+				if cfg.ReactiveRadius {
+					x-bind:class="avatarRadiusClass"
+				}
+			>
+				@layerInitials(cfg, true)
+				@layerLoading(cfg)
+				@layerImage(cfg)
+			</span>
 		</div>
 	} else {
 		<div
 			class={ containerClasses }
-			if cfg.Reactive {
-				x-bind:class="avatarSizeClass"
+			if bindClass != "" {
+				x-bind:class={ bindClass }
 			}
 		>
-			@layerInitials(cfg, false)
+			<span
+				class={ layerBoxClasses }
+				if cfg.ReactiveRadius {
+					x-bind:class="avatarRadiusClass"
+				}
+			>
+				@layerInitials(cfg, false)
+			</span>
 		</div>
 	}
 }

--- a/components/avatar/avatar_templ.go
+++ b/components/avatar/avatar_templ.go
@@ -76,6 +76,95 @@ func Avatar(cfg Config) templ.Component {
 	})
 }
 
+// AvatarStack renders an overlapping group of avatars.
+func AvatarStack(cfg StackConfig) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var2 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var2 == nil {
+			templ_7745c5c3_Var2 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		label := cfg.Label
+		if label == "" {
+			label = "Avatar group"
+		}
+		rootClasses := "flex items-center " + cfg.Class
+		var templ_7745c5c3_Var3 = []any{rootClasses}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var3...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var4 string
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var3).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" role=\"list\" aria-label=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var5 string
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(label)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 52, Col: 58}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		for i, item := range cfg.Items {
+			item.Reactive = item.Reactive || cfg.Reactive
+			item.Class = "ring-2 ring-surface dark:ring-surface-dark " + item.Class
+			if i > 0 {
+				item.Class = "-ml-3 " + item.Class
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div role=\"listitem\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = Avatar(item).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
 // avatarLayers renders the 3-layer stack.
 //
 // When cfg.Reactive is true, the size classes (size-X text-Y) are omitted
@@ -97,46 +186,110 @@ func avatarLayers(cfg Config) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var2 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var2 == nil {
-			templ_7745c5c3_Var2 = templ.NopComponent
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		sizePart := cfg.SizeClasses()
 		if cfg.Reactive {
 			sizePart = ""
 		}
-		containerClasses := "relative inline-flex " + sizePart + " " + cfg.ShapeClasses() + " overflow-hidden " + cfg.VariantClasses() + " " + cfg.Class
+		radiusPart := cfg.ShapeClasses()
+		if cfg.ReactiveRadius {
+			radiusPart = ""
+		}
+		bindClass := ""
+		if cfg.Reactive && cfg.ReactiveRadius {
+			bindClass = "[avatarSizeClass, avatarRadiusClass]"
+		} else if cfg.Reactive {
+			bindClass = "avatarSizeClass"
+		} else if cfg.ReactiveRadius {
+			bindClass = "avatarRadiusClass"
+		}
+		rootSkinClasses := cfg.VariantClasses()
+		layerSkinClasses := ""
+		if cfg.Border {
+			rootSkinClasses = ""
+			layerSkinClasses = cfg.VariantFillClasses()
+		}
+		containerClasses := "relative inline-flex " + sizePart + " " + radiusPart + " " + rootSkinClasses + " " + cfg.BorderClasses() + " " + cfg.Class
+		layerBoxClasses := "relative block size-full overflow-hidden " + radiusPart + " " + layerSkinClasses
 		if cfg.HasImage() {
-			var templ_7745c5c3_Var3 = []any{containerClasses}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var3...)
+			var templ_7745c5c3_Var7 = []any{containerClasses}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var7...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div x-data=\"{ imgLoaded: false, imgError: false }\" class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div x-data=\"{ imgLoaded: false, imgError: false }\" class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var4 string
-			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var3).String())
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var7).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if cfg.Reactive {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, " x-bind:class=\"avatarSizeClass\"")
+			if bindClass != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, " x-bind:class=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var9 string
+				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(bindClass)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 105, Col: 28}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, ">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, ">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var10 = []any{layerBoxClasses}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var10...)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<span class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var10).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if cfg.ReactiveRadius {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, " x-bind:class=\"avatarRadiusClass\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, ">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -152,40 +305,85 @@ func avatarLayers(cfg Config) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			var templ_7745c5c3_Var5 = []any{containerClasses}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var5...)
+			var templ_7745c5c3_Var12 = []any{containerClasses}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var12...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var5).String())
+			var templ_7745c5c3_Var13 string
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var12).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var13)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if cfg.Reactive {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " x-bind:class=\"avatarSizeClass\"")
+			if bindClass != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, " x-bind:class=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var14 string
+				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.ResolveAttributeValue(bindClass)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 123, Col: 28}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var14)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, ">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, ">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var15 = []any{layerBoxClasses}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var15...)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<span class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var16 string
+			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var15).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if cfg.ReactiveRadius {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " x-bind:class=\"avatarRadiusClass\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, ">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -193,7 +391,7 @@ func avatarLayers(cfg Config) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -221,66 +419,66 @@ func layerInitials(cfg Config, withImageOverlay bool) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var17 == nil {
+			templ_7745c5c3_Var17 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		classes := "absolute inset-0 flex items-center justify-center font-bold tracking-wider"
-		var templ_7745c5c3_Var8 = []any{classes}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var8...)
+		var templ_7745c5c3_Var18 = []any{classes}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var18...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<span class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<span class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var8).String())
+		var templ_7745c5c3_Var19 string
+		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var18).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\" aria-hidden=\"true\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" aria-hidden=\"true\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if withImageOverlay {
 			if cfg.SrcExpr != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " x-show=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " x-show=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var10 string
-				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("!(%s) || !imgLoaded || imgError", cfg.SrcExpr))
+				var templ_7745c5c3_Var20 string
+				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("!(%s) || !imgLoaded || imgError", cfg.SrcExpr))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 90, Col: 72}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 148, Col: 72}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var10)
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, " x-show=\"!imgLoaded || imgError\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, " x-show=\"!imgLoaded || imgError\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if cfg.Icon != nil {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<span class=\"w-full h-full mt-3\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<span class=\"w-full h-full mt-3\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -288,22 +486,22 @@ func layerInitials(cfg Config, withImageOverlay bool) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			var templ_7745c5c3_Var11 string
-			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.ResolvedInitials())
+			var templ_7745c5c3_Var21 string
+			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.ResolvedInitials())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 101, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 159, Col: 27}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -330,62 +528,62 @@ func layerLoading(cfg Config) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var12 == nil {
-			templ_7745c5c3_Var12 = templ.NopComponent
+		templ_7745c5c3_Var22 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var22 == nil {
+			templ_7745c5c3_Var22 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<span")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if cfg.SrcExpr != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, " x-show=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, " x-show=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var13 string
-			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("(%s) && !imgLoaded && !imgError", cfg.SrcExpr))
+			var templ_7745c5c3_Var23 string
+			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("(%s) && !imgLoaded && !imgError", cfg.SrcExpr))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 112, Col: 71}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 170, Col: 71}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var13)
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var23)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " x-show=\"!imgLoaded && !imgError\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, " x-show=\"!imgLoaded && !imgError\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " class=\"absolute inset-0 flex items-center justify-center bg-surface-alt dark:bg-surface-dark-alt\" aria-hidden=\"true\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, " class=\"absolute inset-0 flex items-center justify-center bg-surface-alt dark:bg-surface-dark-alt\" aria-hidden=\"true\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var14 = []any{"animate-spin text-on-surface-muted dark:text-on-surface-dark-muted " + cfg.SpinnerSizeClasses()}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var14...)
+		var templ_7745c5c3_Var24 = []any{"animate-spin text-on-surface-muted dark:text-on-surface-dark-muted " + cfg.SpinnerSizeClasses()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var24...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<svg class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<svg class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var15 string
-		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var14).String())
+		var templ_7745c5c3_Var25 string
+		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var24).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var15)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\"><circle class=\"opacity-25\" cx=\"12\" cy=\"12\" r=\"10\" stroke=\"currentColor\" stroke-width=\"4\"></circle> <path class=\"opacity-75\" fill=\"currentColor\" d=\"M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z\"></path></svg></span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\"><circle class=\"opacity-25\" cx=\"12\" cy=\"12\" r=\"10\" stroke=\"currentColor\" stroke-width=\"4\"></circle> <path class=\"opacity-75\" fill=\"currentColor\" d=\"M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z\"></path></svg></span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -424,105 +622,105 @@ func layerImage(cfg Config) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var16 == nil {
-			templ_7745c5c3_Var16 = templ.NopComponent
+		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var26 == nil {
+			templ_7745c5c3_Var26 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<img x-show=\"!imgError\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<img x-show=\"!imgError\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if cfg.SrcExpr != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " x-init=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, " x-init=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var17 string
-			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("if ((%[1]s) && $el.complete) { if ($el.naturalWidth > 0) imgLoaded = true; else imgError = true; }", cfg.SrcExpr))
+			var templ_7745c5c3_Var27 string
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("if ((%[1]s) && $el.complete) { if ($el.naturalWidth > 0) imgLoaded = true; else imgError = true; }", cfg.SrcExpr))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 145, Col: 138}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 203, Col: 138}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var17)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" x-effect=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var18 string
-			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("if (%s) { imgError = false; }", cfg.SrcExpr))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 146, Col: 71}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\" x-effect=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" x-bind:src=\"")
+			var templ_7745c5c3_Var28 string
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("if (%s) { imgError = false; }", cfg.SrcExpr))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 204, Col: 71}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var28)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var19 string
-			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.SrcExpr)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 147, Col: 27}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "\" x-bind:src=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\"")
+			var templ_7745c5c3_Var29 string
+			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.SrcExpr)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 205, Col: 27}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var29)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, " x-init=\"if ($el.complete) { if ($el.naturalWidth > 0) imgLoaded = true; else imgError = true; }\" src=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, " x-init=\"if ($el.complete) { if ($el.naturalWidth > 0) imgLoaded = true; else imgError = true; }\" src=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var20 string
-			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Src)
+			var templ_7745c5c3_Var30 string
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Src)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 150, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 208, Col: 16}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " x-on:load=\"imgLoaded = true\" x-on:error=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, " x-on:load=\"imgLoaded = true\" x-on:error=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var21 string
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("imgError = true; console.warn('[avatar] failed to load image:', '%s')", jsEscapeSingle(cfg.Src)))
+		var templ_7745c5c3_Var31 string
+		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("imgError = true; console.warn('[avatar] failed to load image:', '%s')", jsEscapeSingle(cfg.Src)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 153, Col: 124}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 211, Col: 124}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" alt=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var31)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var22 string
-		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Alt)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 154, Col: 15}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "\" alt=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\" class=\"absolute inset-0 h-full w-full object-cover object-center\">")
+		var templ_7745c5c3_Var32 string
+		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Alt)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 212, Col: 15}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\" class=\"absolute inset-0 h-full w-full object-cover object-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -550,12 +748,12 @@ func avatarWithStatus(cfg Config) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var23 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var23 == nil {
-			templ_7745c5c3_Var23 = templ.NopComponent
+		templ_7745c5c3_Var33 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var33 == nil {
+			templ_7745c5c3_Var33 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<div class=\"relative w-fit\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<div class=\"relative w-fit\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -568,35 +766,35 @@ func avatarWithStatus(cfg Config) templ.Component {
 		if cfg.Reactive {
 			statusSizePart = ""
 		}
-		var templ_7745c5c3_Var24 = []any{"absolute rounded-full border-2 border-surface dark:border-surface-dark " + statusSizePart + " " + cfg.StatusClasses() + " " + positionClass}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var24...)
+		var templ_7745c5c3_Var34 = []any{"absolute rounded-full border-2 border-surface dark:border-surface-dark " + statusSizePart + " " + cfg.StatusClasses() + " " + positionClass}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var34...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<span class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<span class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var25 string
-		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var24).String())
+		var templ_7745c5c3_Var35 string
+		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var34).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/avatar/avatar.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var35)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if cfg.Reactive {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, " x-bind:class=\"avatarStatusSizeClass\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, " x-bind:class=\"avatarStatusSizeClass\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, " aria-hidden=\"true\"></span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, " aria-hidden=\"true\"></span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -625,12 +823,12 @@ func userIconTempl() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var26 == nil {
-			templ_7745c5c3_Var26 = templ.NopComponent
+		templ_7745c5c3_Var36 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var36 == nil {
+			templ_7745c5c3_Var36 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-full h-full mt-3\"><path fill-rule=\"evenodd\" d=\"M7.5 6a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM3.751 20.105a8.25 8.25 0 0116.498 0 .75.75 0 01-.437.695A18.683 18.683 0 0112 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 01-.437-.695z\" clip-rule=\"evenodd\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" aria-hidden=\"true\" fill=\"currentColor\" class=\"w-full h-full mt-3\"><path fill-rule=\"evenodd\" d=\"M7.5 6a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM3.751 20.105a8.25 8.25 0 0116.498 0 .75.75 0 01-.437.695A18.683 18.683 0 0112 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 01-.437-.695z\" clip-rule=\"evenodd\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/avatar/avatar_test.go
+++ b/components/avatar/avatar_test.go
@@ -1,0 +1,115 @@
+package avatar
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestAvatarBorderClassesRenderOnRoot(t *testing.T) {
+	var buf bytes.Buffer
+	err := Avatar(Config{
+		Src:         "/avatar.webp",
+		Alt:         "Bordered avatar",
+		Border:      true,
+		BorderColor: "border-success",
+	}).Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("render avatar: %v", err)
+	}
+
+	html := buf.String()
+	for _, want := range []string{"border-2", "border-success", "p-0.5"} {
+		if !bytes.Contains([]byte(html), []byte(want)) {
+			t.Fatalf("bordered avatar missing %q in rendered HTML:\n%s", want, html)
+		}
+	}
+	if bytes.Contains([]byte(html), []byte("border-outline")) {
+		t.Fatalf("bordered avatar root should not also render outline border classes:\n%s", html)
+	}
+}
+
+func TestAvatarBorderLayersRespectPadding(t *testing.T) {
+	var buf bytes.Buffer
+	err := Avatar(Config{
+		Src:         "/avatar.webp",
+		Alt:         "Bordered avatar",
+		Border:      true,
+		BorderColor: "border-success",
+	}).Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("render avatar: %v", err)
+	}
+
+	html := buf.String()
+	for _, want := range []string{"p-0.5", "relative block size-full overflow-hidden rounded-full"} {
+		if !bytes.Contains([]byte(html), []byte(want)) {
+			t.Fatalf("bordered avatar layers should render inside a clipped content box; missing %q:\n%s", want, html)
+		}
+	}
+}
+
+func TestAvatarSquareRadiusClassesRenderOnRoot(t *testing.T) {
+	var buf bytes.Buffer
+	err := Avatar(Config{
+		Initials: "SQ",
+		Shape:    ShapeSquare,
+		Radius:   RadiusLG,
+	}).Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("render avatar: %v", err)
+	}
+
+	html := buf.String()
+	if !bytes.Contains([]byte(html), []byte("rounded-lg")) {
+		t.Fatalf("square avatar missing rounded-lg in rendered HTML:\n%s", html)
+	}
+	if bytes.Contains([]byte(html), []byte("rounded-full")) {
+		t.Fatalf("square avatar should not render rounded-full:\n%s", html)
+	}
+}
+
+func TestAvatarReactiveRadiusBindsSizeAndRadiusClasses(t *testing.T) {
+	var buf bytes.Buffer
+	err := Avatar(Config{
+		Initials:       "SQ",
+		Shape:          ShapeSquare,
+		Reactive:       true,
+		ReactiveRadius: true,
+	}).Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("render avatar: %v", err)
+	}
+
+	html := buf.String()
+	if !bytes.Contains([]byte(html), []byte(`x-bind:class="[avatarSizeClass, avatarRadiusClass]"`)) {
+		t.Fatalf("reactive square avatar missing combined size/radius binding:\n%s", html)
+	}
+	for _, want := range []string{"relative block size-full overflow-hidden", `x-bind:class="avatarRadiusClass"`} {
+		if !bytes.Contains([]byte(html), []byte(want)) {
+			t.Fatalf("reactive square avatar inner clip box should bind avatarRadiusClass; missing %q:\n%s", want, html)
+		}
+	}
+}
+
+func TestAvatarStackRendersOverlappingItems(t *testing.T) {
+	var buf bytes.Buffer
+	err := AvatarStack(StackConfig{
+		Label: "Project members",
+		Items: []Config{
+			{Src: "/a.webp", Alt: "Ada Lovelace"},
+			{Src: "/g.webp", Alt: "Grace Hopper"},
+			{Initials: "KT", Variant: Primary},
+		},
+	}).Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("render avatar stack: %v", err)
+	}
+
+	html := buf.String()
+	for _, want := range []string{"aria-label=\"Project members\"", "-ml-3", "ring-2", "Ada Lovelace", "Grace Hopper", "KT"} {
+		if !bytes.Contains([]byte(html), []byte(want)) {
+			t.Fatalf("avatar stack missing %q in rendered HTML:\n%s", want, html)
+		}
+	}
+}

--- a/components/avatar/types.go
+++ b/components/avatar/types.go
@@ -38,6 +38,18 @@ const (
 	ShapeSquare Shape = "square" // Rounded corners
 )
 
+// Radius represents square-avatar corner radius variants.
+type Radius string
+
+const (
+	RadiusDefault Radius = ""     // Default square radius
+	RadiusNone    Radius = "none" // No radius
+	RadiusXS      Radius = "xs"   // Extra small radius
+	RadiusSM      Radius = "sm"   // Small radius
+	RadiusMD      Radius = "md"   // Medium radius
+	RadiusLG      Radius = "lg"   // Large radius
+)
+
 // Status represents online/offline status indicator
 type Status string
 
@@ -76,6 +88,8 @@ type Config struct {
 	Variant Variant
 	// Shape of the avatar (circle or square)
 	Shape Shape
+	// Radius controls the corner radius for square avatars.
+	Radius Radius
 	// Border adds a colored border (for image avatars)
 	Border bool
 	// BorderColor is the border color (defaults to variant color if empty)
@@ -108,6 +122,21 @@ type Config struct {
 	//     get avatarSizeClass() { return this.sizeMap[this.selected]; },
 	//     get avatarStatusSizeClass() { return this.statusSizeMap[this.selected]; },
 	//   }"
+	Reactive bool
+	// ReactiveRadius defers square-avatar radius classes to the parent Alpine
+	// scope via `avatarRadiusClass`. Use with ShapeSquare for live radius demos.
+	ReactiveRadius bool
+}
+
+// StackConfig holds configuration for a stacked avatar group.
+type StackConfig struct {
+	// Items are rendered as overlapping avatars from left to right.
+	Items []Config
+	// Label describes the group for assistive technology.
+	Label string
+	// Class allows additional CSS classes on the stack root.
+	Class string
+	// Reactive defers each avatar's size classes to the parent Alpine scope.
 	Reactive bool
 }
 
@@ -146,9 +175,25 @@ func (cfg Config) SizeClasses() string {
 func (cfg Config) ShapeClasses() string {
 	switch cfg.Shape {
 	case ShapeSquare:
-		return "rounded-md"
+		return cfg.RadiusClasses()
 	default:
 		return "rounded-full"
+	}
+}
+
+// RadiusClasses returns the CSS classes for square avatar radius.
+func (cfg Config) RadiusClasses() string {
+	switch cfg.Radius {
+	case RadiusNone:
+		return "rounded-none"
+	case RadiusXS:
+		return "rounded-xs"
+	case RadiusSM:
+		return "rounded-sm"
+	case RadiusLG:
+		return "rounded-lg"
+	default:
+		return "rounded-md"
 	}
 }
 
@@ -171,6 +216,28 @@ func (cfg Config) VariantClasses() string {
 		return "border border-danger bg-danger text-on-danger/80"
 	default:
 		return "border border-outline bg-surface-alt text-on-surface/80 dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark/80"
+	}
+}
+
+// VariantFillClasses returns variant classes without border color.
+func (cfg Config) VariantFillClasses() string {
+	switch cfg.Variant {
+	case Inverse:
+		return "bg-surface-dark-alt text-on-surface-dark/80 dark:bg-surface-alt dark:text-on-surface/80"
+	case Primary:
+		return "bg-primary text-on-primary/80 dark:bg-primary-dark dark:text-on-primary-dark/80"
+	case Secondary:
+		return "bg-secondary text-on-secondary/80 dark:bg-secondary-dark dark:text-on-secondary-dark/80"
+	case Info:
+		return "bg-info text-on-info/80"
+	case Success:
+		return "bg-success text-on-success/80"
+	case Warning:
+		return "bg-warning text-on-warning/80"
+	case Danger:
+		return "bg-danger text-on-danger/80"
+	default:
+		return "bg-surface-alt text-on-surface/80 dark:bg-surface-dark-alt dark:text-on-surface-dark/80"
 	}
 }
 

--- a/site/internal/pages/demo/component_demo.templ
+++ b/site/internal/pages/demo/component_demo.templ
@@ -51,6 +51,9 @@ type ComponentDemoProps struct {
 type DemoSectionProps struct {
 	Title       string
 	Description string
+	// AbovePreview is an optional slot rendered between the section copy and
+	// the macOS-frame preview.
+	AbovePreview templ.Component
 }
 
 templ ComponentDemo(props ComponentDemoProps, demoContent templ.Component, codeExample string) {
@@ -136,10 +139,13 @@ templ APIReference(props []PropDoc) {
 templ DemoSection(props DemoSectionProps, preview templ.Component, code string) {
 	<div class="mt-10">
 		<h2 id={ slugify(props.Title) } data-toc-heading class="scroll-mt-8 text-lg font-semibold font-title mb-1">{ props.Title }</h2>
-		if props.Description != "" {
-			<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">{ props.Description }</p>
-		}
-		<!-- Preview -->
+	if props.Description != "" {
+		<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted mb-4">{ props.Description }</p>
+	}
+	if props.AbovePreview != nil {
+		@props.AbovePreview
+	}
+	<!-- Preview -->
 		<div class="border border-outline dark:border-outline-dark rounded-radius mb-4">
 			<div class="bg-surface-alt dark:bg-surface-dark-alt w-full px-4 py-3 flex items-center justify-between border-b border-outline dark:border-outline-dark rounded-t-radius">
 				<div class="flex gap-1.5">

--- a/site/internal/pages/demo/component_demo_templ.go
+++ b/site/internal/pages/demo/component_demo_templ.go
@@ -59,6 +59,9 @@ type ComponentDemoProps struct {
 type DemoSectionProps struct {
 	Title       string
 	Description string
+	// AbovePreview is an optional slot rendered between the section copy and
+	// the macOS-frame preview.
+	AbovePreview templ.Component
 }
 
 func ComponentDemo(props ComponentDemoProps, demoContent templ.Component, codeExample string) templ.Component {
@@ -89,7 +92,7 @@ func ComponentDemo(props ComponentDemoProps, demoContent templ.Component, codeEx
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.ResolveAttributeValue(slugify(props.Title))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 60, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 63, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var2)
 		if templ_7745c5c3_Err != nil {
@@ -102,7 +105,7 @@ func ComponentDemo(props ComponentDemoProps, demoContent templ.Component, codeEx
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(props.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 60, Col: 120}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 63, Col: 120}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -115,7 +118,7 @@ func ComponentDemo(props ComponentDemoProps, demoContent templ.Component, codeEx
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(props.Description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 62, Col: 23}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 65, Col: 23}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -205,7 +208,7 @@ func APIReference(props []PropDoc) templ.Component {
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 121, Col: 134}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 124, Col: 134}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
@@ -218,7 +221,7 @@ func APIReference(props []PropDoc) templ.Component {
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(p.Type)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 122, Col: 126}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 125, Col: 126}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
@@ -231,7 +234,7 @@ func APIReference(props []PropDoc) templ.Component {
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(p.Default)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 123, Col: 129}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 126, Col: 129}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
@@ -244,7 +247,7 @@ func APIReference(props []PropDoc) templ.Component {
 				var templ_7745c5c3_Var9 string
 				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(p.Description)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 124, Col: 89}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 127, Col: 89}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
@@ -294,7 +297,7 @@ func DemoSection(props DemoSectionProps, preview templ.Component, code string) t
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue(slugify(props.Title))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 138, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 141, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
 		if templ_7745c5c3_Err != nil {
@@ -307,7 +310,7 @@ func DemoSection(props DemoSectionProps, preview templ.Component, code string) t
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(props.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 138, Col: 122}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 141, Col: 122}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
@@ -325,13 +328,19 @@ func DemoSection(props DemoSectionProps, preview templ.Component, code string) t
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(props.Description)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 140, Col: 100}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/component_demo.templ`, Line: 143, Col: 99}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if props.AbovePreview != nil {
+			templ_7745c5c3_Err = props.AbovePreview.Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/site/internal/pages/demo/components/avatar.templ
+++ b/site/internal/pages/demo/components/avatar.templ
@@ -21,7 +21,9 @@ templ avatarShowcaseScript() {
 (function () {
   var factory = () => ({
     selected: 'md',
+    radius: 'md',
     sizes: ['xs','sm','md','lg','xl','2xl'],
+    radii: ['none','xs','sm','md','lg'],
     sizeMap: {
       xs:  'size-8 text-xs',
       sm:  'size-10 text-sm',
@@ -30,11 +32,19 @@ templ avatarShowcaseScript() {
       xl:  'size-24 text-4xl',
       '2xl': 'size-32 text-5xl'
     },
+    radiusMap: {
+      none: 'rounded-none',
+      xs: 'rounded-xs',
+      sm: 'rounded-sm',
+      md: 'rounded-md',
+      lg: 'rounded-lg'
+    },
     statusSizeMap: {
       xs: 'size-2', sm: 'size-2.5', md: 'size-4',
       lg: 'size-5', xl: 'size-6', '2xl': 'size-7'
     },
     get avatarSizeClass()       { return this.sizeMap[this.selected]; },
+    get avatarRadiusClass()     { return this.radiusMap[this.radius]; },
     get avatarStatusSizeClass() { return this.statusSizeMap[this.selected]; }
   });
   // Full page load: Alpine isn't running yet, so defer to alpine:init.
@@ -54,70 +64,119 @@ templ avatarShowcaseScript() {
 }
 
 // avatarDemoContent renders the actual content inside the layout.
-// The x-data wrapper hoists Alpine state above the ComponentDemo macOS-frame
-// so the size selector sits in the page chrome (matching PenguinUI), while
-// every reactive avatar inside the frame still inherits the same scope.
-// The whole demo stays inside one x-data="avatarShowcase" scope so the single
-// size selector (AbovePreview) drives every Reactive avatar across all the
-// per-variant DemoSection boxes in lockstep. Each variant box still carries its
-// e2e data-testid; the API reference sits after #avatar-fragment.
+// The page follows PenguinUI's avatar sections closely: default image, square
+// with radius control, icon placeholder, initials placeholder, border, status,
+// and stacked avatars. The whole page stays inside one Alpine scope so the
+// size selector drives every Reactive avatar in lockstep.
 templ avatarDemoContent() {
 	@avatarShowcaseScript()
 	<div x-data="avatarShowcase">
 		<div id="avatar-fragment">
 			@demo.ComponentDemo(
 				demo.ComponentDemoProps{
-					Title:        "Avatar",
-					Description:  "A visual representation of a user or entity — image, initials, icon placeholder, status indicator, and square shape. The size selector above drives every avatar on the page in lockstep via Alpine.js (Reactive: true).",
+					Title:        "Default Avatar",
+					Description:  "A circle avatar in various sizes.",
 					AbovePreview: avatarSizeSelector(),
 				},
-				avatarImagePreview(),
-				`// Image Avatar (reactive — sized by the shared Alpine scope)
+				avatarDefaultPreview(),
+				`// Default Avatar (reactive — sized by the shared Alpine scope)
 @avatar.Avatar(avatar.Config{
     Src:      "/assets/images/avatars/avatar-8.webp",
-    Alt:      "John Doe",
+    Alt:      "Rounded avatar",
     Reactive: true,
-})
-
-// Bordered + status variants
-@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-primary", Reactive: true})
-@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusSuccess, Reactive: true})`,
+})`,
 			)
 
 			@demo.DemoSection(
 				demo.DemoSectionProps{
-					Title:       "Initials",
-					Description: "Set Initials and a Variant for a colored monogram fallback.",
-				},
-				avatarInitialsPreview(),
-				`@avatar.Avatar(avatar.Config{Initials: "JD", Variant: avatar.Primary, Reactive: true})`,
-			)
-
-			@demo.DemoSection(
-				demo.DemoSectionProps{
-					Title:       "Icon Placeholder",
-					Description: "With neither Src nor Initials, the avatar shows a generic user icon in the Variant color.",
-				},
-				avatarIconPreview(),
-				`@avatar.Avatar(avatar.Config{Variant: avatar.Primary, Reactive: true})`,
-			)
-
-			@demo.DemoSection(
-				demo.DemoSectionProps{
-					Title:       "Status Indicator",
-					Description: "Set Status: StatusOffline, StatusInfo, StatusSuccess, StatusWarning, or StatusDanger for a corner presence dot.",
-				},
-				avatarStatusPreview(),
-				`@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusSuccess, Reactive: true})`,
-			)
-
-			@demo.DemoSection(
-				demo.DemoSectionProps{
-					Title:       "Square Shape",
-					Description: "Shape: avatar.ShapeSquare renders a rounded-square avatar instead of a circle.",
+					Title:        "Square Avatar",
+					Description:  "A square avatar in various sizes with an adjustable border radius.",
+					AbovePreview: avatarRadiusSelector(),
 				},
 				avatarSquarePreview(),
-				`@avatar.Avatar(avatar.Config{Initials: "SQ", Shape: avatar.ShapeSquare, Variant: avatar.Info, Reactive: true})`,
+				`@avatar.Avatar(avatar.Config{
+    Src:            "/assets/images/avatars/avatar-8.webp",
+    Alt:            "Square avatar",
+    Shape:          avatar.ShapeSquare,
+    Radius:         avatar.RadiusMD,
+    Reactive:       true,
+    ReactiveRadius: true,
+})`,
+			)
+
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Avatar with Icon Placeholder",
+					Description: "An avatar in various colors with an icon placeholder.",
+				},
+				avatarIconPreview(),
+				`@avatar.Avatar(avatar.Config{Variant: avatar.Default, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Inverse, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Primary, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Secondary, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Info, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Success, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Warning, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Danger, Reactive: true})`,
+			)
+
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Avatar with Initials Placeholder",
+					Description: "An avatar in various colors with an initials placeholder.",
+				},
+				avatarInitialsPreview(),
+				`@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Default, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Inverse, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Primary, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Secondary, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Info, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Success, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Warning, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Danger, Reactive: true})`,
+			)
+
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Avatar with Border",
+					Description: "An avatar with a border in various colors.",
+				},
+				avatarBorderPreview(),
+				`@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-info", Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-success", Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-warning", Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-danger", Reactive: true})`,
+			)
+
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Avatar with Status Indicator",
+					Description: "An avatar with a status indicator in various colors.",
+				},
+				avatarStatusPreview(),
+				`@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusOffline, Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusInfo, Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusSuccess, Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusWarning, Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusDanger, Reactive: true})`,
+			)
+
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Stacked Avatars",
+					Description: "A stacked avatar group in various sizes.",
+				},
+				avatarStackedPreview(),
+				`@avatar.AvatarStack(avatar.StackConfig{
+    Label:    "Team members",
+    Reactive: true,
+    Items: []avatar.Config{
+        {Src: "/assets/images/avatars/avatar-8.webp", Alt: "Aiden Walker"},
+        {Src: "/assets/images/avatars/avatar-3.webp", Alt: "Emily Rodriguez"},
+        {Src: "/assets/images/avatars/avatar-5.webp", Alt: "Alex Martinez"},
+        {Src: "/assets/images/avatars/avatar-1.webp", Alt: "Bob Johnson"},
+    },
+})`,
 			)
 
 			@demo.DemoSection(
@@ -139,12 +198,18 @@ templ avatarDemoContent() {
 			{Name: "Size", Type: "Size", Default: "SizeMD", Description: `Fixed size: "xs", "sm", "md", "lg", "xl", "2xl" (ignored when Reactive).`},
 			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Color for initials/icon: default, primary, secondary, info, success, warning, danger.`},
 			{Name: "Shape", Type: "Shape", Default: "ShapeCircle", Description: `Shape: "circle" or "square".`},
+			{Name: "Radius", Type: "Radius", Default: "RadiusDefault", Description: `Square-avatar radius: "none", "xs", "sm", "md", "lg".`},
 			{Name: "Border", Type: "bool", Default: "false", Description: "Add a ring border."},
 			{Name: "BorderColor", Type: "string", Default: `""`, Description: "Tailwind border color class for the ring."},
 			{Name: "Status", Type: "Status", Default: `""`, Description: `Presence dot: "offline", "info", "success", "warning", "danger".`},
 			{Name: "Icon", Type: "templ.Component", Default: "nil", Description: "Custom placeholder icon (overrides the default user icon)."},
 			{Name: "Reactive", Type: "bool", Default: "false", Description: "Read size classes from the parent Alpine scope (avatarSizeClass) instead of Size."},
+			{Name: "ReactiveRadius", Type: "bool", Default: "false", Description: "Read square radius classes from the parent Alpine scope (avatarRadiusClass)."},
 			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the avatar root."},
+			{Name: "StackConfig.Items", Type: "[]avatar.Config", Default: "nil", Description: "Avatar configs rendered as an overlapping group."},
+			{Name: "StackConfig.Label", Type: "string", Default: `"Avatar group"`, Description: "Accessible label for the stacked avatar group."},
+			{Name: "StackConfig.Class", Type: "string", Default: `""`, Description: "Extra classes on the stack root."},
+			{Name: "StackConfig.Reactive", Type: "bool", Default: "false", Description: "Apply the shared reactive size binding to every stack item."},
 		})
 	</div>
 }
@@ -168,6 +233,23 @@ templ avatarSizeSelector() {
 	</div>
 }
 
+// avatarRadiusSelector renders the square-avatar radius segmented control.
+templ avatarRadiusSelector() {
+	<div class="mb-3 flex flex-wrap items-center gap-4">
+		<label class="text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong">Border Radius</label>
+		<div data-testid="avatar-radius-selector">
+			@radio.RadioBar() {
+				@avatarRadiusOption("none", "none")
+				@avatarRadiusOption("xs", "xs")
+				@avatarRadiusOption("sm", "sm")
+				@avatarRadiusOption("md", "md")
+				@avatarRadiusOption("lg", "lg")
+			}
+		</div>
+		<span class="sr-only" data-testid="avatar-radius-selected" x-text="radius"></span>
+	</div>
+}
+
 // sizeOption renders a single segmented pill for the size selector.
 templ sizeOption(value, label string) {
 	@radio.Radio(radio.Config{
@@ -183,32 +265,28 @@ templ sizeOption(value, label string) {
 	})
 }
 
-// avatarImagePreview renders the reactive image avatars (default ComponentDemo box).
-templ avatarImagePreview() {
+// avatarRadiusOption renders a single segmented pill for the radius selector.
+templ avatarRadiusOption(value, label string) {
+	@radio.Radio(radio.Config{
+		ID:        "avatar-radius-" + value,
+		Name:      "avatar-radius",
+		Value:     value,
+		Label:     label,
+		Segmented: true,
+		Alpine: &radio.AlpineConfig{
+			BindChecked: "radius === '" + value + "'",
+			OnChange:    "radius = '" + value + "'",
+		},
+	})
+}
+
+// avatarDefaultPreview renders the reactive default image avatar.
+templ avatarDefaultPreview() {
 	<div id="avatar-image" class="w-full max-w-2xl mx-auto">
 		<div class="flex flex-wrap items-center justify-center gap-4" data-testid="avatar-section-image">
 			@avatar.Avatar(avatar.Config{
 				Src:      "/assets/images/avatars/avatar-8.webp",
-				Alt:      "User Avatar",
-				Reactive: true,
-			})
-			@avatar.Avatar(avatar.Config{
-				Src:         "/assets/images/avatars/avatar-8.webp",
-				Alt:         "User Avatar with border",
-				Border:      true,
-				BorderColor: "border-primary",
-				Reactive:    true,
-			})
-			@avatar.Avatar(avatar.Config{
-				Src:      "/assets/images/avatars/avatar-8.webp",
-				Alt:      "User with Status",
-				Status:   avatar.StatusSuccess,
-				Reactive: true,
-			})
-			@avatar.Avatar(avatar.Config{
-				Src:      "/assets/images/avatars/avatar-8.webp",
-				Alt:      "User Offline",
-				Status:   avatar.StatusOffline,
+				Alt:      "Rounded avatar",
 				Reactive: true,
 			})
 		</div>
@@ -219,13 +297,14 @@ templ avatarImagePreview() {
 templ avatarInitialsPreview() {
 	<div id="avatar-initials" class="w-full max-w-2xl mx-auto">
 		<div class="flex flex-wrap items-center justify-center gap-4" data-testid="avatar-section-initials">
-			@avatar.Avatar(avatar.Config{Initials: "JD", Variant: avatar.Default, Reactive: true})
-			@avatar.Avatar(avatar.Config{Initials: "AB", Variant: avatar.Primary, Reactive: true})
-			@avatar.Avatar(avatar.Config{Initials: "CD", Variant: avatar.Secondary, Reactive: true})
-			@avatar.Avatar(avatar.Config{Initials: "EF", Variant: avatar.Info, Reactive: true})
-			@avatar.Avatar(avatar.Config{Initials: "GH", Variant: avatar.Success, Reactive: true})
-			@avatar.Avatar(avatar.Config{Initials: "IJ", Variant: avatar.Warning, Reactive: true})
-			@avatar.Avatar(avatar.Config{Initials: "KL", Variant: avatar.Danger, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Default, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Inverse, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Primary, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Secondary, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Info, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Success, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Warning, Reactive: true})
+			@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Danger, Reactive: true})
 		</div>
 	</div>
 }
@@ -233,10 +312,27 @@ templ avatarInitialsPreview() {
 // avatarIconPreview renders the icon-placeholder avatars.
 templ avatarIconPreview() {
 	<div id="avatar-icon" class="w-full max-w-2xl mx-auto">
-		<div class="flex flex-wrap items-center justify-center gap-4">
+		<div class="flex flex-wrap items-center justify-center gap-4" data-testid="avatar-section-icon">
 			@avatar.Avatar(avatar.Config{Variant: avatar.Default, Reactive: true})
+			@avatar.Avatar(avatar.Config{Variant: avatar.Inverse, Reactive: true})
 			@avatar.Avatar(avatar.Config{Variant: avatar.Primary, Reactive: true})
+			@avatar.Avatar(avatar.Config{Variant: avatar.Secondary, Reactive: true})
 			@avatar.Avatar(avatar.Config{Variant: avatar.Info, Reactive: true})
+			@avatar.Avatar(avatar.Config{Variant: avatar.Success, Reactive: true})
+			@avatar.Avatar(avatar.Config{Variant: avatar.Warning, Reactive: true})
+			@avatar.Avatar(avatar.Config{Variant: avatar.Danger, Reactive: true})
+		</div>
+	</div>
+}
+
+// avatarBorderPreview renders image avatars with semantic border colors.
+templ avatarBorderPreview() {
+	<div id="avatar-border" class="w-full max-w-2xl mx-auto">
+		<div class="flex flex-wrap items-center justify-center gap-4" data-testid="avatar-section-border">
+			@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Info border avatar", Border: true, BorderColor: "border-info", Reactive: true})
+			@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Success border avatar", Border: true, BorderColor: "border-success", Reactive: true})
+			@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Warning border avatar", Border: true, BorderColor: "border-warning", Reactive: true})
+			@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Danger border avatar", Border: true, BorderColor: "border-danger", Reactive: true})
 		</div>
 	</div>
 }
@@ -258,9 +354,32 @@ templ avatarStatusPreview() {
 templ avatarSquarePreview() {
 	<div id="avatar-square" class="w-full max-w-2xl mx-auto">
 		<div class="flex flex-wrap items-center justify-center gap-4" data-testid="avatar-section-square">
-			@avatar.Avatar(avatar.Config{Initials: "SQ", Variant: avatar.Info, Shape: avatar.ShapeSquare, Reactive: true})
-			@avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Square", Shape: avatar.ShapeSquare, Reactive: true})
-			@avatar.Avatar(avatar.Config{Initials: "SQ", Variant: avatar.Success, Shape: avatar.ShapeSquare, Status: avatar.StatusSuccess, Reactive: true})
+			@avatar.Avatar(avatar.Config{
+				Src:            "/assets/images/avatars/avatar-8.webp",
+				Alt:            "Square avatar",
+				Shape:          avatar.ShapeSquare,
+				Radius:         avatar.RadiusMD,
+				Reactive:       true,
+				ReactiveRadius: true,
+			})
+		</div>
+	</div>
+}
+
+// avatarStackedPreview renders a stacked group of image avatars.
+templ avatarStackedPreview() {
+	<div id="avatar-stacked" class="w-full max-w-2xl mx-auto">
+		<div class="flex items-center justify-center" data-testid="avatar-section-stacked">
+			@avatar.AvatarStack(avatar.StackConfig{
+				Label:    "Team members",
+				Reactive: true,
+				Items: []avatar.Config{
+					{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Aiden Walker"},
+					{Src: "/assets/images/avatars/avatar-3.webp", Alt: "Emily Rodriguez"},
+					{Src: "/assets/images/avatars/avatar-5.webp", Alt: "Alex Martinez"},
+					{Src: "/assets/images/avatars/avatar-1.webp", Alt: "Bob Johnson"},
+				},
+			})
 		</div>
 	</div>
 }

--- a/site/internal/pages/demo/components/avatar_templ.go
+++ b/site/internal/pages/demo/components/avatar_templ.go
@@ -74,7 +74,9 @@ func avatarShowcaseScript() templ.Component {
 (function () {
   var factory = () => ({
     selected: 'md',
+    radius: 'md',
     sizes: ['xs','sm','md','lg','xl','2xl'],
+    radii: ['none','xs','sm','md','lg'],
     sizeMap: {
       xs:  'size-8 text-xs',
       sm:  'size-10 text-sm',
@@ -83,11 +85,19 @@ func avatarShowcaseScript() templ.Component {
       xl:  'size-24 text-4xl',
       '2xl': 'size-32 text-5xl'
     },
+    radiusMap: {
+      none: 'rounded-none',
+      xs: 'rounded-xs',
+      sm: 'rounded-sm',
+      md: 'rounded-md',
+      lg: 'rounded-lg'
+    },
     statusSizeMap: {
       xs: 'size-2', sm: 'size-2.5', md: 'size-4',
       lg: 'size-5', xl: 'size-6', '2xl': 'size-7'
     },
     get avatarSizeClass()       { return this.sizeMap[this.selected]; },
+    get avatarRadiusClass()     { return this.radiusMap[this.radius]; },
     get avatarStatusSizeClass() { return this.statusSizeMap[this.selected]; }
   });
   // Full page load: Alpine isn't running yet, so defer to alpine:init.
@@ -112,13 +122,10 @@ func avatarShowcaseScript() templ.Component {
 }
 
 // avatarDemoContent renders the actual content inside the layout.
-// The x-data wrapper hoists Alpine state above the ComponentDemo macOS-frame
-// so the size selector sits in the page chrome (matching PenguinUI), while
-// every reactive avatar inside the frame still inherits the same scope.
-// The whole demo stays inside one x-data="avatarShowcase" scope so the single
-// size selector (AbovePreview) drives every Reactive avatar across all the
-// per-variant DemoSection boxes in lockstep. Each variant box still carries its
-// e2e data-testid; the API reference sits after #avatar-fragment.
+// The page follows PenguinUI's avatar sections closely: default image, square
+// with radius control, icon placeholder, initials placeholder, border, status,
+// and stacked avatars. The whole page stays inside one Alpine scope so the
+// size selector drives every Reactive avatar in lockstep.
 func avatarDemoContent() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -150,65 +157,121 @@ func avatarDemoContent() templ.Component {
 		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
-				Title:        "Avatar",
-				Description:  "A visual representation of a user or entity — image, initials, icon placeholder, status indicator, and square shape. The size selector above drives every avatar on the page in lockstep via Alpine.js (Reactive: true).",
+				Title:        "Default Avatar",
+				Description:  "A circle avatar in various sizes.",
 				AbovePreview: avatarSizeSelector(),
 			},
-			avatarImagePreview(),
-			`// Image Avatar (reactive — sized by the shared Alpine scope)
+			avatarDefaultPreview(),
+			`// Default Avatar (reactive — sized by the shared Alpine scope)
 @avatar.Avatar(avatar.Config{
     Src:      "/assets/images/avatars/avatar-8.webp",
-    Alt:      "John Doe",
+    Alt:      "Rounded avatar",
     Reactive: true,
-})
-
-// Bordered + status variants
-@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-primary", Reactive: true})
-@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusSuccess, Reactive: true})`,
+})`,
 		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = demo.DemoSection(
 			demo.DemoSectionProps{
-				Title:       "Initials",
-				Description: "Set Initials and a Variant for a colored monogram fallback.",
-			},
-			avatarInitialsPreview(),
-			`@avatar.Avatar(avatar.Config{Initials: "JD", Variant: avatar.Primary, Reactive: true})`,
-		).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = demo.DemoSection(
-			demo.DemoSectionProps{
-				Title:       "Icon Placeholder",
-				Description: "With neither Src nor Initials, the avatar shows a generic user icon in the Variant color.",
-			},
-			avatarIconPreview(),
-			`@avatar.Avatar(avatar.Config{Variant: avatar.Primary, Reactive: true})`,
-		).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = demo.DemoSection(
-			demo.DemoSectionProps{
-				Title:       "Status Indicator",
-				Description: "Set Status: StatusOffline, StatusInfo, StatusSuccess, StatusWarning, or StatusDanger for a corner presence dot.",
-			},
-			avatarStatusPreview(),
-			`@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusSuccess, Reactive: true})`,
-		).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = demo.DemoSection(
-			demo.DemoSectionProps{
-				Title:       "Square Shape",
-				Description: "Shape: avatar.ShapeSquare renders a rounded-square avatar instead of a circle.",
+				Title:        "Square Avatar",
+				Description:  "A square avatar in various sizes with an adjustable border radius.",
+				AbovePreview: avatarRadiusSelector(),
 			},
 			avatarSquarePreview(),
-			`@avatar.Avatar(avatar.Config{Initials: "SQ", Shape: avatar.ShapeSquare, Variant: avatar.Info, Reactive: true})`,
+			`@avatar.Avatar(avatar.Config{
+    Src:            "/assets/images/avatars/avatar-8.webp",
+    Alt:            "Square avatar",
+    Shape:          avatar.ShapeSquare,
+    Radius:         avatar.RadiusMD,
+    Reactive:       true,
+    ReactiveRadius: true,
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Avatar with Icon Placeholder",
+				Description: "An avatar in various colors with an icon placeholder.",
+			},
+			avatarIconPreview(),
+			`@avatar.Avatar(avatar.Config{Variant: avatar.Default, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Inverse, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Primary, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Secondary, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Info, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Success, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Warning, Reactive: true})
+@avatar.Avatar(avatar.Config{Variant: avatar.Danger, Reactive: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Avatar with Initials Placeholder",
+				Description: "An avatar in various colors with an initials placeholder.",
+			},
+			avatarInitialsPreview(),
+			`@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Default, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Inverse, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Primary, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Secondary, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Info, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Success, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Warning, Reactive: true})
+@avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Danger, Reactive: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Avatar with Border",
+				Description: "An avatar with a border in various colors.",
+			},
+			avatarBorderPreview(),
+			`@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-info", Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-success", Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-warning", Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Border: true, BorderColor: "border-danger", Reactive: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Avatar with Status Indicator",
+				Description: "An avatar with a status indicator in various colors.",
+			},
+			avatarStatusPreview(),
+			`@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusOffline, Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusInfo, Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusSuccess, Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusWarning, Reactive: true})
+@avatar.Avatar(avatar.Config{Src: "...", Status: avatar.StatusDanger, Reactive: true})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Stacked Avatars",
+				Description: "A stacked avatar group in various sizes.",
+			},
+			avatarStackedPreview(),
+			`@avatar.AvatarStack(avatar.StackConfig{
+    Label:    "Team members",
+    Reactive: true,
+    Items: []avatar.Config{
+        {Src: "/assets/images/avatars/avatar-8.webp", Alt: "Aiden Walker"},
+        {Src: "/assets/images/avatars/avatar-3.webp", Alt: "Emily Rodriguez"},
+        {Src: "/assets/images/avatars/avatar-5.webp", Alt: "Alex Martinez"},
+        {Src: "/assets/images/avatars/avatar-1.webp", Alt: "Bob Johnson"},
+    },
+})`,
 		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -238,12 +301,18 @@ func avatarDemoContent() templ.Component {
 			{Name: "Size", Type: "Size", Default: "SizeMD", Description: `Fixed size: "xs", "sm", "md", "lg", "xl", "2xl" (ignored when Reactive).`},
 			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Color for initials/icon: default, primary, secondary, info, success, warning, danger.`},
 			{Name: "Shape", Type: "Shape", Default: "ShapeCircle", Description: `Shape: "circle" or "square".`},
+			{Name: "Radius", Type: "Radius", Default: "RadiusDefault", Description: `Square-avatar radius: "none", "xs", "sm", "md", "lg".`},
 			{Name: "Border", Type: "bool", Default: "false", Description: "Add a ring border."},
 			{Name: "BorderColor", Type: "string", Default: `""`, Description: "Tailwind border color class for the ring."},
 			{Name: "Status", Type: "Status", Default: `""`, Description: `Presence dot: "offline", "info", "success", "warning", "danger".`},
 			{Name: "Icon", Type: "templ.Component", Default: "nil", Description: "Custom placeholder icon (overrides the default user icon)."},
 			{Name: "Reactive", Type: "bool", Default: "false", Description: "Read size classes from the parent Alpine scope (avatarSizeClass) instead of Size."},
+			{Name: "ReactiveRadius", Type: "bool", Default: "false", Description: "Read square radius classes from the parent Alpine scope (avatarRadiusClass)."},
 			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the avatar root."},
+			{Name: "StackConfig.Items", Type: "[]avatar.Config", Default: "nil", Description: "Avatar configs rendered as an overlapping group."},
+			{Name: "StackConfig.Label", Type: "string", Default: `"Avatar group"`, Description: "Accessible label for the stacked avatar group."},
+			{Name: "StackConfig.Class", Type: "string", Default: `""`, Description: "Extra classes on the stack root."},
+			{Name: "StackConfig.Reactive", Type: "bool", Default: "false", Description: "Apply the shared reactive size binding to every stack item."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -353,8 +422,8 @@ func avatarSizeSelector() templ.Component {
 	})
 }
 
-// sizeOption renders a single segmented pill for the size selector.
-func sizeOption(value, label string) templ.Component {
+// avatarRadiusSelector renders the square-avatar radius segmented control.
+func avatarRadiusSelector() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -375,6 +444,94 @@ func sizeOption(value, label string) templ.Component {
 			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"mb-3 flex flex-wrap items-center gap-4\"><label class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Border Radius</label><div data-testid=\"avatar-radius-selector\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = avatarRadiusOption("none", "none").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = avatarRadiusOption("xs", "xs").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = avatarRadiusOption("sm", "sm").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = avatarRadiusOption("md", "md").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = avatarRadiusOption("lg", "lg").Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = radio.RadioBar().Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div><span class=\"sr-only\" data-testid=\"avatar-radius-selected\" x-text=\"radius\"></span></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// sizeOption renders a single segmented pill for the size selector.
+func sizeOption(value, label string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = radio.Radio(radio.Config{
 			ID:        "avatar-size-" + value,
 			Name:      "avatar-size",
@@ -393,8 +550,8 @@ func sizeOption(value, label string) templ.Component {
 	})
 }
 
-// avatarImagePreview renders the reactive image avatars (default ComponentDemo box).
-func avatarImagePreview() templ.Component {
+// avatarRadiusOption renders a single segmented pill for the radius selector.
+func avatarRadiusOption(value, label string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -410,52 +567,64 @@ func avatarImagePreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"avatar-image\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-image\">")
+		templ_7745c5c3_Err = radio.Radio(radio.Config{
+			ID:        "avatar-radius-" + value,
+			Name:      "avatar-radius",
+			Value:     value,
+			Label:     label,
+			Segmented: true,
+			Alpine: &radio.AlpineConfig{
+				BindChecked: "radius === '" + value + "'",
+				OnChange:    "radius = '" + value + "'",
+			},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// avatarDefaultPreview renders the reactive default image avatar.
+func avatarDefaultPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"avatar-image\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-image\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{
 			Src:      "/assets/images/avatars/avatar-8.webp",
-			Alt:      "User Avatar",
+			Alt:      "Rounded avatar",
 			Reactive: true,
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{
-			Src:         "/assets/images/avatars/avatar-8.webp",
-			Alt:         "User Avatar with border",
-			Border:      true,
-			BorderColor: "border-primary",
-			Reactive:    true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{
-			Src:      "/assets/images/avatars/avatar-8.webp",
-			Alt:      "User with Status",
-			Status:   avatar.StatusSuccess,
-			Reactive: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{
-			Src:      "/assets/images/avatars/avatar-8.webp",
-			Alt:      "User Offline",
-			Status:   avatar.StatusOffline,
-			Reactive: true,
-		}).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -480,44 +649,48 @@ func avatarInitialsPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"avatar-initials\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-initials\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div id=\"avatar-initials\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-initials\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "JD", Variant: avatar.Default, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Default, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "AB", Variant: avatar.Primary, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Inverse, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "CD", Variant: avatar.Secondary, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Primary, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "EF", Variant: avatar.Info, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Secondary, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "GH", Variant: avatar.Success, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Info, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "IJ", Variant: avatar.Warning, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Success, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "KL", Variant: avatar.Danger, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Warning, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div></div>")
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "JS", Variant: avatar.Danger, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -542,12 +715,12 @@ func avatarIconPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"avatar-icon\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div id=\"avatar-icon\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-icon\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -555,7 +728,15 @@ func avatarIconPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Variant: avatar.Inverse, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Variant: avatar.Primary, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Variant: avatar.Secondary, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -563,7 +744,69 @@ func avatarIconPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div></div>")
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Variant: avatar.Success, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Variant: avatar.Warning, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Variant: avatar.Danger, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// avatarBorderPreview renders image avatars with semantic border colors.
+func avatarBorderPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div id=\"avatar-border\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-border\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Info border avatar", Border: true, BorderColor: "border-info", Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Success border avatar", Border: true, BorderColor: "border-success", Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Warning border avatar", Border: true, BorderColor: "border-warning", Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Danger border avatar", Border: true, BorderColor: "border-danger", Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -588,12 +831,12 @@ func avatarStatusPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var10 == nil {
-			templ_7745c5c3_Var10 = templ.NopComponent
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"avatar-status\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-status\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<div id=\"avatar-status\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-status\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -617,7 +860,7 @@ func avatarStatusPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -642,28 +885,74 @@ func avatarSquarePreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var11 == nil {
-			templ_7745c5c3_Var11 = templ.NopComponent
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div id=\"avatar-square\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-square\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div id=\"avatar-square\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex flex-wrap items-center justify-center gap-4\" data-testid=\"avatar-section-square\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "SQ", Variant: avatar.Info, Shape: avatar.ShapeSquare, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{
+			Src:            "/assets/images/avatars/avatar-8.webp",
+			Alt:            "Square avatar",
+			Shape:          avatar.ShapeSquare,
+			Radius:         avatar.RadiusMD,
+			Reactive:       true,
+			ReactiveRadius: true,
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Square", Shape: avatar.ShapeSquare, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = avatar.Avatar(avatar.Config{Initials: "SQ", Variant: avatar.Success, Shape: avatar.ShapeSquare, Status: avatar.StatusSuccess, Reactive: true}).Render(ctx, templ_7745c5c3_Buffer)
+		return nil
+	})
+}
+
+// avatarStackedPreview renders a stacked group of image avatars.
+func avatarStackedPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var16 == nil {
+			templ_7745c5c3_Var16 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div id=\"avatar-stacked\" class=\"w-full max-w-2xl mx-auto\"><div class=\"flex items-center justify-center\" data-testid=\"avatar-section-stacked\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div></div>")
+		templ_7745c5c3_Err = avatar.AvatarStack(avatar.StackConfig{
+			Label:    "Team members",
+			Reactive: true,
+			Items: []avatar.Config{
+				{Src: "/assets/images/avatars/avatar-8.webp", Alt: "Aiden Walker"},
+				{Src: "/assets/images/avatars/avatar-3.webp", Alt: "Emily Rodriguez"},
+				{Src: "/assets/images/avatars/avatar-5.webp", Alt: "Alex Martinez"},
+				{Src: "/assets/images/avatars/avatar-1.webp", Alt: "Bob Johnson"},
+			},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -689,12 +978,12 @@ func avatarFixturesPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var12 == nil {
-			templ_7745c5c3_Var12 = templ.NopComponent
+		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var17 == nil {
+			templ_7745c5c3_Var17 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div id=\"avatar-fixtures\" class=\"w-full max-w-2xl mx-auto\" data-testid=\"avatar-e2e-fixtures\"><div class=\"flex flex-wrap items-center justify-center gap-4\"><div data-testid=\"avatar-test-loaded\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div id=\"avatar-fixtures\" class=\"w-full max-w-2xl mx-auto\" data-testid=\"avatar-e2e-fixtures\"><div class=\"flex flex-wrap items-center justify-center gap-4\"><div data-testid=\"avatar-test-loaded\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -708,7 +997,7 @@ func avatarFixturesPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</div><div data-testid=\"avatar-test-error\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div><div data-testid=\"avatar-test-error\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -722,7 +1011,7 @@ func avatarFixturesPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div><div data-testid=\"avatar-test-initials\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div><div data-testid=\"avatar-test-initials\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -734,7 +1023,7 @@ func avatarFixturesPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/tests/e2e/avatar_test.go
+++ b/site/tests/e2e/avatar_test.go
@@ -260,6 +260,59 @@ func TestAvatar_SizeSelector_DrivesReactiveAvatars(t *testing.T) {
 	assert.Equal(t, "xs", txt)
 }
 
+// TestAvatar_RadiusSelector_DrivesSquareAvatar verifies the PenguinUI-style
+// square avatar radius selector updates the reactive square preview.
+func TestAvatar_RadiusSelector_DrivesSquareAvatar(t *testing.T) {
+	page := newPage(t, sharedBrowser)
+	navigateToAvatarDemo(t, page)
+
+	require.NoError(t, page.Locator("label[for='avatar-radius-none']").Click())
+	_, err := page.WaitForFunction(
+		`() => {
+			const root = document.querySelector("[data-testid='avatar-section-square'] .relative.inline-flex");
+			return root && (root.getAttribute('class') || '').includes('rounded-none');
+		}`,
+		nil,
+		playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)},
+	)
+	require.NoError(t, err, "after clicking none, square avatar root should carry rounded-none")
+
+	require.NoError(t, page.Locator("label[for='avatar-radius-lg']").Click())
+	_, err = page.WaitForFunction(
+		`() => {
+			const root = document.querySelector("[data-testid='avatar-section-square'] .relative.inline-flex");
+			return root && (root.getAttribute('class') || '').includes('rounded-lg');
+		}`,
+		nil,
+		playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)},
+	)
+	require.NoError(t, err, "after clicking lg, square avatar root should carry rounded-lg")
+}
+
+func TestAvatar_StackedAvatars_RenderOverlappedGroup(t *testing.T) {
+	page := newPage(t, sharedBrowser)
+	navigateToAvatarDemo(t, page)
+
+	stack := page.Locator("[data-testid='avatar-section-stacked'] [role='list']")
+	require.NoError(t, stack.WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateAttached,
+		Timeout: playwright.Float(3000),
+	}))
+
+	label, err := stack.GetAttribute("aria-label")
+	require.NoError(t, err)
+	assert.Equal(t, "Team members", label)
+
+	count, err := stack.Locator("[role='listitem']").Count()
+	require.NoError(t, err)
+	assert.Equal(t, 4, count)
+
+	cls, err := stack.Locator("[role='listitem']").Nth(1).Locator(".relative.inline-flex").GetAttribute("class")
+	require.NoError(t, err)
+	assert.Contains(t, cls, "-ml-3")
+	assert.Contains(t, cls, "ring-2")
+}
+
 // TestAvatar_SizeSelector_FixturesUnchanged verifies that the E2E test fixtures
 // section stays at fixed SizeMD even when the selector changes.
 func TestAvatar_SizeSelector_FixturesUnchanged(t *testing.T) {


### PR DESCRIPTION
## Summary
- expand the avatar docs to follow PenguinUI sections for default, square, placeholders, borders, status, and stacked avatars
- add square radius controls, reactive radius binding, border rendering fixes, and first-class AvatarStack support
- add avatar unit and E2E coverage for border, radius, stacked, and image load/error behavior

## Test Plan
- `go test ./...`
- `cd site && go test ./internal/...`
- `go build -o bin/server ./site/cmd/server`
- `golangci-lint run`
- `cd site && golangci-lint run`
- `cd site && go test ./tests/e2e/... -count=1 -timeout 15m`
