### PR TITLE
docs(textinput): add live pattern feedback

### DIFF
--- a/site/internal/pages/demo/components/textinput.templ
+++ b/site/internal/pages/demo/components/textinput.templ
@@ -118,14 +118,20 @@ templ textInputDemoContent() {
 		@demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Pattern Validation",
-				Description: "Pattern sets the HTML pattern attribute for native regex validation on submit.",
+				Description: "Pattern sets the HTML pattern attribute; pair it with input events when you want live native-validity feedback.",
 			},
 			textInputPatternPreview(),
 			`@textinput.TextInput(textinput.Config{
     ID: "cluster", Name: "cluster_id", Label: "Cluster ID",
     Placeholder: "tabc123",
     Pattern:     "t[a-z0-9]{6}",
-    HelperText:  "Must match: t[a-z0-9]{6}",
+    Attrs: templ.Attributes{
+        "x-on:input": "touched = true; valid = $event.target.checkValidity()",
+        "x-on:blur":  "touched = true; valid = $event.target.checkValidity()",
+        "x-bind:class": "touched ? (valid ? 'border-success' : 'border-danger') : ''",
+        "x-bind:aria-invalid": "touched && !valid ? 'true' : 'false'",
+        "aria-describedby": "patternInput-feedback",
+    },
 })`,
 		)
 
@@ -265,15 +271,32 @@ templ textInputReadonlyPreview() {
 
 // textInputPatternPreview renders the pattern-validated input.
 templ textInputPatternPreview() {
-	<div id="textinput-pattern" class="w-full max-w-sm mx-auto">
+	<div
+		id="textinput-pattern"
+		class="w-full max-w-sm mx-auto"
+		x-data="{ touched: false, valid: false, message() { if (!this.touched) return 'Try tabc123'; return this.valid ? 'Looks good' : 'Needs a leading t plus 6 lowercase letters or numbers'; } }"
+	>
 		@textinput.TextInput(textinput.Config{
 			ID:          "patternInput",
 			Name:        "cluster_id",
 			Label:       "Cluster ID",
 			Placeholder: "tabc123",
 			Pattern:     "t[a-z0-9]{6}",
-			HelperText:  "Must match: t[a-z0-9]{6}",
+			Attrs: templ.Attributes{
+				"x-on:input":           "touched = true; valid = $event.target.checkValidity()",
+				"x-on:blur":            "touched = true; valid = $event.target.checkValidity()",
+				"x-bind:class":         "touched ? (valid ? 'border-success' : 'border-danger') : ''",
+				"x-bind:aria-invalid":  "touched && !valid ? 'true' : 'false'",
+				"aria-describedby":     "patternInput-feedback",
+			},
 		})
+		<small
+			id="patternInput-feedback"
+			class="mt-1 block pl-0.5 text-xs text-on-surface/60 dark:text-on-surface-dark/60"
+			x-text="message()"
+			x-bind:class="touched ? (valid ? 'text-success' : 'text-danger') : 'text-on-surface/60 dark:text-on-surface-dark/60'"
+			aria-live="polite"
+		></small>
 	</div>
 }
 

--- a/site/internal/pages/demo/components/textinput_templ.go
+++ b/site/internal/pages/demo/components/textinput_templ.go
@@ -188,14 +188,20 @@ func textInputDemoContent() templ.Component {
 		templ_7745c5c3_Err = demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Pattern Validation",
-				Description: "Pattern sets the HTML pattern attribute for native regex validation on submit.",
+				Description: "Pattern sets the HTML pattern attribute; pair it with input events when you want live native-validity feedback.",
 			},
 			textInputPatternPreview(),
 			`@textinput.TextInput(textinput.Config{
     ID: "cluster", Name: "cluster_id", Label: "Cluster ID",
     Placeholder: "tabc123",
     Pattern:     "t[a-z0-9]{6}",
-    HelperText:  "Must match: t[a-z0-9]{6}",
+    Attrs: templ.Attributes{
+        "x-on:input": "touched = true; valid = $event.target.checkValidity()",
+        "x-on:blur":  "touched = true; valid = $event.target.checkValidity()",
+        "x-bind:class": "touched ? (valid ? 'border-success' : 'border-danger') : ''",
+        "x-bind:aria-invalid": "touched && !valid ? 'true' : 'false'",
+        "aria-describedby": "patternInput-feedback",
+    },
 })`,
 		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
@@ -585,7 +591,7 @@ func textInputPatternPreview() templ.Component {
 			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"textinput-pattern\" class=\"w-full max-w-sm mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"textinput-pattern\" class=\"w-full max-w-sm mx-auto\" x-data=\"{ touched: false, valid: false, message() { if (!this.touched) return 'Try tabc123'; return this.valid ? 'Looks good' : 'Needs a leading t plus 6 lowercase letters or numbers'; } }\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -595,12 +601,18 @@ func textInputPatternPreview() templ.Component {
 			Label:       "Cluster ID",
 			Placeholder: "tabc123",
 			Pattern:     "t[a-z0-9]{6}",
-			HelperText:  "Must match: t[a-z0-9]{6}",
+			Attrs: templ.Attributes{
+				"x-on:input":          "touched = true; valid = $event.target.checkValidity()",
+				"x-on:blur":           "touched = true; valid = $event.target.checkValidity()",
+				"x-bind:class":        "touched ? (valid ? 'border-success' : 'border-danger') : ''",
+				"x-bind:aria-invalid": "touched && !valid ? 'true' : 'false'",
+				"aria-describedby":    "patternInput-feedback",
+			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<small id=\"patternInput-feedback\" class=\"mt-1 block pl-0.5 text-xs text-on-surface/60 dark:text-on-surface-dark/60\" x-text=\"message()\" x-bind:class=\"touched ? (valid ? 'text-success' : 'text-danger') : 'text-on-surface/60 dark:text-on-surface-dark/60'\" aria-live=\"polite\"></small></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/tests/e2e/textinput_attrs_test.go
+++ b/site/tests/e2e/textinput_attrs_test.go
@@ -72,6 +72,46 @@ func TestTextInput_PatternAttribute(t *testing.T) {
 	assert.Equal(t, "t[a-z0-9]{6}", pattern)
 }
 
+func TestTextInput_PatternValidationFeedback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/text-input", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	_, err = page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+	require.NoError(t, err)
+
+	input := page.Locator("#patternInput")
+	require.NoError(t, input.WaitFor())
+	feedback := page.Locator("#patternInput-feedback")
+
+	require.NoError(t, input.PressSequentially("fasds"))
+	require.NoError(t, feedback.WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+	text, err := feedback.TextContent()
+	require.NoError(t, err)
+	assert.Contains(t, text, "Needs a leading t plus 6 lowercase letters or numbers")
+
+	require.NoError(t, input.Fill(""))
+	require.NoError(t, input.PressSequentially("tabc123"))
+	text, err = feedback.TextContent()
+	require.NoError(t, err)
+	assert.Contains(t, text, "Looks good")
+	valid, err := input.Evaluate("el => el.checkValidity()", nil)
+	require.NoError(t, err)
+	assert.Equal(t, true, valid)
+}
+
 func TestTextInput_MaxLengthAttribute(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping E2E test in short mode")


### PR DESCRIPTION
## Summary
- Make the Text Input pattern-validation demo respond while users type.
- Use native checkValidity() through demo-level Alpine attrs without changing the component API.
- Add E2E coverage for invalid and valid pattern feedback.

## Test Plan
- go test ./...
- cd site && go test ./...
- go build -o bin/server ./site/cmd/server