### PR TITLE
fix(form): confirm external submit with toast

### DIFF
--- a/site/internal/pages/demo/components/form.templ
+++ b/site/internal/pages/demo/components/form.templ
@@ -3,9 +3,11 @@ package components
 import (
 	"github.com/araihu/goshtoso/components/form"
 	gocombobox "github.com/araihu/goshtoso/components/combobox"
+	"github.com/araihu/goshtoso/components/modal"
 	"github.com/araihu/goshtoso/components/tagslist"
 	"github.com/araihu/goshtoso/components/textarea"
 	"github.com/araihu/goshtoso/components/textinput"
+	"github.com/araihu/goshtoso/components/toast"
 	"github.com/araihu/goshtoso/components/toggle"
 	"github.com/araihu/goshtoso/site/internal/pages/demo"
 )
@@ -50,10 +52,26 @@ templ formDemoContent() {
 				Description: "Render the form with no Footer; a button outside the form uses the form=\"...\" attribute to submit it — the typical modal pattern.",
 			},
 			formExternalPreview(),
-			`@form.Form(form.Config{ID: "external-form", Action: "#"}) {
+			`@form.Form(form.Config{
+    ID: "external-form",
+    HTMX: &form.HTMXConfig{
+        Post: "/api/components/form/external-submit",
+        Swap: "none",
+    },
+}) {
     @form.Section(form.SectionConfig{Title: "Upgrade"}) { ... }
 }
-<button type="submit" form="external-form">Upgrade (External Button)</button>`,
+@modal.Modal(modal.Config{
+    ID:            "externalSubmitConfirm",
+    Title:         "Confirm upgrade",
+    TriggerText:   "Upgrade (External Button)",
+    PrimaryText:   "Confirm upgrade",
+    SecondaryText: "Cancel",
+    PrimaryAction: &modal.ButtonAction{
+        OnClick: "document.getElementById('external-form').requestSubmit()",
+    },
+})
+@toast.Container(toast.ContainerConfig{})`,
 		)
 	</div>
 	// API reference lives outside #form-fragment.
@@ -100,9 +118,25 @@ var formDemoCode = `// Built-in field types — set Input, Combobox, Textarea, T
     })
 }
 
-// External submit (modal pattern — no footer, button uses form="..." attribute)
-@form.Form(form.Config{ID: "modal-form", HTMX: &form.HTMXConfig{Post: "/api", Swap: "none"}}) { ... }
-<button type="submit" form="modal-form">Submit</button>`
+// External submit (modal pattern — no footer, modal confirmation calls requestSubmit)
+@form.Form(form.Config{
+    ID: "modal-form",
+    HTMX: &form.HTMXConfig{
+        Post: "/api/submit",
+        Swap: "none",
+    },
+}) { ... }
+@modal.Modal(modal.Config{
+    ID:            "modalSubmitConfirm",
+    Title:         "Confirm submit",
+    TriggerText:   "Submit",
+    PrimaryText:   "Confirm submit",
+    SecondaryText: "Cancel",
+    PrimaryAction: &modal.ButtonAction{
+        OnClick: "document.getElementById('modal-form').requestSubmit()",
+    },
+})
+@toast.Container(toast.ContainerConfig{})`
 
 // formCompletePreview renders the full composable form.
 templ formCompletePreview() {
@@ -339,8 +373,11 @@ templ formExternalPreview() {
 	<div id="form-external" class="w-full max-w-2xl mx-auto">
 		<div class="flex flex-col gap-4">
 				@form.Form(form.Config{
-					ID:     "external-form",
-					Action: "#",
+					ID: "external-form",
+					HTMX: &form.HTMXConfig{
+						Post: "/api/components/form/external-submit",
+						Swap: "none",
+					},
 				}) {
 					@form.Section(form.SectionConfig{Title: "Upgrade"}) {
 						@form.FieldGroup(form.FieldGroupConfig{
@@ -361,14 +398,19 @@ templ formExternalPreview() {
 				}
 				<!-- External button -->
 				<div class="flex justify-end">
-					<button
-						type="submit"
-						form="external-form"
-						class="inline-flex items-center justify-center px-6 py-2.5 rounded-radius text-sm font-medium text-on-primary dark:text-on-primary-dark bg-primary dark:bg-primary-dark border border-primary dark:border-primary-dark hover:opacity-75 transition"
-					>
-						Upgrade (External Button)
-					</button>
+					@modal.Modal(modal.Config{
+						ID:            "externalSubmitConfirm",
+						Title:         "Confirm upgrade",
+						Body:          "Submit the upgrade request with the selected target version.",
+						TriggerText:   "Upgrade (External Button)",
+						PrimaryText:   "Confirm upgrade",
+						SecondaryText: "Cancel",
+						PrimaryAction: &modal.ButtonAction{
+							OnClick: "document.getElementById('external-form').requestSubmit()",
+						},
+					})
 				</div>
+				@toast.Container(toast.ContainerConfig{})
 			</div>
 		</div>
 }

--- a/site/internal/pages/demo/components/form_templ.go
+++ b/site/internal/pages/demo/components/form_templ.go
@@ -11,9 +11,11 @@ import templruntime "github.com/a-h/templ/runtime"
 import (
 	gocombobox "github.com/araihu/goshtoso/components/combobox"
 	"github.com/araihu/goshtoso/components/form"
+	"github.com/araihu/goshtoso/components/modal"
 	"github.com/araihu/goshtoso/components/tagslist"
 	"github.com/araihu/goshtoso/components/textarea"
 	"github.com/araihu/goshtoso/components/textinput"
+	"github.com/araihu/goshtoso/components/toast"
 	"github.com/araihu/goshtoso/components/toggle"
 	"github.com/araihu/goshtoso/site/internal/pages/demo"
 )
@@ -110,10 +112,26 @@ func formDemoContent() templ.Component {
 				Description: "Render the form with no Footer; a button outside the form uses the form=\"...\" attribute to submit it — the typical modal pattern.",
 			},
 			formExternalPreview(),
-			`@form.Form(form.Config{ID: "external-form", Action: "#"}) {
+			`@form.Form(form.Config{
+    ID: "external-form",
+    HTMX: &form.HTMXConfig{
+        Post: "/api/components/form/external-submit",
+        Swap: "none",
+    },
+}) {
     @form.Section(form.SectionConfig{Title: "Upgrade"}) { ... }
 }
-<button type="submit" form="external-form">Upgrade (External Button)</button>`,
+@modal.Modal(modal.Config{
+    ID:            "externalSubmitConfirm",
+    Title:         "Confirm upgrade",
+    TriggerText:   "Upgrade (External Button)",
+    PrimaryText:   "Confirm upgrade",
+    SecondaryText: "Cancel",
+    PrimaryAction: &modal.ButtonAction{
+        OnClick: "document.getElementById('external-form').requestSubmit()",
+    },
+})
+@toast.Container(toast.ContainerConfig{})`,
 		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -170,9 +188,25 @@ var formDemoCode = `// Built-in field types — set Input, Combobox, Textarea, T
     })
 }
 
-// External submit (modal pattern — no footer, button uses form="..." attribute)
-@form.Form(form.Config{ID: "modal-form", HTMX: &form.HTMXConfig{Post: "/api", Swap: "none"}}) { ... }
-<button type="submit" form="modal-form">Submit</button>`
+// External submit (modal pattern — no footer, modal confirmation calls requestSubmit)
+@form.Form(form.Config{
+    ID: "modal-form",
+    HTMX: &form.HTMXConfig{
+        Post: "/api/submit",
+        Swap: "none",
+    },
+}) { ... }
+@modal.Modal(modal.Config{
+    ID:            "modalSubmitConfirm",
+    Title:         "Confirm submit",
+    TriggerText:   "Submit",
+    PrimaryText:   "Confirm submit",
+    SecondaryText: "Cancel",
+    PrimaryAction: &modal.ButtonAction{
+        OnClick: "document.getElementById('modal-form').requestSubmit()",
+    },
+})
+@toast.Container(toast.ContainerConfig{})`
 
 // formCompletePreview renders the full composable form.
 func formCompletePreview() templ.Component {
@@ -781,13 +815,42 @@ func formExternalPreview() templ.Component {
 			return nil
 		})
 		templ_7745c5c3_Err = form.Form(form.Config{
-			ID:     "external-form",
-			Action: "#",
+			ID: "external-form",
+			HTMX: &form.HTMXConfig{
+				Post: "/api/components/form/external-submit",
+				Swap: "none",
+			},
 		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<!-- External button --><div class=\"flex justify-end\"><button type=\"submit\" form=\"external-form\" class=\"inline-flex items-center justify-center px-6 py-2.5 rounded-radius text-sm font-medium text-on-primary dark:text-on-primary-dark bg-primary dark:bg-primary-dark border border-primary dark:border-primary-dark hover:opacity-75 transition\">Upgrade (External Button)</button></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<!-- External button --><div class=\"flex justify-end\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = modal.Modal(modal.Config{
+			ID:            "externalSubmitConfirm",
+			Title:         "Confirm upgrade",
+			Body:          "Submit the upgrade request with the selected target version.",
+			TriggerText:   "Upgrade (External Button)",
+			PrimaryText:   "Confirm upgrade",
+			SecondaryText: "Cancel",
+			PrimaryAction: &modal.ButtonAction{
+				OnClick: "document.getElementById('external-form').requestSubmit()",
+			},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = toast.Container(toast.ContainerConfig{}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -817,7 +880,7 @@ func networkReadView() templ.Component {
 			templ_7745c5c3_Var17 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div class=\"grid grid-cols-1 md:grid-cols-2 gap-4\"><div class=\"flex flex-col gap-1\"><span class=\"text-xs font-medium text-on-surface-muted dark:text-on-surface-dark-muted uppercase tracking-wider\">Pod Subnet CIDR</span> <span class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">10.244.0.0/16</span></div><div class=\"flex flex-col gap-1\"><span class=\"text-xs font-medium text-on-surface-muted dark:text-on-surface-dark-muted uppercase tracking-wider\">Service Subnet CIDR</span> <span class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">10.96.0.0/12</span></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<div class=\"grid grid-cols-1 md:grid-cols-2 gap-4\"><div class=\"flex flex-col gap-1\"><span class=\"text-xs font-medium text-on-surface-muted dark:text-on-surface-dark-muted uppercase tracking-wider\">Pod Subnet CIDR</span> <span class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">10.244.0.0/16</span></div><div class=\"flex flex-col gap-1\"><span class=\"text-xs font-medium text-on-surface-muted dark:text-on-surface-dark-muted uppercase tracking-wider\">Service Subnet CIDR</span> <span class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">10.96.0.0/12</span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/server/server.go
+++ b/site/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/araihu/goshtoso/components/carousel"
 	combobox "github.com/araihu/goshtoso/components/combobox"
+	"github.com/araihu/goshtoso/components/toast"
 	"github.com/araihu/goshtoso/site/internal/examples/ticker"
 	"github.com/araihu/goshtoso/site/internal/pages/demo"
 	"github.com/araihu/goshtoso/site/internal/pages/demo/components"
@@ -91,6 +92,7 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("/api/components/table/rows", s.handleTableRows)
 	s.mux.HandleFunc("/api/components/toast", s.handleToastOOB)
 	s.mux.HandleFunc("/api/components/carousel/slides", s.handleCarouselSlides)
+	s.mux.HandleFunc("/api/components/form/external-submit", s.handleFormExternalSubmit)
 	s.mux.HandleFunc("/api/components/form-validation", s.handleFormValidation)
 	s.mux.HandleFunc("/api/components/steps/demo", s.handleStepsDemo)
 	s.mux.HandleFunc("/api/components/radio/echo", s.handleRadioEcho)
@@ -198,6 +200,26 @@ func htmlEscape(s string) string {
 func (s *Server) handleAPIHello(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 	_, _ = fmt.Fprintf(w, `<p class="text-green-600">Hello from HTMX! Request received at %s %s</p>`, r.Method, r.URL.Path)
+}
+
+func (s *Server) handleFormExternalSubmit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	version := r.FormValue("version")
+	if version == "" {
+		version = "selected version"
+	} else {
+		version = "v" + version
+	}
+	_ = toast.OOBToast(toast.Config{
+		Variant: toast.Success,
+		Title:   "Upgrade request submitted",
+		Message: fmt.Sprintf("Target version: %s", version),
+	}).Render(r.Context(), w)
 }
 
 func (s *Server) handleStepsDemo(w http.ResponseWriter, r *http.Request) {

--- a/site/tests/e2e/form_demo_test.go
+++ b/site/tests/e2e/form_demo_test.go
@@ -1,0 +1,54 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormDemoExternalSubmitUsesModalConfirmation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newPage(t, sharedBrowser)
+	_, err := page.Goto(baseURL+"/components/form", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+
+	_, err = page.Evaluate(`() => {
+		window.externalFormSubmitCount = 0;
+		const form = document.querySelector('#external-form');
+		form.addEventListener('submit', () => { window.externalFormSubmitCount += 1; });
+	}`)
+	require.NoError(t, err)
+	initialURL := page.URL()
+
+	require.NoError(t, page.GetByRole("button", playwright.PageGetByRoleOptions{
+		Name: "Upgrade (External Button)",
+	}).Click())
+
+	count, err := page.Evaluate(`() => String(window.externalFormSubmitCount)`)
+	require.NoError(t, err)
+	require.Equal(t, "0", count, "opening the modal must not submit the form")
+
+	dialog := page.Locator("[role='dialog'][aria-labelledby='externalSubmitConfirmTitle']")
+	require.NoError(t, dialog.WaitFor())
+	require.NoError(t, dialog.GetByRole("button", playwright.LocatorGetByRoleOptions{
+		Name: "Confirm upgrade",
+	}).Click())
+
+	_, err = page.WaitForFunction(`() => window.externalFormSubmitCount === 1`, nil)
+	require.NoError(t, err)
+
+	toast := page.Locator("#toast-container [data-toast-id]", playwright.PageLocatorOptions{
+		HasText: "Upgrade request submitted",
+	})
+	require.NoError(t, toast.WaitFor())
+	text, err := toast.InnerText()
+	require.NoError(t, err)
+	require.Contains(t, text, "v1.31.5")
+	require.Equal(t, initialURL, page.URL(), "HTMX submit should not reload or navigate the page")
+}


### PR DESCRIPTION
## Summary
- updates the form docs external-submit example to open a modal before submitting
- submits via HTMX with `hx-swap=none` and renders success feedback through `toast.OOBToast`
- adds an E2E regression for the modal confirmation and toast feedback flow

## Test Plan
- [x] `go test ./...`
- [x] `cd site && go test ./...`
- [x] `cd site && go build -o bin/server ./cmd/server`
- [x] `git diff --check`