### PR TITLE
docs(readme): mention docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ Then open:
 - <http://localhost:8090/examples/todo>
 - <http://localhost:8090/examples/logs>
 
-The public demo is available at [goshtoso.araihu.com](https://goshtoso.araihu.com).
+The public documentation site is available at
+[https://goshtoso.araihu.com/](https://goshtoso.araihu.com/).
 
 ## Using Assets
 


### PR DESCRIPTION
## Summary
- Updates the README to name https://goshtoso.araihu.com/ as the public documentation site.

## Test Plan
- `git diff --check`
- README docs URL scan
- README component count check: `37/37`
- README local link check
