### PR TITLE
feat(fileinput): add upload variant

### DIFF
--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -568,10 +568,13 @@ import "github.com/araihu/goshtoso/components/fileinput"  // package fileinput
 
 **Entry points:** `FileInput(cfg Config)`
 
+- **Variant** — VariantDropZone = "", VariantUpload = "upload"
+
 **Config**
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `Variant` | `Variant` | Variant controls the visual style (default: drop zone) |
 | `ID` | `string` | ID is the HTML id for the file input element |
 | `Name` | `string` | Name is the form field name |
 | `Label` | `string` | Label text displayed above the drop zone (e.g. "Cover Picture") |

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1402,6 +1402,9 @@
   .items-start {
     align-items: flex-start;
   }
+  .items-stretch {
+    align-items: stretch;
+  }
   .justify-between {
     justify-content: space-between;
   }
@@ -4131,6 +4134,22 @@
       }
     }
   }
+  .focus-within\:outline-2 {
+    &:focus-within {
+      outline-style: var(--tw-outline-style);
+      outline-width: 2px;
+    }
+  }
+  .focus-within\:outline-offset-2 {
+    &:focus-within {
+      outline-offset: 2px;
+    }
+  }
+  .focus-within\:outline-primary {
+    &:focus-within {
+      outline-color: var(--color-primary);
+    }
+  }
   .hover\:scale-110 {
     &:hover {
       @media (hover: hover) {
@@ -6205,6 +6224,13 @@
           content: var(--tw-content);
           background-color: var(--color-warning);
         }
+      }
+    }
+  }
+  .dark\:focus-within\:outline-primary-dark {
+    &:where(.dark, .dark *) {
+      &:focus-within {
+        outline-color: var(--color-primary-dark);
       }
     }
   }

--- a/components/fileinput/fileinput.templ
+++ b/components/fileinput/fileinput.templ
@@ -11,11 +11,21 @@ package fileinput
 //	    HelperText: "PNG, JPG, WebP - Max 5MB",
 //	})
 templ FileInput(cfg Config) {
+	if cfg.IsUpload() {
+		@uploadInput(cfg)
+	} else {
+		@dropZoneInput(cfg)
+	}
+}
+
+// dropZoneInput renders the drag-and-drop file input variant.
+templ dropZoneInput(cfg Config) {
 	<div class={ cfg.ContainerClasses() }>
 		if cfg.Label != "" {
 			<span class={ cfg.LabelClasses() }>{ cfg.Label }</span>
 		}
 		<div
+			data-fileinput-variant="dropzone"
 			x-data="{ dragging: false }"
 			@dragover.prevent=""
 			@dragenter="dragging = true"
@@ -54,8 +64,51 @@ templ FileInput(cfg Config) {
 				 or drag and drop here
 			</div>
 			if cfg.HelperText != "" {
-				<small id={ cfg.ID + "-helper" }>{ cfg.HelperText }</small>
+				<small id={ cfg.ID + "-helper" } class={ cfg.HelperTextClasses() }>{ cfg.HelperText }</small>
 			}
 		</div>
+	</div>
+}
+
+// uploadInput renders the compact text-input-style upload variant.
+templ uploadInput(cfg Config) {
+	<div class={ cfg.UploadContainerClasses() }>
+		if cfg.Label != "" {
+			<label for={ cfg.ID } class={ cfg.LabelClasses() }>{ cfg.Label }</label>
+		}
+		<label
+			for={ cfg.ID }
+			data-fileinput-variant="upload"
+			x-data="{ fileName: '' }"
+			x-on:change.capture="fileName = $event.target.files.length ? $event.target.files[0].name : ''"
+			class={ cfg.UploadControlClasses() }
+		>
+			<input
+				id={ cfg.ID }
+				name={ cfg.Name }
+				type="file"
+				class="sr-only"
+				if cfg.Accept != "" {
+					accept={ cfg.Accept }
+				}
+				if cfg.Required {
+					required
+				}
+				if cfg.Disabled {
+					disabled
+				}
+				if cfg.HelperText != "" {
+					aria-describedby={ cfg.ID + "-helper" }
+				}
+				{ cfg.Attrs... }
+			/>
+			<span class={ cfg.UploadFileNameClasses() }>
+				<span class="truncate" x-text="fileName || 'No file selected'">No file selected</span>
+			</span>
+			<span aria-hidden="true" class={ cfg.UploadButtonClasses() }>Browse</span>
+		</label>
+		if cfg.HelperText != "" {
+			<small id={ cfg.ID + "-helper" } class={ cfg.HelperTextClasses() }>{ cfg.HelperText }</small>
+		}
 	</div>
 }

--- a/components/fileinput/fileinput_templ.go
+++ b/components/fileinput/fileinput_templ.go
@@ -39,8 +39,45 @@ func FileInput(cfg Config) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var2 = []any{cfg.ContainerClasses()}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var2...)
+		if cfg.IsUpload() {
+			templ_7745c5c3_Err = uploadInput(cfg).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else {
+			templ_7745c5c3_Err = dropZoneInput(cfg).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		return nil
+	})
+}
+
+// dropZoneInput renders the drag-and-drop file input variant.
+func dropZoneInput(cfg Config) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var2 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var2 == nil {
+			templ_7745c5c3_Var2 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		var templ_7745c5c3_Var3 = []any{cfg.ContainerClasses()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var3...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -48,12 +85,12 @@ func FileInput(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var2).String())
+		var templ_7745c5c3_Var4 string
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var3).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -62,8 +99,8 @@ func FileInput(cfg Config) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if cfg.Label != "" {
-			var templ_7745c5c3_Var4 = []any{cfg.LabelClasses()}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var4...)
+			var templ_7745c5c3_Var5 = []any{cfg.LabelClasses()}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var5...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -71,12 +108,12 @@ func FileInput(cfg Config) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var5 string
-			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var4).String())
+			var templ_7745c5c3_Var6 string
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var5).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -84,12 +121,12 @@ func FileInput(cfg Config) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.Label)
+			var templ_7745c5c3_Var7 string
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 16, Col: 49}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 25, Col: 49}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -98,21 +135,21 @@ func FileInput(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		var templ_7745c5c3_Var7 = []any{cfg.DropZoneClasses()}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var7...)
+		var templ_7745c5c3_Var8 = []any{cfg.DropZoneClasses()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var8...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div x-data=\"{ dragging: false }\" @dragover.prevent=\"\" @dragenter=\"dragging = true\" @dragleave=\"dragging = false\" @drop.prevent=\"dragging = false; $refs.fileInput.files = $event.dataTransfer.files; $refs.fileInput.dispatchEvent(new Event('change', { bubbles: true }))\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div data-fileinput-variant=\"dropzone\" x-data=\"{ dragging: false }\" @dragover.prevent=\"\" @dragenter=\"dragging = true\" @dragleave=\"dragging = false\" @drop.prevent=\"dragging = false; $refs.fileInput.files = $event.dataTransfer.files; $refs.fileInput.dispatchEvent(new Event('change', { bubbles: true }))\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var7).String())
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var8).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -120,8 +157,8 @@ func FileInput(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var9 = []any{cfg.BrowseLabelClasses()}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var9...)
+		var templ_7745c5c3_Var10 = []any{cfg.BrowseLabelClasses()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var10...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -129,12 +166,12 @@ func FileInput(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var10 string
-		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID)
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 31, Col: 23}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 41, Col: 23}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var10)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -142,12 +179,12 @@ func FileInput(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var11 string
-		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var9).String())
+		var templ_7745c5c3_Var12 string
+		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var10).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var12)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -155,12 +192,12 @@ func FileInput(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var12 string
-		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID)
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 34, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 44, Col: 17}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var12)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var13)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -168,12 +205,12 @@ func FileInput(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var13 string
-		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Name)
+		var templ_7745c5c3_Var14 string
+		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 35, Col: 21}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 45, Col: 21}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var13)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var14)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -186,12 +223,12 @@ func FileInput(cfg Config) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var14 string
-			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Accept)
+			var templ_7745c5c3_Var15 string
+			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Accept)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 39, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 49, Col: 26}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var14)
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var15)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -217,12 +254,12 @@ func FileInput(cfg Config) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var15 string
-			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID + "-helper")
+			var templ_7745c5c3_Var16 string
+			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID + "-helper")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 48, Col: 44}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 58, Col: 44}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var15)
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -240,38 +277,371 @@ func FileInput(cfg Config) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if cfg.HelperText != "" {
+			var templ_7745c5c3_Var17 = []any{cfg.HelperTextClasses()}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var17...)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<small id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var16 string
-			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID + "-helper")
+			var templ_7745c5c3_Var18 string
+			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID + "-helper")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 57, Col: 34}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 67, Col: 34}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var17 string
-			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.HelperText)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 57, Col: 53}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\" class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</small>")
+			var templ_7745c5c3_Var19 string
+			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var17).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var20 string
+			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.HelperText)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 67, Col: 87}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</small>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// uploadInput renders the compact text-input-style upload variant.
+func uploadInput(cfg Config) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var21 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var21 == nil {
+			templ_7745c5c3_Var21 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		var templ_7745c5c3_Var22 = []any{cfg.UploadContainerClasses()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var22...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<div class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var23 string
+		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var22).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var23)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if cfg.Label != "" {
+			var templ_7745c5c3_Var24 = []any{cfg.LabelClasses()}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var24...)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<label for=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var25 string
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 77, Col: 22}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var26 string
+			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var24).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var26)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var27 string
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.Label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 77, Col: 65}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</label> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		var templ_7745c5c3_Var28 = []any{cfg.UploadControlClasses()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var28...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<label for=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var29 string
+		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 80, Col: 15}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var29)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" data-fileinput-variant=\"upload\" x-data=\"{ fileName: '' }\" x-on:change.capture=\"fileName = $event.target.files.length ? $event.target.files[0].name : ''\" class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var30 string
+		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var28).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\"><input id=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var31 string
+		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 87, Col: 15}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var31)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\" name=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var32 string
+		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Name)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 88, Col: 19}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" type=\"file\" class=\"sr-only\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if cfg.Accept != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, " accept=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var33 string
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Accept)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 92, Col: 24}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var33)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if cfg.Required {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, " required")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if cfg.Disabled {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, " disabled")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if cfg.HelperText != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, " aria-describedby=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var34 string
+			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID + "-helper")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 101, Col: 42}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var34)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, cfg.Attrs)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var35 = []any{cfg.UploadFileNameClasses()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var35...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<span class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var36 string
+		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var35).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var36)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\"><span class=\"truncate\" x-text=\"fileName || 'No file selected'\">No file selected</span></span> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var37 = []any{cfg.UploadButtonClasses()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var37...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<span aria-hidden=\"true\" class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var38 string
+		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var37).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var38)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "\">Browse</span></label> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if cfg.HelperText != "" {
+			var templ_7745c5c3_Var39 = []any{cfg.HelperTextClasses()}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var39...)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<small id=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var40 string
+			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID + "-helper")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 111, Col: 33}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var40)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\" class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var41 string
+			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var39).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var41)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var42 string
+			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.HelperText)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/fileinput/fileinput.templ`, Line: 111, Col: 86}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</small>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/fileinput/types.go
+++ b/components/fileinput/types.go
@@ -2,8 +2,20 @@ package fileinput
 
 import "github.com/a-h/templ"
 
+// Variant controls the visual style of the file input.
+type Variant string
+
+const (
+	// VariantDropZone renders the drag-and-drop drop zone. This is the default.
+	VariantDropZone Variant = ""
+	// VariantUpload renders a compact text-input-style upload control.
+	VariantUpload Variant = "upload"
+)
+
 // Config holds configuration for the file input component
 type Config struct {
+	// Variant controls the visual style (default: drop zone)
+	Variant Variant
 	// ID is the HTML id for the file input element
 	ID string
 	// Name is the form field name
@@ -33,6 +45,15 @@ func (cfg Config) ContainerClasses() string {
 	return base
 }
 
+// UploadContainerClasses returns classes for the compact upload wrapper.
+func (cfg Config) UploadContainerClasses() string {
+	base := "flex w-full max-w-xl flex-col gap-1 text-left text-on-surface dark:text-on-surface-dark"
+	if cfg.Class != "" {
+		return base + " " + cfg.Class
+	}
+	return base
+}
+
 // LabelClasses returns CSS classes for the label text above the drop zone
 func (cfg Config) LabelClasses() string {
 	return "w-fit pl-0.5 text-sm text-on-surface dark:text-on-surface-dark"
@@ -50,4 +71,37 @@ func (cfg Config) DropZoneClasses() string {
 // BrowseLabelClasses returns CSS classes for the "Browse" label link
 func (cfg Config) BrowseLabelClasses() string {
 	return "font-medium text-primary group-focus-within:underline dark:text-primary-dark cursor-pointer"
+}
+
+// IsUpload returns true when the compact upload variant should render.
+func (cfg Config) IsUpload() bool {
+	return cfg.Variant == VariantUpload
+}
+
+// UploadControlClasses returns classes for the compact upload control.
+func (cfg Config) UploadControlClasses() string {
+	base := "flex w-full items-stretch overflow-hidden rounded-radius border border-outline bg-surface-alt text-sm text-on-surface focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-primary dark:border-outline-dark dark:bg-surface-dark-alt/50 dark:text-on-surface-dark dark:focus-within:outline-primary-dark"
+	if cfg.Disabled {
+		return base + " cursor-not-allowed opacity-75"
+	}
+	return base + " cursor-pointer"
+}
+
+// UploadFileNameClasses returns classes for the compact file-name display.
+func (cfg Config) UploadFileNameClasses() string {
+	return "flex min-w-0 flex-1 items-center px-2 py-2 text-on-surface-muted dark:text-on-surface-dark-muted"
+}
+
+// UploadButtonClasses returns classes for the compact Browse affordance.
+func (cfg Config) UploadButtonClasses() string {
+	base := "flex shrink-0 items-center border-l border-outline bg-surface px-3 py-2 font-medium text-primary dark:border-outline-dark dark:bg-surface-dark dark:text-primary-dark"
+	if cfg.Disabled {
+		return base + " cursor-not-allowed"
+	}
+	return base
+}
+
+// HelperTextClasses returns classes for helper text below the field.
+func (cfg Config) HelperTextClasses() string {
+	return "pl-0.5 text-xs text-on-surface/60 dark:text-on-surface-dark/60"
 }

--- a/site/internal/pages/demo/components/fileinput.templ
+++ b/site/internal/pages/demo/components/fileinput.templ
@@ -32,6 +32,22 @@ templ fileInputDemoContent() {
 
 		@demo.DemoSection(
 			demo.DemoSectionProps{
+				Title:       "Upload",
+				Description: "VariantUpload uses a compact text-input-style control for dense forms.",
+			},
+			fileInputUploadPreview(),
+			`@fileinput.FileInput(fileinput.Config{
+    Variant:    fileinput.VariantUpload,
+    ID:         "resume",
+    Name:       "resume",
+    Label:      "Resume",
+    Accept:     ".pdf,.docx",
+    HelperText: "PDF or DOCX - Max 10MB",
+})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
 				Title:       "Required",
 				Description: "Required: true marks the field as required for form submission.",
 			},
@@ -76,6 +92,7 @@ templ fileInputDemoContent() {
 	</div>
 	// API reference lives outside #fileinput-fragment.
 	@demo.APIReference([]demo.PropDoc{
+		{Name: "Variant", Type: "fileinput.Variant", Default: "fileinput.VariantDropZone", Description: "Visual style: VariantDropZone or VariantUpload."},
 		{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the input (and label's for target)."},
 		{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
 		{Name: "Label", Type: "string", Default: `""`, Description: "Label above the drop zone (omit for none)."},
@@ -97,6 +114,20 @@ templ fileInputDefaultPreview() {
 			Label:      "Cover Picture",
 			Accept:     "image/*",
 			HelperText: "PNG, JPG, WebP - Max 5MB",
+		})
+	</div>
+}
+
+// fileInputUploadPreview renders the compact upload input.
+templ fileInputUploadPreview() {
+	<div id="fileinput-upload" class="w-full max-w-md mx-auto">
+		@fileinput.FileInput(fileinput.Config{
+			Variant:    fileinput.VariantUpload,
+			ID:         "demoUpload",
+			Name:       "resume",
+			Label:      "Resume",
+			Accept:     ".pdf,.docx",
+			HelperText: "PDF or DOCX - Max 10MB",
 		})
 	</div>
 }

--- a/site/internal/pages/demo/components/fileinput_templ.go
+++ b/site/internal/pages/demo/components/fileinput_templ.go
@@ -90,6 +90,24 @@ func fileInputDemoContent() templ.Component {
 		}
 		templ_7745c5c3_Err = demo.DemoSection(
 			demo.DemoSectionProps{
+				Title:       "Upload",
+				Description: "VariantUpload uses a compact text-input-style control for dense forms.",
+			},
+			fileInputUploadPreview(),
+			`@fileinput.FileInput(fileinput.Config{
+    Variant:    fileinput.VariantUpload,
+    ID:         "resume",
+    Name:       "resume",
+    Label:      "Resume",
+    Accept:     ".pdf,.docx",
+    HelperText: "PDF or DOCX - Max 10MB",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
 				Title:       "Required",
 				Description: "Required: true marks the field as required for form submission.",
 			},
@@ -143,6 +161,7 @@ func fileInputDemoContent() templ.Component {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Variant", Type: "fileinput.Variant", Default: "fileinput.VariantDropZone", Description: "Visual style: VariantDropZone or VariantUpload."},
 			{Name: "ID", Type: "string", Default: `""`, Description: "Unique id for the input (and label's for target)."},
 			{Name: "Name", Type: "string", Default: `""`, Description: "Form field name."},
 			{Name: "Label", Type: "string", Default: `""`, Description: "Label above the drop zone (omit for none)."},
@@ -204,8 +223,8 @@ func fileInputDefaultPreview() templ.Component {
 	})
 }
 
-// fileInputRequiredPreview renders the required input.
-func fileInputRequiredPreview() templ.Component {
+// fileInputUploadPreview renders the compact upload input.
+func fileInputUploadPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -226,7 +245,52 @@ func fileInputRequiredPreview() templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"fileinput-required\" class=\"w-full max-w-md mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"fileinput-upload\" class=\"w-full max-w-md mx-auto\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = fileinput.FileInput(fileinput.Config{
+			Variant:    fileinput.VariantUpload,
+			ID:         "demoUpload",
+			Name:       "resume",
+			Label:      "Resume",
+			Accept:     ".pdf,.docx",
+			HelperText: "PDF or DOCX - Max 10MB",
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// fileInputRequiredPreview renders the required input.
+func fileInputRequiredPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"fileinput-required\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -241,7 +305,7 @@ func fileInputRequiredPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -266,12 +330,12 @@ func fileInputDisabledPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var5 == nil {
-			templ_7745c5c3_Var5 = templ.NopComponent
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"fileinput-disabled\" class=\"w-full max-w-md mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"fileinput-disabled\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -285,7 +349,7 @@ func fileInputDisabledPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -310,12 +374,12 @@ func fileInputNoLabelPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"fileinput-nolabel\" class=\"w-full max-w-md mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div id=\"fileinput-nolabel\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -328,7 +392,7 @@ func fileInputNoLabelPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/tests/e2e/fileinput_test.go
+++ b/site/tests/e2e/fileinput_test.go
@@ -1,0 +1,192 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileInputVariants(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/fileinput", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+
+	t.Run("DropZoneDefaultStillRenders", func(t *testing.T) {
+		dropZone := page.Locator("#fileinput-default [data-fileinput-variant='dropzone']")
+		count, err := dropZone.Count()
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		classAttr, err := dropZone.GetAttribute("class")
+		require.NoError(t, err)
+		require.Contains(t, classAttr, "border-dashed")
+		require.Contains(t, classAttr, "p-8")
+
+		input := page.Locator("#demoCoverPicture")
+		accept, err := input.GetAttribute("accept")
+		require.NoError(t, err)
+		require.Equal(t, "image/*", accept)
+
+		describedBy, err := input.GetAttribute("aria-describedby")
+		require.NoError(t, err)
+		require.Equal(t, "demoCoverPicture-helper", describedBy)
+
+		helperText, err := page.Locator("#demoCoverPicture-helper").TextContent()
+		require.NoError(t, err)
+		require.Equal(t, "PNG, JPG, WebP - Max 5MB", helperText)
+	})
+
+	t.Run("UploadVariantUsesTextInputStyle", func(t *testing.T) {
+		upload := page.Locator("#fileinput-upload [data-fileinput-variant='upload']")
+		count, err := upload.Count()
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+
+		classAttr, err := upload.GetAttribute("class")
+		require.NoError(t, err)
+		require.Contains(t, classAttr, "rounded-radius")
+		require.Contains(t, classAttr, "border-outline")
+		require.Contains(t, classAttr, "bg-surface-alt")
+		require.NotContains(t, classAttr, "border-dashed")
+		require.NotContains(t, classAttr, "p-8")
+
+		input := page.Locator("#demoUpload")
+		inputClass, err := input.GetAttribute("class")
+		require.NoError(t, err)
+		require.Contains(t, inputClass, "sr-only")
+
+		inputType, err := input.GetAttribute("type")
+		require.NoError(t, err)
+		require.Equal(t, "file", inputType)
+
+		name, err := input.GetAttribute("name")
+		require.NoError(t, err)
+		require.Equal(t, "resume", name)
+
+		accept, err := input.GetAttribute("accept")
+		require.NoError(t, err)
+		require.Equal(t, ".pdf,.docx", accept)
+
+		labelFor, err := page.Locator("#fileinput-upload [data-fileinput-variant='upload']").GetAttribute("for")
+		require.NoError(t, err)
+		require.Equal(t, "demoUpload", labelFor)
+
+		helper := page.Locator("#demoUpload-helper")
+		helperText, err := helper.TextContent()
+		require.NoError(t, err)
+		require.Equal(t, "PDF or DOCX - Max 10MB", helperText)
+
+		describedBy, err := input.GetAttribute("aria-describedby")
+		require.NoError(t, err)
+		require.Equal(t, "demoUpload-helper", describedBy)
+	})
+
+	t.Run("UploadVariantShowsSelectedFileName", func(t *testing.T) {
+		_, err := page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+		require.NoError(t, err)
+
+		input := page.Locator("#demoUpload")
+		require.NoError(t, input.SetInputFiles(playwright.InputFile{
+			Name:     "portfolio.pdf",
+			MimeType: "application/pdf",
+			Buffer:   []byte("%PDF-1.4\n"),
+		}))
+
+		_, err = page.WaitForFunction(
+			"() => document.querySelector('#fileinput-upload [x-text]')?.textContent === 'portfolio.pdf'",
+			nil,
+			playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("DropZoneStatesKeepNativeAttributes", func(t *testing.T) {
+		required := page.Locator("#demoDocument")
+		requiredAttr, err := required.GetAttribute("required")
+		require.NoError(t, err)
+		require.Equal(t, "", requiredAttr)
+
+		requiredDropZoneClass, err := page.Locator("#fileinput-required [data-fileinput-variant='dropzone']").GetAttribute("class")
+		require.NoError(t, err)
+		require.Contains(t, requiredDropZoneClass, "border-dashed")
+
+		disabled := page.Locator("#demoDisabled")
+		disabledAttr, err := disabled.GetAttribute("disabled")
+		require.NoError(t, err)
+		require.Equal(t, "", disabledAttr)
+
+		disabledDropZoneClass, err := page.Locator("#fileinput-disabled [data-fileinput-variant='dropzone']").GetAttribute("class")
+		require.NoError(t, err)
+		require.Contains(t, disabledDropZoneClass, "opacity-50")
+		require.Contains(t, disabledDropZoneClass, "cursor-not-allowed")
+	})
+
+	t.Run("NoLabelVariantOmitsVisibleLabel", func(t *testing.T) {
+		labels := page.Locator("#fileinput-nolabel span.w-fit")
+		count, err := labels.Count()
+		require.NoError(t, err)
+		require.Equal(t, 0, count)
+
+		input := page.Locator("#demoNoLabel")
+		accept, err := input.GetAttribute("accept")
+		require.NoError(t, err)
+		require.Equal(t, "image/*,.pdf", accept)
+	})
+
+	t.Run("APIReferenceDocumentsVariant", func(t *testing.T) {
+		variantRow := page.Locator("table").Filter(playwright.LocatorFilterOptions{HasText: "VariantDropZone"}).
+			Locator("tr").Filter(playwright.LocatorFilterOptions{HasText: "Variant"})
+		count, err := variantRow.Count()
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+	})
+}
+
+func TestFileInputFragmentNavNoErrors(t *testing.T) {
+	page := newIsolatedPage(t)
+
+	var jsErrors []string
+	page.On("pageerror", func(err error) { jsErrors = append(jsErrors, err.Error()) })
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			jsErrors = append(jsErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL + "/getting-started")
+	require.NoError(t, err)
+	_, err = page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("a[href='/components/fileinput']").Click())
+	_, err = page.WaitForFunction(
+		"() => document.querySelectorAll('[data-fileinput-variant=\"dropzone\"]').length >= 1 && document.querySelectorAll('[data-fileinput-variant=\"upload\"]').length === 1",
+		nil,
+		playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)},
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("#demoUpload").SetInputFiles(playwright.InputFile{
+		Name:     "fragment-resume.pdf",
+		MimeType: "application/pdf",
+		Buffer:   []byte("%PDF-1.4\n"),
+	}))
+	_, err = page.WaitForFunction(
+		"() => document.querySelector('#fileinput-upload [x-text]')?.textContent === 'fragment-resume.pdf'",
+		nil,
+		playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)},
+	)
+	require.NoError(t, err)
+	require.Empty(t, jsErrors, "no JS console/page errors on fragment-nav file input page: %v", jsErrors)
+}


### PR DESCRIPTION
## Summary
- add a compact `fileinput.VariantUpload` style for dense forms while keeping the existing drop-zone variant as the default
- document the upload variant on `/components/fileinput` and update the generated component reference/CSS
- add thorough file input E2E coverage for variant rendering, upload filename updates, native attributes, API docs, and fragment navigation

## Test Plan
- [x] `go build -o bin/server ./site/cmd/server`
- [x] `go test ./tests/e2e -count=1 -timeout 5m -run 'TestFileInput'` from `site/`
- [x] `go test ./...`
- [x] `go test ./... -count=1 -timeout 15m` from `site/`
- [x] `git diff --check`
