### PR TITLE
refactor(combobox): make current implementation canonical

### DIFF
--- a/.agents/skills/using-goshtoso/SKILL.md
+++ b/.agents/skills/using-goshtoso/SKILL.md
@@ -175,8 +175,7 @@ fails). For depth, use the `templ` and `htmx` skills. The rules:
 **The full catalog — every package, entry point, config struct, field, and enum
 — lives in [`components-reference.md`](components-reference.md), generated from
 the `components/` source.** Read it to look up any component. It covers every
-public package under `components/`, including nested ones (e.g. `combobox/v2`,
-whose package is `v2` → `@v2.Combobox(...)`).
+public package under `components/`, including nested component packages.
 
 The **table** is the most complex: sortable columns, HTMX OOB-swap pagination,
 filter bar/inline variants, infinite scroll. Its HTMX endpoint contract is

--- a/.claude/skills/using-goshtoso/SKILL.md
+++ b/.claude/skills/using-goshtoso/SKILL.md
@@ -175,8 +175,7 @@ fails). For depth, use the `templ` and `htmx` skills. The rules:
 **The full catalog — every package, entry point, config struct, field, and enum
 — lives in [`components-reference.md`](components-reference.md), generated from
 the `components/` source.** Read it to look up any component. It covers every
-public package under `components/`, including nested ones (e.g. `combobox/v2`,
-whose package is `v2` → `@v2.Combobox(...)`).
+public package under `components/`, including nested component packages.
 
 The **table** is the most complex: sortable columns, HTMX OOB-swap pagination,
 filter bar/inline variants, infinite scroll. Its HTMX endpoint contract is

--- a/components/combobox/body_test.go
+++ b/components/combobox/body_test.go
@@ -297,7 +297,7 @@ func TestCombobox_ClientMode_EmitsScript(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, Combobox(cfg, State{Options: cfg.Source.Static}).Render(context.Background(), &buf))
 	html := buf.String()
-	assert.Contains(t, html, `__goshtosoComboboxV2Init`, "listener script inlined")
+	assert.Contains(t, html, `__goshtosoComboboxInit`, "listener script inlined")
 }
 
 func TestCombobox_ServerMode_NoScript(t *testing.T) {
@@ -308,7 +308,7 @@ func TestCombobox_ServerMode_NoScript(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	require.NoError(t, Combobox(cfg, State{Options: []Option{{Value: "red"}}}).Render(context.Background(), &buf))
-	assert.NotContains(t, buf.String(), `__goshtosoComboboxV2Init`)
+	assert.NotContains(t, buf.String(), `__goshtosoComboboxInit`)
 }
 
 func TestOptionsList_DisabledOption_OmitsHXPost(t *testing.T) {

--- a/components/combobox/client.go
+++ b/components/combobox/client.go
@@ -16,7 +16,7 @@ var clientJS string
 // updates.
 //
 // The listener itself (emitted by ClientScript) is safe to render repeatedly —
-// a module-init guard (window.__goshtosoComboboxV2Init) prevents double-binding.
+// a module-init guard (window.__goshtosoComboboxInit) prevents double-binding.
 // ClientScript is emitted automatically by Combobox when cfg.IsClientMode() is
 // true; consumers rarely need to call it directly.
 const ClientEvent = "combobox:change"

--- a/components/combobox/client.js
+++ b/components/combobox/client.js
@@ -1,6 +1,6 @@
 (function () {
-  if (window.__goshtosoComboboxV2Init) return;
-  window.__goshtosoComboboxV2Init = true;
+  if (window.__goshtosoComboboxInit) return;
+  window.__goshtosoComboboxInit = true;
 
   function clientRoot(target) {
     if (!target || !target.closest) return null;
@@ -23,7 +23,7 @@
   }
 
   function storageKey(cfg) {
-    return 'goshtoso:combobox:v2:' + cfg.id + ':selected';
+    return 'goshtoso:combobox:' + cfg.id + ':selected';
   }
 
   function saveSelected(cfg, selected) {

--- a/components/combobox/combobox.templ
+++ b/components/combobox/combobox.templ
@@ -163,7 +163,7 @@ templ optionCheckbox(selected bool) {
 	<div class="relative flex shrink-0 items-center">
 		<input
 			type="checkbox"
-			class="peer relative size-4 appearance-none overflow-hidden rounded-sm border border-outline bg-surface-alt before:absolute before:inset-0 before:content-[''] checked:border-primary checked:before:bg-primary focus:outline-2 focus:outline-offset-2 focus:outline-outline-strong checked:focus:outline-primary active:outline-offset-0 dark:border-outline-dark dark:bg-surface-dark-alt dark:checked:border-primary-dark dark:checked:before:bg-primary-dark"
+			class="peer pointer-events-none relative size-4 appearance-none overflow-hidden rounded-sm border border-outline bg-surface-alt before:absolute before:inset-0 before:content-[''] checked:border-primary checked:before:bg-primary focus:outline-2 focus:outline-offset-2 focus:outline-outline-strong checked:focus:outline-primary active:outline-offset-0 dark:border-outline-dark dark:bg-surface-dark-alt dark:checked:border-primary-dark dark:checked:before:bg-primary-dark"
 			checked?={ selected }
 			tabindex="-1"
 		/>
@@ -174,7 +174,7 @@ templ optionCheckbox(selected bool) {
 }
 
 // ClientScript emits the delegated client-side listener as an inline script.
-// The IIFE guard (window.__goshtosoComboboxV2Init) makes repeated renders safe.
+// The IIFE guard (window.__goshtosoComboboxInit) makes repeated renders safe.
 templ ClientScript() {
 	@templ.Raw("<script>" + clientJS + "</script>")
 }

--- a/components/combobox/combobox_templ.go
+++ b/components/combobox/combobox_templ.go
@@ -686,7 +686,7 @@ func optionCheckbox(selected bool) templ.Component {
 			templ_7745c5c3_Var37 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<div class=\"relative flex shrink-0 items-center\"><input type=\"checkbox\" class=\"peer relative size-4 appearance-none overflow-hidden rounded-sm border border-outline bg-surface-alt before:absolute before:inset-0 before:content-[''] checked:border-primary checked:before:bg-primary focus:outline-2 focus:outline-offset-2 focus:outline-outline-strong checked:focus:outline-primary active:outline-offset-0 dark:border-outline-dark dark:bg-surface-dark-alt dark:checked:border-primary-dark dark:checked:before:bg-primary-dark\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<div class=\"relative flex shrink-0 items-center\"><input type=\"checkbox\" class=\"peer pointer-events-none relative size-4 appearance-none overflow-hidden rounded-sm border border-outline bg-surface-alt before:absolute before:inset-0 before:content-[''] checked:border-primary checked:before:bg-primary focus:outline-2 focus:outline-offset-2 focus:outline-outline-strong checked:focus:outline-primary active:outline-offset-0 dark:border-outline-dark dark:bg-surface-dark-alt dark:checked:border-primary-dark dark:checked:before:bg-primary-dark\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -705,7 +705,7 @@ func optionCheckbox(selected bool) templ.Component {
 }
 
 // ClientScript emits the delegated client-side listener as an inline script.
-// The IIFE guard (window.__goshtosoComboboxV2Init) makes repeated renders safe.
+// The IIFE guard (window.__goshtosoComboboxInit) makes repeated renders safe.
 func ClientScript() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context

--- a/components/combobox/types.go
+++ b/components/combobox/types.go
@@ -53,11 +53,6 @@ type Config struct {
 	Disabled        bool
 }
 
-// InitialState returns the first-paint state for static/client-mode comboboxes.
-func (c Config) InitialState() State {
-	return State{Options: c.Source.Static, Selected: c.Selected}
-}
-
 // State is the per-request render state.
 type State struct {
 	Options  []Option
@@ -108,6 +103,11 @@ func (c Config) Validate() error {
 		}
 	}
 	return nil
+}
+
+// InitialState returns the first render state for static/client-mode comboboxes.
+func (c Config) InitialState() State {
+	return State{Options: c.Source.Static, Selected: c.Selected}
 }
 
 // IsSelected reports whether value is in the selected set.

--- a/scripts/skillgen/main.go
+++ b/scripts/skillgen/main.go
@@ -85,7 +85,7 @@ func run() error {
 }
 
 // componentDirs returns every directory under components/ (recursively, so
-// nested packages like combobox/v2 are included) that directly contains Go
+// nested component packages are included) that directly contains Go
 // source, as paths relative to componentsDir.
 func componentDirs() ([]string, error) {
 	var dirs []string

--- a/site/internal/pages/demo/components/combobox.templ
+++ b/site/internal/pages/demo/components/combobox.templ
@@ -58,6 +58,11 @@ templ ComboboxPage() {
 	@demo.Layout("Combobox", "combobox", comboboxDemoContent())
 }
 
+// ComboboxDemoPage renders the Combobox component demo.
+templ ComboboxDemoPage() {
+	@demo.Layout("Combobox", "combobox", comboboxDemoContent())
+}
+
 // comboboxDemoContent renders the canonical HTMX SSR combobox demo. Each
 // mode lives in its own preview frame followed by its own code block (mirrors
 // penguinui.com/components/combobox). Wrapped in #combobox-fragment.

--- a/site/internal/pages/demo/components/combobox_templ.go
+++ b/site/internal/pages/demo/components/combobox_templ.go
@@ -91,6 +91,36 @@ func ComboboxPage() templ.Component {
 	})
 }
 
+// ComboboxDemoPage renders the Combobox component demo.
+func ComboboxDemoPage() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var2 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var2 == nil {
+			templ_7745c5c3_Var2 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = demo.Layout("Combobox", "combobox", comboboxDemoContent()).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
 // comboboxDemoContent renders the canonical HTMX SSR combobox demo. Each
 // mode lives in its own preview frame followed by its own code block (mirrors
 // penguinui.com/components/combobox). Wrapped in #combobox-fragment.
@@ -110,9 +140,9 @@ func comboboxDemoContent() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var2 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var2 == nil {
-			templ_7745c5c3_Var2 = templ.NopComponent
+		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var3 == nil {
+			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"combobox-fragment\">")
@@ -216,9 +246,9 @@ func comboboxIndustryPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var3 == nil {
-			templ_7745c5c3_Var3 = templ.NopComponent
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"combobox-industry\" class=\"w-full max-w-xs mx-auto\">")
@@ -254,9 +284,9 @@ func comboboxSkillsPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var4 == nil {
-			templ_7745c5c3_Var4 = templ.NopComponent
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"combobox-skills\" class=\"w-full max-w-xs mx-auto\">")
@@ -292,9 +322,9 @@ func comboboxUsersPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var5 == nil {
-			templ_7745c5c3_Var5 = templ.NopComponent
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"combobox-users\" class=\"w-full max-w-xs mx-auto\">")

--- a/site/internal/pages/demo/components/form.templ
+++ b/site/internal/pages/demo/components/form.templ
@@ -97,10 +97,7 @@ var formDemoCode = `// Built-in field types — set Input, Combobox, Textarea, T
 })
 @form.FieldGroup(form.FieldGroupConfig{
     ID: "provider", Label: "Provider",
-    Combobox: &gocombobox.Config{
-        ID: "provider", Name: "provider",
-        Source: gocombobox.Source{Static: opts},
-    },
+    Combobox: &gocombobox.Config{ID: "provider", Name: "provider", Source: gocombobox.Source{Static: opts}},
 })
 
 // Custom component — use { children... } for anything not built-in
@@ -383,16 +380,16 @@ templ formExternalPreview() {
 						@form.FieldGroup(form.FieldGroupConfig{
 							ID:    "version",
 							Label: "Target Version",
-								Combobox: &gocombobox.Config{
-									ID:   "version",
-									Name: "version",
-									Source: gocombobox.Source{Static: []gocombobox.Option{
-										{Value: "1.32.0", Label: "v1.32.0"},
-										{Value: "1.31.5", Label: "v1.31.5"},
-										{Value: "1.30.8", Label: "v1.30.8"},
-									}},
-									Selected: []string{"1.31.5"},
-								},
+							Combobox: &gocombobox.Config{
+								ID:   "version",
+								Name: "version",
+								Source: gocombobox.Source{Static: []gocombobox.Option{
+									{Value: "1.32.0", Label: "v1.32.0"},
+									{Value: "1.31.5", Label: "v1.31.5"},
+									{Value: "1.30.8", Label: "v1.30.8"},
+								}},
+								Selected: []string{"1.31.5"},
+							},
 						})
 					}
 				}

--- a/site/internal/pages/demo/components/form_templ.go
+++ b/site/internal/pages/demo/components/form_templ.go
@@ -167,10 +167,7 @@ var formDemoCode = `// Built-in field types — set Input, Combobox, Textarea, T
 })
 @form.FieldGroup(form.FieldGroupConfig{
     ID: "provider", Label: "Provider",
-    Combobox: &gocombobox.Config{
-        ID: "provider", Name: "provider",
-        Source: gocombobox.Source{Static: opts},
-    },
+    Combobox: &gocombobox.Config{ID: "provider", Name: "provider", Source: gocombobox.Source{Static: opts}},
 })
 
 // Custom component — use { children... } for anything not built-in

--- a/site/internal/server/server.go
+++ b/site/internal/server/server.go
@@ -98,7 +98,7 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("/api/components/radio/echo", s.handleRadioEcho)
 	s.registerGettingStartedRoutes()
 
-	// HTMX SSR combobox (v2) — users demo runs server-mode lazy search.
+	// Combobox users demo runs server-mode lazy search.
 	usersHandler := combobox.Handler(components.UsersCfg, usersProvider)
 	s.mux.Handle("/api/components/combobox/users/options", usersHandler)
 	s.mux.Handle("/api/components/combobox/users/toggle", usersHandler)

--- a/site/tests/e2e/combobox_client_test.go
+++ b/site/tests/e2e/combobox_client_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestComboboxV2_ClientMode_NoHTTPOnToggle(t *testing.T) {
+func TestCombobox_ClientMode_NoHTTPOnToggle(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping E2E test in short mode")
 	}
@@ -83,7 +83,7 @@ func TestComboboxV2_ClientMode_NoHTTPOnToggle(t *testing.T) {
 	assert.False(t, visible, "single-select dropdown should close after selection")
 }
 
-func TestComboboxV2_ClientMode_MultiToggleAndClear(t *testing.T) {
+func TestCombobox_ClientMode_MultiToggleAndClear(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping E2E test in short mode")
 	}
@@ -120,7 +120,7 @@ func TestComboboxV2_ClientMode_MultiToggleAndClear(t *testing.T) {
 	require.NoError(t, trigger.Click())
 	time.Sleep(300 * time.Millisecond)
 
-	// Toggle two options.
+	// Toggle two options by row click, then one by clicking directly on the visible checkbox square.
 	require.NoError(t, page.Locator(`#skills [data-combobox-option][data-value="go"]`).First().Click())
 	time.Sleep(100 * time.Millisecond)
 
@@ -130,29 +130,39 @@ func TestComboboxV2_ClientMode_MultiToggleAndClear(t *testing.T) {
 
 	require.NoError(t, page.Locator(`#skills [data-combobox-option][data-value="rust"]`).First().Click())
 	time.Sleep(100 * time.Millisecond)
+	kotlinCheckbox := page.Locator(`#skills [data-combobox-option][data-value="kt"] input[type=checkbox]`).First()
+	kotlinBox, err := kotlinCheckbox.BoundingBox()
+	require.NoError(t, err)
+	require.NotNil(t, kotlinBox)
+	require.NoError(t, page.Mouse().Click(kotlinBox.X+kotlinBox.Width/2, kotlinBox.Y+kotlinBox.Height/2))
+	time.Sleep(100 * time.Millisecond)
 
-	// Trigger label shows "2 selected".
+	// Trigger label shows "3 selected".
 	label, err := page.Locator(`#skills-trigger-label`).TextContent()
 	require.NoError(t, err)
-	assert.Equal(t, "2 selected", label)
+	assert.Equal(t, "3 selected", label)
 
-	// Two hidden inputs present.
+	// Three hidden inputs present.
 	hiddenCount, err := page.Locator(`#skills input[type=hidden][name="skills"]`).Count()
 	require.NoError(t, err)
-	assert.Equal(t, 2, hiddenCount)
+	assert.Equal(t, 3, hiddenCount)
+
+	kotlinChecked, err := kotlinCheckbox.IsChecked()
+	require.NoError(t, err)
+	assert.True(t, kotlinChecked, "direct checkbox click should keep selected option visually checked")
 
 	// Deselect "go" by clicking it again (toggle off).
 	require.NoError(t, page.Locator(`#skills [data-combobox-option][data-value="go"]`).First().Click())
 	time.Sleep(100 * time.Millisecond)
 
-	// Label back to single-option label; one hidden input remains.
+	// Label still shows multiple selections; two hidden inputs remain.
 	label, err = page.Locator(`#skills-trigger-label`).TextContent()
 	require.NoError(t, err)
-	assert.Equal(t, "Rust", label)
+	assert.Equal(t, "2 selected", label)
 
 	hiddenCount, err = page.Locator(`#skills input[type=hidden][name="skills"]`).Count()
 	require.NoError(t, err)
-	assert.Equal(t, 1, hiddenCount)
+	assert.Equal(t, 2, hiddenCount)
 
 	// Re-select "go" so we have 2 selected again, then use clear-all.
 	require.NoError(t, page.Locator(`#skills [data-combobox-option][data-value="go"]`).First().Click())


### PR DESCRIPTION
## Summary
- make the current combobox implementation the canonical root component surface
- remove remaining v2 naming from component internals, docs skill references, and E2E names
- keep the checkbox click-through regression covered in the client combobox E2E tests

## Test Plan
- git diff --check
- go test ./... -count=1
- go build -o bin/server ./site/cmd/server
- go test ./site/tests/e2e/... -count=1 -timeout 5m -run TestCombobox
- cd site && go test ./... -count=1