### PR TITLE
feat(select): support trigger leading

### DIFF
--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -1056,7 +1056,7 @@ import "github.com/araihu/goshtoso/components/select"  // package selectfield
 | `Readonly` | `bool` | Readonly renders the select as disabled (grayed out) + hidden input with value so it still submits |
 | `Attrs` | `templ.Attributes` | Attrs allows arbitrary HTML attributes on the <select> element (e.g., hx-post, hx-indicator) |
 | `Shell` | `bool` | Shell enables "shell mode": the Select renders its trigger + dropdown |
-| `TriggerLeading` | `templ.Component` | TriggerLeading is optional content rendered at the start of the trigger |
+| `TriggerLeading` | `templ.Component` | TriggerLeading is optional content rendered at the start of the trigger. |
 | `ValueExpr` | `string` | ValueExpr is an Alpine expression (x-text) for the trigger's value text |
 | `TriggerLabel` | `string` | TriggerLabel is optional static text shown left-aligned in the trigger |
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1009,9 +1009,6 @@
   .max-h-52 {
     max-height: calc(var(--spacing) * 52);
   }
-  .max-h-80 {
-    max-height: calc(var(--spacing) * 80);
-  }
   .max-h-svh {
     max-height: 100svh;
   }
@@ -4946,11 +4943,6 @@
   .sm\:hidden {
     @media (width >= 40rem) {
       display: none;
-    }
-  }
-  .sm\:inline {
-    @media (width >= 40rem) {
-      display: inline;
     }
   }
   .sm\:inline-flex {

--- a/components/select/select.templ
+++ b/components/select/select.templ
@@ -64,6 +64,9 @@ templ Select(cfg Config) {
 						<span class="truncate text-sm font-normal" x-text={ cfg.ValueExpr }></span>
 					}
 				} else {
+					if cfg.TriggerLeading != nil {
+						@cfg.TriggerLeading
+					}
 					<span class="truncate text-sm font-normal" x-text="selectedOption ? selectedOption.label : placeholder"></span>
 				}
 				<!-- Chevron -->

--- a/components/select/select_shell_test.go
+++ b/components/select/select_shell_test.go
@@ -50,3 +50,15 @@ func TestSelect_DataMode_Unchanged(t *testing.T) {
 	assert.Contains(t, html, "allOptions")
 	assert.Contains(t, html, `role="listbox"`)
 }
+
+func TestSelect_DataMode_RendersTriggerLeading(t *testing.T) {
+	html := renderSelect(t, Config{
+		ID:             "theme",
+		TriggerLeading: templ.Raw(`<span data-test-leading aria-hidden="true"></span>`),
+		Options:        []Option{{Value: "minimal", Label: "Minimal", Selected: true}},
+	}, nil)
+
+	assert.Contains(t, html, "data-test-leading")
+	assert.Contains(t, html, `x-text="selectedOption ? selectedOption.label : placeholder"`)
+	assert.Less(t, strings.Index(html, "data-test-leading"), strings.Index(html, `x-text="selectedOption ? selectedOption.label : placeholder"`))
+}

--- a/components/select/select_templ.go
+++ b/components/select/select_templ.go
@@ -313,7 +313,13 @@ func Select(cfg Config) templ.Component {
 				}
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<span class=\"truncate text-sm font-normal\" x-text=\"selectedOption ? selectedOption.label : placeholder\"></span>")
+			if cfg.TriggerLeading != nil {
+				templ_7745c5c3_Err = cfg.TriggerLeading.Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, " <span class=\"truncate text-sm font-normal\" x-text=\"selectedOption ? selectedOption.label : placeholder\"></span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -330,7 +336,7 @@ func Select(cfg Config) templ.Component {
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 88, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 91, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
 			if templ_7745c5c3_Err != nil {
@@ -343,7 +349,7 @@ func Select(cfg Config) templ.Component {
 			var templ_7745c5c3_Var19 string
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 89, Col: 20}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 92, Col: 20}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
 			if templ_7745c5c3_Err != nil {
@@ -361,7 +367,7 @@ func Select(cfg Config) templ.Component {
 				var templ_7745c5c3_Var20 string
 				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Autocomplete)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 95, Col: 37}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 98, Col: 37}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
 				if templ_7745c5c3_Err != nil {
@@ -384,7 +390,7 @@ func Select(cfg Config) templ.Component {
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Label + " list")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 107, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 110, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 		if templ_7745c5c3_Err != nil {
@@ -407,7 +413,7 @@ func Select(cfg Config) templ.Component {
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(jsStringLiteral(cfg.ID+"-option-") + " + index")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 120, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 123, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
 			if templ_7745c5c3_Err != nil {
@@ -448,7 +454,7 @@ func Select(cfg Config) templ.Component {
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.HelperText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 151, Col: 20}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/select/select.templ`, Line: 154, Col: 20}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {

--- a/components/select/types.go
+++ b/components/select/types.go
@@ -73,8 +73,7 @@ type Config struct {
 	// chrome but hosts arbitrary templ children as the dropdown body instead
 	// of an option list. Used to wrap custom pickers (e.g. a color palette).
 	Shell bool
-	// TriggerLeading is optional content rendered at the start of the trigger
-	// in shell mode (e.g. a color swatch). Ignored when Shell is false.
+	// TriggerLeading is optional content rendered at the start of the trigger.
 	TriggerLeading templ.Component
 	// ValueExpr is an Alpine expression (x-text) for the trigger's value text
 	// in shell mode. Resolves against the host page's x-data scope.

--- a/site/internal/pages/demo/layout.templ
+++ b/site/internal/pages/demo/layout.templ
@@ -2,6 +2,7 @@ package demo
 
 import (
 	"github.com/araihu/goshtoso/assets"
+	selectfield "github.com/araihu/goshtoso/components/select"
 	"github.com/araihu/goshtoso/components/sidebar"
 )
 
@@ -134,41 +135,15 @@ templ Layout(title string, activeComponent string, content templ.Component) {
 					
 					<!-- Right side controls -->
 					<div class="flex items-center gap-2">
-						<!-- Theme Selector Dropdown -->
-						<div class="relative" x-data="{ open: false }" @click.away="open = false">
-							<button 
-								@click="open = !open"
-								class="flex items-center gap-2 px-3 py-1.5 text-sm rounded-md border border-outline bg-surface-alt hover:bg-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:hover:bg-surface-dark transition-colors"
-							>
-								<svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"/>
-								</svg>
-								<span x-text="theme === 'minimal' ? 'Minimal' : theme" class="hidden sm:inline capitalize"></span>
-								<svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
-								</svg>
-							</button>
-							
-							<!-- Dropdown Menu -->
-							<div 
-								x-show="open" 
-								@click.away="open = false"
-								x-cloak
-								class="absolute right-0 mt-2 w-48 max-h-80 overflow-y-auto rounded-radius border border-outline bg-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark z-50"
-							>
-								<div class="py-1">
-									for _, t := range getThemeOptions() {
-										<button
-											data-theme-key={ t.Key }
-											@click="setTheme($el.dataset.themeKey); open = false"
-											class="w-full px-4 py-1.5 text-left text-sm hover:bg-surface-alt dark:hover:bg-surface-dark-alt flex items-center justify-between"
-											:class="theme === $el.dataset.themeKey ? 'bg-primary/10 text-primary font-medium' : ''"
-										>
-											<span>{ t.Label }</span>
-										</button>
-									}
-								</div>
-							</div>
+						<!-- Theme Selector -->
+						<div class="w-36 sm:w-44">
+							@selectfield.Select(selectfield.Config{
+								ID:             "site-theme",
+								Name:           "theme",
+								AlpineModel:    "theme",
+								TriggerLeading: themeSelectIcon(),
+								Options:        getThemeOptions(),
+							})
 						</div>
 						
 						<!-- Dark Mode Toggle -->
@@ -659,27 +634,29 @@ templ siteFooter() {
 	</footer>
 }
 
-type themeOption struct {
-	Key   string
-	Label string
+func getThemeOptions() []selectfield.Option {
+	return []selectfield.Option{
+		{Value: "goshtoso", Label: "Goshtoso"},
+		{Value: "minimal", Label: "Minimal"},
+		{Value: "modern", Label: "Modern"},
+		{Value: "arctic", Label: "Arctic"},
+		{Value: "high-contrast", Label: "High Contrast"},
+		{Value: "neo-brutalism", Label: "Neo Brutalism"},
+		{Value: "news", Label: "News"},
+		{Value: "industrial", Label: "Industrial"},
+		{Value: "90s", Label: "90s"},
+		{Value: "pastel", Label: "Pastel"},
+		{Value: "christmas", Label: "Christmas"},
+		{Value: "halloween", Label: "Halloween"},
+		{Value: "zombie", Label: "Halloween II"},
+		{Value: "prototype", Label: "Prototype"},
+		{Value: "totvs", Label: "TOTVS"},
+		{Value: "dracula", Label: "Dracula"},
+	}
 }
 
-func getThemeOptions() []themeOption {
-	return []themeOption{
-		{Key: "goshtoso", Label: "Goshtoso"},
-		{Key: "minimal", Label: "Minimal"},
-		{Key: "modern", Label: "Modern"},
-		{Key: "arctic", Label: "Arctic"},
-		{Key: "high-contrast", Label: "High Contrast"},
-		{Key: "neo-brutalism", Label: "Neo Brutalism"},
-		{Key: "news", Label: "News"},
-		{Key: "industrial", Label: "Industrial"},
-		{Key: "90s", Label: "90s"},
-		{Key: "pastel", Label: "Pastel"},
-		{Key: "christmas", Label: "Christmas"},
-		{Key: "halloween", Label: "Halloween"},
-		{Key: "zombie", Label: "Halloween II"},
-		{Key: "prototype", Label: "Prototype"},
-		{Key: "dracula", Label: "Dracula"},
-	}
+templ themeSelectIcon() {
+	<svg xmlns="http://www.w3.org/2000/svg" class="size-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+		<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"></path>
+	</svg>
 }

--- a/site/internal/pages/demo/layout_templ.go
+++ b/site/internal/pages/demo/layout_templ.go
@@ -10,6 +10,7 @@ import templruntime "github.com/a-h/templ/runtime"
 
 import (
 	"github.com/araihu/goshtoso/assets"
+	selectfield "github.com/araihu/goshtoso/components/select"
 	"github.com/araihu/goshtoso/components/sidebar"
 )
 
@@ -42,7 +43,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 30, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 31, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -67,7 +68,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineFocusURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 43, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 44, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 		if templ_7745c5c3_Err != nil {
@@ -80,7 +81,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineCollapseURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 44, Col: 47}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 45, Col: 47}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
 		if templ_7745c5c3_Err != nil {
@@ -93,7 +94,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineJSURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 45, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 46, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
 		if templ_7745c5c3_Err != nil {
@@ -106,7 +107,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.HTMXURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 46, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 47, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 		if templ_7745c5c3_Err != nil {
@@ -119,7 +120,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.HTMXExtWSURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 47, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 48, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var7)
 		if templ_7745c5c3_Err != nil {
@@ -132,49 +133,27 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.HTMXExtSSEURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 48, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 49, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\"></script><script>\n\t\t\t\t// Alpine nav store + htmx integration for fragment-swap sidebar navigation.\n\t\t\t\t// The store's `path` field is read inside the sidebar wrapper's x-effect so\n\t\t\t\t// the search filter re-applies after an OOB sidebar swap.\n\t\t\t\tdocument.addEventListener('alpine:init', () => {\n\t\t\t\t\tAlpine.store('nav', { path: window.location.pathname });\n\t\t\t\t});\n\t\t\t\tdocument.addEventListener('htmx:pushedIntoHistory', () => {\n\t\t\t\t\tif (window.Alpine && Alpine.store('nav')) {\n\t\t\t\t\t\tAlpine.store('nav').path = window.location.pathname;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\t// Sidebar OOB swap rebuilds the .sidebar-scroll element, so its scrollTop\n\t\t\t\t// resets. Capture before each swap and restore right after.\n\t\t\t\tvar __sidebarScrollTop = 0;\n\t\t\t\tdocument.addEventListener('htmx:beforeSwap', () => {\n\t\t\t\t\tvar el = document.querySelector('.sidebar-scroll');\n\t\t\t\t\tif (el) __sidebarScrollTop = el.scrollTop;\n\t\t\t\t});\n\t\t\t\tdocument.addEventListener('htmx:afterSwap', (e) => {\n\t\t\t\t\tif (e && e.detail && e.detail.target && window.Alpine && Alpine.initTree) {\n\t\t\t\t\t\tAlpine.initTree(e.detail.target);\n\t\t\t\t\t}\n\t\t\t\t\t// Sidebar scroll-restore and main scroll-reset apply ONLY to full\n\t\t\t\t\t// page-nav swaps (target = #main-content), where the sidebar OOB-rebuilds.\n\t\t\t\t\t// In-page swaps (accordions, tabs, table rows, the SSE log feed) must not\n\t\t\t\t\t// touch sidebar/main scroll — an ungated sidebar restore here reset the\n\t\t\t\t\t// nav to the top on every SSE log append.\n\t\t\t\t\tvar tgt = e && e.detail && e.detail.target;\n\t\t\t\t\tif (tgt && tgt.id === 'main-content') {\n\t\t\t\t\t\tvar sb = document.querySelector('.sidebar-scroll');\n\t\t\t\t\t\tif (sb) sb.scrollTop = __sidebarScrollTop;\n\t\t\t\t\t\tvar main = document.querySelector('main');\n\t\t\t\t\t\tif (main) main.scrollTo({ top: 0 });\n\t\t\t\t\t\tif (window.buildTOC) window.buildTOC();\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t</script><style>\n\t\t\t\t[x-cloak] { display: none !important; }\n\t\t\t\t/* Hide scrollbar for sidebar */\n\t\t\t\t.sidebar-scroll::-webkit-scrollbar {\n\t\t\t\t\tdisplay: none;\n\t\t\t\t}\n\t\t\t\t.sidebar-scroll {\n\t\t\t\t\t-ms-overflow-style: none;\n\t\t\t\t\tscrollbar-width: none;\n\t\t\t\t}\n\t\t\t\t/* First-paint entrance animations — masks layout shift on hard reload.\n\t\t\t\t   Gated by html.boot which is stripped ~600ms after DOMContentLoaded,\n\t\t\t\t   so HTMX partial swaps do not retrigger. */\n\t\t\t\t@keyframes goshFadeIn { from { opacity: 0; } to { opacity: 1; } }\n\t\t\t\t@keyframes goshSlideDown {\n\t\t\t\t\tfrom { opacity: 0; transform: translate3d(0, -8px, 0); }\n\t\t\t\t\tto   { opacity: 1; transform: none; }\n\t\t\t\t}\n\t\t\t\t@keyframes goshSlideRight {\n\t\t\t\t\tfrom { opacity: 0; transform: translate3d(-12px, 0, 0); }\n\t\t\t\t\tto   { opacity: 1; transform: none; }\n\t\t\t\t}\n\t\t\t\thtml.boot [data-boot-anim=\"header\"]  { animation: goshSlideDown 260ms ease-out both; }\n\t\t\t\thtml.boot [data-boot-anim=\"sidebar\"] { animation: goshSlideRight 320ms ease-out 60ms both; }\n\t\t\t\thtml.boot [data-boot-anim=\"main\"]    { animation: goshFadeIn 320ms ease-out 120ms both; }\n\t\t\t\t@media (prefers-reduced-motion: reduce) {\n\t\t\t\t\thtml.boot [data-boot-anim] { animation: none; }\n\t\t\t\t}\n\t\t\t</style></head><body class=\"h-screen overflow-hidden bg-surface text-on-surface dark:bg-surface-dark dark:text-on-surface-dark theme-transition\"><!-- Header --><header data-boot-anim=\"header\" class=\"sticky top-0 z-50 border-b border-outline bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/60 dark:border-outline-dark dark:bg-surface-dark/95 dark:supports-[backdrop-filter]:bg-surface-dark/60\"><div class=\"flex h-16 items-center justify-between px-4 lg:px-8\"><div class=\"flex items-center gap-4\"><button @click=\"sidebarOpen = !sidebarOpen\" class=\"lg:hidden p-2 rounded-md hover:bg-surface-alt dark:hover:bg-surface-dark-alt\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-6 w-6\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M4 6h16M4 12h16M4 18h16\"></path></svg></button> <a href=\"/\" class=\"flex items-center gap-2\"><span class=\"text-2xl font-bold font-title\"><span class=\"text-primary dark:text-primary-dark\">Go</span>shtoso</span></a></div><!-- Right side controls --><div class=\"flex items-center gap-2\"><!-- Theme Selector Dropdown --><div class=\"relative\" x-data=\"{ open: false }\" @click.away=\"open = false\"><button @click=\"open = !open\" class=\"flex items-center gap-2 px-3 py-1.5 text-sm rounded-md border border-outline bg-surface-alt hover:bg-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:hover:bg-surface-dark transition-colors\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-4 w-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01\"></path></svg> <span x-text=\"theme === 'minimal' ? 'Minimal' : theme\" class=\"hidden sm:inline capitalize\"></span> <svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-4 w-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M19 9l-7 7-7-7\"></path></svg></button><!-- Dropdown Menu --><div x-show=\"open\" @click.away=\"open = false\" x-cloak class=\"absolute right-0 mt-2 w-48 max-h-80 overflow-y-auto rounded-radius border border-outline bg-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark z-50\"><div class=\"py-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\"></script><script>\n\t\t\t\t// Alpine nav store + htmx integration for fragment-swap sidebar navigation.\n\t\t\t\t// The store's `path` field is read inside the sidebar wrapper's x-effect so\n\t\t\t\t// the search filter re-applies after an OOB sidebar swap.\n\t\t\t\tdocument.addEventListener('alpine:init', () => {\n\t\t\t\t\tAlpine.store('nav', { path: window.location.pathname });\n\t\t\t\t});\n\t\t\t\tdocument.addEventListener('htmx:pushedIntoHistory', () => {\n\t\t\t\t\tif (window.Alpine && Alpine.store('nav')) {\n\t\t\t\t\t\tAlpine.store('nav').path = window.location.pathname;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\t// Sidebar OOB swap rebuilds the .sidebar-scroll element, so its scrollTop\n\t\t\t\t// resets. Capture before each swap and restore right after.\n\t\t\t\tvar __sidebarScrollTop = 0;\n\t\t\t\tdocument.addEventListener('htmx:beforeSwap', () => {\n\t\t\t\t\tvar el = document.querySelector('.sidebar-scroll');\n\t\t\t\t\tif (el) __sidebarScrollTop = el.scrollTop;\n\t\t\t\t});\n\t\t\t\tdocument.addEventListener('htmx:afterSwap', (e) => {\n\t\t\t\t\tif (e && e.detail && e.detail.target && window.Alpine && Alpine.initTree) {\n\t\t\t\t\t\tAlpine.initTree(e.detail.target);\n\t\t\t\t\t}\n\t\t\t\t\t// Sidebar scroll-restore and main scroll-reset apply ONLY to full\n\t\t\t\t\t// page-nav swaps (target = #main-content), where the sidebar OOB-rebuilds.\n\t\t\t\t\t// In-page swaps (accordions, tabs, table rows, the SSE log feed) must not\n\t\t\t\t\t// touch sidebar/main scroll — an ungated sidebar restore here reset the\n\t\t\t\t\t// nav to the top on every SSE log append.\n\t\t\t\t\tvar tgt = e && e.detail && e.detail.target;\n\t\t\t\t\tif (tgt && tgt.id === 'main-content') {\n\t\t\t\t\t\tvar sb = document.querySelector('.sidebar-scroll');\n\t\t\t\t\t\tif (sb) sb.scrollTop = __sidebarScrollTop;\n\t\t\t\t\t\tvar main = document.querySelector('main');\n\t\t\t\t\t\tif (main) main.scrollTo({ top: 0 });\n\t\t\t\t\t\tif (window.buildTOC) window.buildTOC();\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t</script><style>\n\t\t\t\t[x-cloak] { display: none !important; }\n\t\t\t\t/* Hide scrollbar for sidebar */\n\t\t\t\t.sidebar-scroll::-webkit-scrollbar {\n\t\t\t\t\tdisplay: none;\n\t\t\t\t}\n\t\t\t\t.sidebar-scroll {\n\t\t\t\t\t-ms-overflow-style: none;\n\t\t\t\t\tscrollbar-width: none;\n\t\t\t\t}\n\t\t\t\t/* First-paint entrance animations — masks layout shift on hard reload.\n\t\t\t\t   Gated by html.boot which is stripped ~600ms after DOMContentLoaded,\n\t\t\t\t   so HTMX partial swaps do not retrigger. */\n\t\t\t\t@keyframes goshFadeIn { from { opacity: 0; } to { opacity: 1; } }\n\t\t\t\t@keyframes goshSlideDown {\n\t\t\t\t\tfrom { opacity: 0; transform: translate3d(0, -8px, 0); }\n\t\t\t\t\tto   { opacity: 1; transform: none; }\n\t\t\t\t}\n\t\t\t\t@keyframes goshSlideRight {\n\t\t\t\t\tfrom { opacity: 0; transform: translate3d(-12px, 0, 0); }\n\t\t\t\t\tto   { opacity: 1; transform: none; }\n\t\t\t\t}\n\t\t\t\thtml.boot [data-boot-anim=\"header\"]  { animation: goshSlideDown 260ms ease-out both; }\n\t\t\t\thtml.boot [data-boot-anim=\"sidebar\"] { animation: goshSlideRight 320ms ease-out 60ms both; }\n\t\t\t\thtml.boot [data-boot-anim=\"main\"]    { animation: goshFadeIn 320ms ease-out 120ms both; }\n\t\t\t\t@media (prefers-reduced-motion: reduce) {\n\t\t\t\t\thtml.boot [data-boot-anim] { animation: none; }\n\t\t\t\t}\n\t\t\t</style></head><body class=\"h-screen overflow-hidden bg-surface text-on-surface dark:bg-surface-dark dark:text-on-surface-dark theme-transition\"><!-- Header --><header data-boot-anim=\"header\" class=\"sticky top-0 z-50 border-b border-outline bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/60 dark:border-outline-dark dark:bg-surface-dark/95 dark:supports-[backdrop-filter]:bg-surface-dark/60\"><div class=\"flex h-16 items-center justify-between px-4 lg:px-8\"><div class=\"flex items-center gap-4\"><button @click=\"sidebarOpen = !sidebarOpen\" class=\"lg:hidden p-2 rounded-md hover:bg-surface-alt dark:hover:bg-surface-dark-alt\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-6 w-6\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M4 6h16M4 12h16M4 18h16\"></path></svg></button> <a href=\"/\" class=\"flex items-center gap-2\"><span class=\"text-2xl font-bold font-title\"><span class=\"text-primary dark:text-primary-dark\">Go</span>shtoso</span></a></div><!-- Right side controls --><div class=\"flex items-center gap-2\"><!-- Theme Selector --><div class=\"w-36 sm:w-44\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		for _, t := range getThemeOptions() {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<button data-theme-key=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var9 string
-			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(t.Key)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 162, Col: 33}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" @click=\"setTheme($el.dataset.themeKey); open = false\" class=\"w-full px-4 py-1.5 text-left text-sm hover:bg-surface-alt dark:hover:bg-surface-dark-alt flex items-center justify-between\" :class=\"theme === $el.dataset.themeKey ? 'bg-primary/10 text-primary font-medium' : ''\"><span>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(t.Label)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 167, Col: 26}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</span></button>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
+		templ_7745c5c3_Err = selectfield.Select(selectfield.Config{
+			ID:             "site-theme",
+			Name:           "theme",
+			AlpineModel:    "theme",
+			TriggerLeading: themeSelectIcon(),
+			Options:        getThemeOptions(),
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div></div></div><!-- Dark Mode Toggle --><button id=\"darkModeToggleBtn\" aria-label=\"dark mode toggle\" @click=\"$store.darkMode.toggle()\" class=\"p-2 text-on-surface hover:bg-surface-dark/5 dark:text-on-surface-dark dark:hover:bg-surface/5 transition-colors\"><!-- Light Mode Icon (Sun) - shows when dark mode is ON --><svg x-show=\"$store.darkMode.on\" name=\"Light Mode\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.2\" stroke=\"currentColor\" class=\"h-6 w-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z\"></path></svg><!-- Dark Mode Icon (Moon) - shows when dark mode is OFF --><svg x-show=\"!$store.darkMode.on\" name=\"Dark Mode\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.2\" stroke=\"currentColor\" class=\"h-6 w-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z\"></path></svg></button><!-- GitHub Link --><a href=\"https://github.com/araihu/goshtoso\" target=\"_blank\" class=\"hidden sm:inline-flex p-2 rounded-md hover:bg-surface-alt dark:hover:bg-surface-dark-alt transition-colors\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-5 w-5\" fill=\"currentColor\" viewBox=\"0 0 24 24\"><path d=\"M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z\"></path></svg></a></div></div></header><div class=\"flex h-[calc(100vh-4rem)] overflow-hidden\"><!-- Sidebar Component --><div data-boot-anim=\"sidebar\" class=\"fixed top-16 bottom-0 left-0 z-40 w-72 shrink-0 transform transition-transform duration-200 ease-in-out lg:static lg:translate-x-0 lg:h-full\" :class=\"sidebarOpen ? 'translate-x-0' : '-translate-x-full'\"><div class=\"h-full\" x-data=\"{ q: '' }\" x-effect=\"\n\t\t\t\t\t\tvoid $store.nav?.path;\n\t\t\t\t\t\tconst items = $el.querySelectorAll('[data-sidebar-item]');\n\t\t\t\t\t\tconst sections = $el.querySelectorAll('[data-sidebar-section]');\n\t\t\t\t\t\tconst term = q.toLowerCase();\n\t\t\t\t\t\titems.forEach(el => {\n\t\t\t\t\t\t\tel.style.display = !term || el.dataset.sidebarItem.toLowerCase().includes(term) ? '' : 'none';\n\t\t\t\t\t\t});\n\t\t\t\t\t\tsections.forEach(el => {\n\t\t\t\t\t\t\tconst visible = [...el.querySelectorAll('[data-sidebar-item]')].some(i => i.style.display !== 'none');\n\t\t\t\t\t\t\tel.style.display = visible ? '' : 'none';\n\t\t\t\t\t\t});\n\t\t\t\t\t\"><div id=\"sidebar-nav-content\" class=\"h-full\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div><!-- Dark Mode Toggle --><button id=\"darkModeToggleBtn\" aria-label=\"dark mode toggle\" @click=\"$store.darkMode.toggle()\" class=\"p-2 text-on-surface hover:bg-surface-dark/5 dark:text-on-surface-dark dark:hover:bg-surface/5 transition-colors\"><!-- Light Mode Icon (Sun) - shows when dark mode is ON --><svg x-show=\"$store.darkMode.on\" name=\"Light Mode\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.2\" stroke=\"currentColor\" class=\"h-6 w-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z\"></path></svg><!-- Dark Mode Icon (Moon) - shows when dark mode is OFF --><svg x-show=\"!$store.darkMode.on\" name=\"Dark Mode\" xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.2\" stroke=\"currentColor\" class=\"h-6 w-6\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z\"></path></svg></button><!-- GitHub Link --><a href=\"https://github.com/araihu/goshtoso\" target=\"_blank\" class=\"hidden sm:inline-flex p-2 rounded-md hover:bg-surface-alt dark:hover:bg-surface-dark-alt transition-colors\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-5 w-5\" fill=\"currentColor\" viewBox=\"0 0 24 24\"><path d=\"M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z\"></path></svg></a></div></div></header><div class=\"flex h-[calc(100vh-4rem)] overflow-hidden\"><!-- Sidebar Component --><div data-boot-anim=\"sidebar\" class=\"fixed top-16 bottom-0 left-0 z-40 w-72 shrink-0 transform transition-transform duration-200 ease-in-out lg:static lg:translate-x-0 lg:h-full\" :class=\"sidebarOpen ? 'translate-x-0' : '-translate-x-full'\"><div class=\"h-full\" x-data=\"{ q: '' }\" x-effect=\"\n\t\t\t\t\t\tvoid $store.nav?.path;\n\t\t\t\t\t\tconst items = $el.querySelectorAll('[data-sidebar-item]');\n\t\t\t\t\t\tconst sections = $el.querySelectorAll('[data-sidebar-section]');\n\t\t\t\t\t\tconst term = q.toLowerCase();\n\t\t\t\t\t\titems.forEach(el => {\n\t\t\t\t\t\t\tel.style.display = !term || el.dataset.sidebarItem.toLowerCase().includes(term) ? '' : 'none';\n\t\t\t\t\t\t});\n\t\t\t\t\t\tsections.forEach(el => {\n\t\t\t\t\t\t\tconst visible = [...el.querySelectorAll('[data-sidebar-item]')].some(i => i.style.display !== 'none');\n\t\t\t\t\t\t\tel.style.display = visible ? '' : 'none';\n\t\t\t\t\t\t});\n\t\t\t\t\t\"><div id=\"sidebar-nav-content\" class=\"h-full\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -187,29 +166,29 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div></div></div><!-- Overlay for mobile sidebar --><div x-show=\"sidebarOpen\" @click=\"sidebarOpen = false\" class=\"fixed inset-0 z-30 bg-black/50 lg:hidden\" x-cloak></div><!-- Main Content --><main data-boot-anim=\"main\" class=\"flex-1 overflow-y-auto p-6 lg:p-8\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div></div></div><!-- Overlay for mobile sidebar --><div x-show=\"sidebarOpen\" @click=\"sidebarOpen = false\" class=\"fixed inset-0 z-30 bg-black/50 lg:hidden\" x-cloak></div><!-- Main Content --><main data-boot-anim=\"main\" class=\"flex-1 overflow-y-auto p-6 lg:p-8\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var11 = []any{"mx-auto " + mainContentMaxWidth(activeComponent)}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var11...)
+		var templ_7745c5c3_Var9 = []any{"mx-auto " + mainContentMaxWidth(activeComponent)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var9...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"main-content\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div id=\"main-content\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var12 string
-		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var11).String())
+		var templ_7745c5c3_Var10 string
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var9).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var12)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var10)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -225,7 +204,7 @@ func Layout(title string, activeComponent string, content templ.Component) templ
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div></main><!-- Right rail: \"On this page\" section nav, built from [data-toc-heading]. --><aside id=\"toc-rail\" data-boot-anim=\"main\" class=\"hidden xl:block w-60 shrink-0 overflow-y-auto border-l border-outline dark:border-outline-dark\"><div class=\"sticky top-0 px-6 py-8\"><p class=\"mb-3 text-xs font-semibold uppercase tracking-wide text-on-surface-muted dark:text-on-surface-dark-muted\">On this page</p><nav id=\"toc-list\" aria-label=\"On this page\" class=\"flex flex-col border-l border-outline dark:border-outline-dark\"></nav></div></aside></div><!-- Browser storage notice. Shows until the visitor chooses allowed or denied\n\t\t\t     storage via the gt_storage preference cookie. Keep in lock-step with\n\t\t\t     landing.templ's cookieConsent(). --><div x-data=\"{ show: !window.goshtosoStorageConsent || window.goshtosoStorageConsent.shouldShow(), allow() { window.goshtosoStorageConsent.allow(); this.show = false }, deny() { window.goshtosoStorageConsent.deny(); this.show = false } }\" x-show=\"show\" x-cloak x-transition class=\"fixed bottom-4 left-4 right-4 sm:left-auto z-50 flex max-w-none sm:max-w-md flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark\" role=\"dialog\" aria-modal=\"false\" aria-labelledby=\"cookie-banner-title\"><div class=\"flex items-center gap-2 border-b border-outline px-4 py-3 dark:border-outline-dark\"><h3 id=\"cookie-banner-title\" class=\"font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Browser storage</h3></div><p class=\"px-4 text-sm text-on-surface dark:text-on-surface-dark\">Goshtoso can store preferences and demo state in your browser. Some examples use cookies and IndexedDB to persist local demo state. There is no analytics, advertising, or third-party tracking. You can use the site without storage, but preferences and some examples will reset or stop persisting. Details in our <a href=\"/privacy\" hx-get=\"/privacy\" hx-target=\"#main-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" @click=\"show = false\" class=\"text-primary dark:text-primary-dark underline underline-offset-2\">Privacy Policy</a>.</p><div class=\"flex flex-col-reverse gap-2 px-4 pb-4 sm:flex-row sm:justify-end\"><button @click=\"deny()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius border border-outline text-on-surface dark:border-outline-dark dark:text-on-surface-dark hover:border-primary dark:hover:border-primary-dark hover:text-primary dark:hover:text-primary-dark transition-colors\">Use without storage</button> <button @click=\"allow()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark hover:opacity-90 transition-opacity\">Allow browser storage</button></div></div><!-- Right-rail \"On this page\" TOC: built from #main-content [data-toc-heading].\n\t\t\t     Rebuilt on every main-content HTMX swap via window.buildTOC (see head script). --><script>\n\t\t\t\t(function () {\n\t\t\t\t\tvar spy = null;\n\t\t\t\t\tfunction clearActive(nav) {\n\t\t\t\t\t\tnav.querySelectorAll('[data-toc-link]').forEach(function (a) {\n\t\t\t\t\t\t\ta.classList.remove('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t\t\ta.classList.add('border-transparent');\n\t\t\t\t\t\t});\n\t\t\t\t\t}\n\t\t\t\t\tfunction setActive(nav, id) {\n\t\t\t\t\t\tvar a = nav.querySelector('[data-toc-link=\"' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '\"]');\n\t\t\t\t\t\tif (!a) return;\n\t\t\t\t\t\tclearActive(nav);\n\t\t\t\t\t\ta.classList.remove('border-transparent');\n\t\t\t\t\t\ta.classList.add('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t}\n\t\t\t\t\twindow.buildTOC = function () {\n\t\t\t\t\t\tvar rail = document.getElementById('toc-rail');\n\t\t\t\t\t\tvar nav = document.getElementById('toc-list');\n\t\t\t\t\t\tvar main = document.getElementById('main-content');\n\t\t\t\t\t\tif (!rail || !nav || !main) return;\n\t\t\t\t\t\tif (spy) { spy.disconnect(); spy = null; }\n\t\t\t\t\t\tvar heads = Array.prototype.slice.call(main.querySelectorAll('[data-toc-heading]'));\n\t\t\t\t\t\tnav.innerHTML = '';\n\t\t\t\t\t\t// One heading (just the page title) isn't worth a rail — hide it.\n\t\t\t\t\t\tif (heads.length < 2) { rail.style.display = 'none'; return; }\n\t\t\t\t\t\trail.style.display = '';\n\t\t\t\t\t\theads.forEach(function (h) {\n\t\t\t\t\t\t\tif (!h.id) return;\n\t\t\t\t\t\t\tvar a = document.createElement('a');\n\t\t\t\t\t\t\ta.href = '#' + h.id;\n\t\t\t\t\t\t\ta.textContent = (h.textContent || '').trim();\n\t\t\t\t\t\t\ta.setAttribute('data-toc-link', h.id);\n\t\t\t\t\t\t\ta.className = 'block border-l border-transparent py-1.5 pl-4 -ml-px text-sm text-on-surface-muted transition-colors hover:text-on-surface-strong dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-strong';\n\t\t\t\t\t\t\ta.addEventListener('click', function (ev) {\n\t\t\t\t\t\t\t\tev.preventDefault();\n\t\t\t\t\t\t\t\th.scrollIntoView({ behavior: 'smooth', block: 'start' });\n\t\t\t\t\t\t\t\thistory.replaceState(null, '', '#' + h.id);\n\t\t\t\t\t\t\t\tsetActive(nav, h.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t\tnav.appendChild(a);\n\t\t\t\t\t\t});\n\t\t\t\t\t\t// Scroll-spy: main is the scroll container, so it's the observer root.\n\t\t\t\t\t\tspy = new IntersectionObserver(function (entries) {\n\t\t\t\t\t\t\tentries.forEach(function (en) {\n\t\t\t\t\t\t\t\tif (en.isIntersecting) setActive(nav, en.target.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t}, { root: main, rootMargin: '0px 0px -75% 0px', threshold: 0 });\n\t\t\t\t\t\theads.forEach(function (h) { if (h.id) spy.observe(h); });\n\t\t\t\t\t\tsetActive(nav, heads[0].id);\n\t\t\t\t\t};\n\t\t\t\t\tif (document.readyState === 'loading') {\n\t\t\t\t\t\tdocument.addEventListener('DOMContentLoaded', window.buildTOC);\n\t\t\t\t\t} else {\n\t\t\t\t\t\twindow.buildTOC();\n\t\t\t\t\t}\n\t\t\t\t})();\n\t\t\t</script></body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div></main><!-- Right rail: \"On this page\" section nav, built from [data-toc-heading]. --><aside id=\"toc-rail\" data-boot-anim=\"main\" class=\"hidden xl:block w-60 shrink-0 overflow-y-auto border-l border-outline dark:border-outline-dark\"><div class=\"sticky top-0 px-6 py-8\"><p class=\"mb-3 text-xs font-semibold uppercase tracking-wide text-on-surface-muted dark:text-on-surface-dark-muted\">On this page</p><nav id=\"toc-list\" aria-label=\"On this page\" class=\"flex flex-col border-l border-outline dark:border-outline-dark\"></nav></div></aside></div><!-- Browser storage notice. Shows until the visitor chooses allowed or denied\n\t\t\t     storage via the gt_storage preference cookie. Keep in lock-step with\n\t\t\t     landing.templ's cookieConsent(). --><div x-data=\"{ show: !window.goshtosoStorageConsent || window.goshtosoStorageConsent.shouldShow(), allow() { window.goshtosoStorageConsent.allow(); this.show = false }, deny() { window.goshtosoStorageConsent.deny(); this.show = false } }\" x-show=\"show\" x-cloak x-transition class=\"fixed bottom-4 left-4 right-4 sm:left-auto z-50 flex max-w-none sm:max-w-md flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark\" role=\"dialog\" aria-modal=\"false\" aria-labelledby=\"cookie-banner-title\"><div class=\"flex items-center gap-2 border-b border-outline px-4 py-3 dark:border-outline-dark\"><h3 id=\"cookie-banner-title\" class=\"font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Browser storage</h3></div><p class=\"px-4 text-sm text-on-surface dark:text-on-surface-dark\">Goshtoso can store preferences and demo state in your browser. Some examples use cookies and IndexedDB to persist local demo state. There is no analytics, advertising, or third-party tracking. You can use the site without storage, but preferences and some examples will reset or stop persisting. Details in our <a href=\"/privacy\" hx-get=\"/privacy\" hx-target=\"#main-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" @click=\"show = false\" class=\"text-primary dark:text-primary-dark underline underline-offset-2\">Privacy Policy</a>.</p><div class=\"flex flex-col-reverse gap-2 px-4 pb-4 sm:flex-row sm:justify-end\"><button @click=\"deny()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius border border-outline text-on-surface dark:border-outline-dark dark:text-on-surface-dark hover:border-primary dark:hover:border-primary-dark hover:text-primary dark:hover:text-primary-dark transition-colors\">Use without storage</button> <button @click=\"allow()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark hover:opacity-90 transition-opacity\">Allow browser storage</button></div></div><!-- Right-rail \"On this page\" TOC: built from #main-content [data-toc-heading].\n\t\t\t     Rebuilt on every main-content HTMX swap via window.buildTOC (see head script). --><script>\n\t\t\t\t(function () {\n\t\t\t\t\tvar spy = null;\n\t\t\t\t\tfunction clearActive(nav) {\n\t\t\t\t\t\tnav.querySelectorAll('[data-toc-link]').forEach(function (a) {\n\t\t\t\t\t\t\ta.classList.remove('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t\t\ta.classList.add('border-transparent');\n\t\t\t\t\t\t});\n\t\t\t\t\t}\n\t\t\t\t\tfunction setActive(nav, id) {\n\t\t\t\t\t\tvar a = nav.querySelector('[data-toc-link=\"' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '\"]');\n\t\t\t\t\t\tif (!a) return;\n\t\t\t\t\t\tclearActive(nav);\n\t\t\t\t\t\ta.classList.remove('border-transparent');\n\t\t\t\t\t\ta.classList.add('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t}\n\t\t\t\t\twindow.buildTOC = function () {\n\t\t\t\t\t\tvar rail = document.getElementById('toc-rail');\n\t\t\t\t\t\tvar nav = document.getElementById('toc-list');\n\t\t\t\t\t\tvar main = document.getElementById('main-content');\n\t\t\t\t\t\tif (!rail || !nav || !main) return;\n\t\t\t\t\t\tif (spy) { spy.disconnect(); spy = null; }\n\t\t\t\t\t\tvar heads = Array.prototype.slice.call(main.querySelectorAll('[data-toc-heading]'));\n\t\t\t\t\t\tnav.innerHTML = '';\n\t\t\t\t\t\t// One heading (just the page title) isn't worth a rail — hide it.\n\t\t\t\t\t\tif (heads.length < 2) { rail.style.display = 'none'; return; }\n\t\t\t\t\t\trail.style.display = '';\n\t\t\t\t\t\theads.forEach(function (h) {\n\t\t\t\t\t\t\tif (!h.id) return;\n\t\t\t\t\t\t\tvar a = document.createElement('a');\n\t\t\t\t\t\t\ta.href = '#' + h.id;\n\t\t\t\t\t\t\ta.textContent = (h.textContent || '').trim();\n\t\t\t\t\t\t\ta.setAttribute('data-toc-link', h.id);\n\t\t\t\t\t\t\ta.className = 'block border-l border-transparent py-1.5 pl-4 -ml-px text-sm text-on-surface-muted transition-colors hover:text-on-surface-strong dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-strong';\n\t\t\t\t\t\t\ta.addEventListener('click', function (ev) {\n\t\t\t\t\t\t\t\tev.preventDefault();\n\t\t\t\t\t\t\t\th.scrollIntoView({ behavior: 'smooth', block: 'start' });\n\t\t\t\t\t\t\t\thistory.replaceState(null, '', '#' + h.id);\n\t\t\t\t\t\t\t\tsetActive(nav, h.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t\tnav.appendChild(a);\n\t\t\t\t\t\t});\n\t\t\t\t\t\t// Scroll-spy: main is the scroll container, so it's the observer root.\n\t\t\t\t\t\tspy = new IntersectionObserver(function (entries) {\n\t\t\t\t\t\t\tentries.forEach(function (en) {\n\t\t\t\t\t\t\t\tif (en.isIntersecting) setActive(nav, en.target.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t}, { root: main, rootMargin: '0px 0px -75% 0px', threshold: 0 });\n\t\t\t\t\t\theads.forEach(function (h) { if (h.id) spy.observe(h); });\n\t\t\t\t\t\tsetActive(nav, heads[0].id);\n\t\t\t\t\t};\n\t\t\t\t\tif (document.readyState === 'loading') {\n\t\t\t\t\t\tdocument.addEventListener('DOMContentLoaded', window.buildTOC);\n\t\t\t\t\t} else {\n\t\t\t\t\t\twindow.buildTOC();\n\t\t\t\t\t}\n\t\t\t\t})();\n\t\t\t</script></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -286,12 +265,12 @@ func sidebarSearchSlot() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var13 == nil {
-			templ_7745c5c3_Var13 = templ.NopComponent
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<div class=\"shrink-0 px-4 py-3\"><div class=\"relative\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" fill=\"none\" stroke-width=\"2\" class=\"absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-on-surface-muted dark:text-on-surface-dark-muted\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z\"></path></svg> <input type=\"search\" x-model=\"q\" class=\"w-full border border-outline rounded-radius bg-surface py-1.5 pl-9 pr-3 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-75 dark:border-outline-dark dark:bg-surface-dark/50 dark:focus-visible:outline-primary-dark\" name=\"search\" aria-label=\"Search components\" placeholder=\"Search components...\"></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div class=\"shrink-0 px-4 py-3\"><div class=\"relative\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" fill=\"none\" stroke-width=\"2\" class=\"absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-on-surface-muted dark:text-on-surface-dark-muted\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z\"></path></svg> <input type=\"search\" x-model=\"q\" class=\"w-full border border-outline rounded-radius bg-surface py-1.5 pl-9 pr-3 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-75 dark:border-outline-dark dark:bg-surface-dark/50 dark:focus-visible:outline-primary-dark\" name=\"search\" aria-label=\"Search components\" placeholder=\"Search components...\"></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -315,12 +294,12 @@ func sidebarHomeIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var14 == nil {
-			templ_7745c5c3_Var14 = templ.NopComponent
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -344,12 +323,12 @@ func sidebarExamplesIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var15 == nil {
-			templ_7745c5c3_Var15 = templ.NopComponent
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M3.75 6A2.25 2.25 0 016 3.75h3.75A2.25 2.25 0 0112 6v3.75A2.25 2.25 0 019.75 12H6a2.25 2.25 0 01-2.25-2.25V6ZM14.25 6A2.25 2.25 0 0116.5 3.75H18A2.25 2.25 0 0120.25 6v1.5A2.25 2.25 0 0118 9.75h-1.5a2.25 2.25 0 01-2.25-2.25V6ZM14.25 14.25A2.25 2.25 0 0116.5 12H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-1.5A2.25 2.25 0 0114.25 18v-3.75ZM3.75 16.5A2.25 2.25 0 016 14.25h3.75A2.25 2.25 0 0112 16.5V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-1.5Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M3.75 6A2.25 2.25 0 016 3.75h3.75A2.25 2.25 0 0112 6v3.75A2.25 2.25 0 019.75 12H6a2.25 2.25 0 01-2.25-2.25V6ZM14.25 6A2.25 2.25 0 0116.5 3.75H18A2.25 2.25 0 0120.25 6v1.5A2.25 2.25 0 0118 9.75h-1.5a2.25 2.25 0 01-2.25-2.25V6ZM14.25 14.25A2.25 2.25 0 0116.5 12H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-1.5A2.25 2.25 0 0114.25 18v-3.75ZM3.75 16.5A2.25 2.25 0 016 14.25h3.75A2.25 2.25 0 0112 16.5V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-1.5Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -373,12 +352,12 @@ func sidebarThemeIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var16 == nil {
-			templ_7745c5c3_Var16 = templ.NopComponent
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M4.098 19.902a3.75 3.75 0 005.304 0l6.401-6.402M6.75 21A3.75 3.75 0 013 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 003.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.879 2.88M6.75 17.25h.008v.008H6.75v-.008z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M4.098 19.902a3.75 3.75 0 005.304 0l6.401-6.402M6.75 21A3.75 3.75 0 013 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 003.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.879 2.88M6.75 17.25h.008v.008H6.75v-.008z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -402,12 +381,12 @@ func sidebarAttributionsIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var17 == nil {
-			templ_7745c5c3_Var17 = templ.NopComponent
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -431,12 +410,12 @@ func sidebarLicenseIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var18 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var18 == nil {
-			templ_7745c5c3_Var18 = templ.NopComponent
+		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var16 == nil {
+			templ_7745c5c3_Var16 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -600,33 +579,33 @@ func componentNavFooter(activeComponent string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var19 == nil {
-			templ_7745c5c3_Var19 = templ.NopComponent
+		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var17 == nil {
+			templ_7745c5c3_Var17 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		prev, next := getComponentNav(activeComponent)
 		if prev != nil || next != nil {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div class=\"mt-12 flex items-center justify-between border-t border-outline dark:border-outline-dark pt-6 pb-4\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div class=\"mt-12 flex items-center justify-between border-t border-outline dark:border-outline-dark pt-6 pb-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if prev != nil {
 				prevAttrs := navHxAttrs(prev.Href, "")
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<a href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var20 templ.SafeURL
-				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(prev.Href))
+				var templ_7745c5c3_Var18 templ.SafeURL
+				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(prev.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 599, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 574, Col: 36}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -634,45 +613,45 @@ func componentNavFooter(activeComponent string) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, " class=\"group flex items-center gap-2 text-sm text-on-surface-muted hover:text-primary dark:text-on-surface-dark-muted dark:hover:text-primary-dark transition-colors\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"size-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M15 19l-7-7 7-7\"></path></svg> <span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " class=\"group flex items-center gap-2 text-sm text-on-surface-muted hover:text-primary dark:text-on-surface-dark-muted dark:hover:text-primary-dark transition-colors\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"size-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M15 19l-7-7 7-7\"></path></svg> <span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var21 string
-				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(prev.Label)
+				var templ_7745c5c3_Var19 string
+				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(prev.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 606, Col: 23}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 581, Col: 23}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</span></a> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</span></a> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if next != nil {
 				nextAttrs := navHxAttrs(next.Href, "")
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<a href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var22 templ.SafeURL
-				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(next.Href))
+				var templ_7745c5c3_Var20 templ.SafeURL
+				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(next.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 614, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 589, Col: 36}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -680,30 +659,30 @@ func componentNavFooter(activeComponent string) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, " class=\"group flex items-center gap-2 text-sm text-on-surface-muted hover:text-primary dark:text-on-surface-dark-muted dark:hover:text-primary-dark transition-colors\"><span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " class=\"group flex items-center gap-2 text-sm text-on-surface-muted hover:text-primary dark:text-on-surface-dark-muted dark:hover:text-primary-dark transition-colors\"><span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var23 string
-				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(next.Label)
+				var templ_7745c5c3_Var21 string
+				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(next.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 618, Col: 23}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 593, Col: 23}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</span> <svg xmlns=\"http://www.w3.org/2000/svg\" class=\"size-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M9 5l7 7-7 7\"></path></svg></a>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</span> <svg xmlns=\"http://www.w3.org/2000/svg\" class=\"size-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M9 5l7 7-7 7\"></path></svg></a>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -728,9 +707,9 @@ func storageConsentScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var24 == nil {
-			templ_7745c5c3_Var24 = templ.NopComponent
+		templ_7745c5c3_Var22 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var22 == nil {
+			templ_7745c5c3_Var22 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = templ.Raw(`<script>(function(){if(window.goshtosoStorageConsent)return;var pref='gt_storage';var maxAge=15552000;var demoCookies=['gt_todo','gt_profile','gt_chat'];var localKeys=['theme','darkMode','themeOverrides','themeTitleFont','themeBodyFont','themeRadius','themeCssMode','themeCssFilter','cookieConsent'];function cookieValue(name){var parts=document.cookie?document.cookie.split('; '):[];for(var i=0;i<parts.length;i++){var p=parts[i];var eq=p.indexOf('=');var key=eq>=0?p.slice(0,eq):p;if(key===name)return eq>=0?decodeURIComponent(p.slice(eq+1)):'';}return '';}function setCookie(name,value,age){document.cookie=name+'='+encodeURIComponent(value)+'; Path=/; Max-Age='+age+'; SameSite=Lax';}function expireCookie(name){setCookie(name,'',0);}function clearLocalStorage(){try{localKeys.forEach(function(key){localStorage.removeItem(key);});}catch(e){}}function clearIndexedDB(){try{if(window.indexedDB&&indexedDB.deleteDatabase)indexedDB.deleteDatabase('gt_profile');}catch(e){}}window.goshtosoStorageConsent={shouldShow:function(){var v=cookieValue(pref);return v!=='allowed'&&v!=='denied';},allowed:function(){return cookieValue(pref)!=='denied';},allow:function(){setCookie(pref,'allowed',maxAge);try{localStorage.setItem('cookieConsent','v2');}catch(e){}},deny:function(){setCookie(pref,'denied',maxAge);demoCookies.forEach(expireCookie);clearLocalStorage();clearIndexedDB();}};if(cookieValue(pref)==='denied'){clearLocalStorage();clearIndexedDB();}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
@@ -760,15 +739,15 @@ func siteFooter() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var25 == nil {
-			templ_7745c5c3_Var25 = templ.NopComponent
+		templ_7745c5c3_Var23 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var23 == nil {
+			templ_7745c5c3_Var23 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		privacyAttrs := navHxAttrs("/privacy", "")
 		attrAttrs := navHxAttrs("/attributions", "")
 		licenseAttrs := navHxAttrs("/license", "")
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<footer class=\"mt-16 border-t border-outline dark:border-outline-dark pt-8 pb-10 text-center\"><p class=\"font-title font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">Goshtoso <span class=\"font-normal text-on-surface-muted dark:text-on-surface-dark-muted\">2026</span></p><nav class=\"mt-3 flex items-center justify-center gap-2 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\"><a href=\"/privacy\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<footer class=\"mt-16 border-t border-outline dark:border-outline-dark pt-8 pb-10 text-center\"><p class=\"font-title font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">Goshtoso <span class=\"font-normal text-on-surface-muted dark:text-on-surface-dark-muted\">2026</span></p><nav class=\"mt-3 flex items-center justify-center gap-2 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\"><a href=\"/privacy\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -776,7 +755,7 @@ func siteFooter() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">Privacy</a> <span class=\"text-primary dark:text-primary-dark\">•</span> <a href=\"/attributions\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">Privacy</a> <span class=\"text-primary dark:text-primary-dark\">•</span> <a href=\"/attributions\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -784,7 +763,7 @@ func siteFooter() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">Attributions</a> <span class=\"text-primary dark:text-primary-dark\">•</span> <a href=\"/license\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">Attributions</a> <span class=\"text-primary dark:text-primary-dark\">•</span> <a href=\"/license\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -792,7 +771,7 @@ func siteFooter() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">License</a></nav><div class=\"mt-4 flex items-center justify-center gap-4\"><a href=\"https://github.com/araihu/goshtoso\" target=\"_blank\" rel=\"noopener\" aria-label=\"GitHub\" class=\"text-on-surface-muted hover:text-on-surface-strong dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-strong transition-colors\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"currentColor\" class=\"size-5\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.523 2 12 2Z\"></path></svg></a></div></footer>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">License</a></nav><div class=\"mt-4 flex items-center justify-center gap-4\"><a href=\"https://github.com/araihu/goshtoso\" target=\"_blank\" rel=\"noopener\" aria-label=\"GitHub\" class=\"text-on-surface-muted hover:text-on-surface-strong dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-strong transition-colors\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"currentColor\" class=\"size-5\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.523 2 12 2Z\"></path></svg></a></div></footer>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -800,29 +779,54 @@ func siteFooter() templ.Component {
 	})
 }
 
-type themeOption struct {
-	Key   string
-	Label string
+func getThemeOptions() []selectfield.Option {
+	return []selectfield.Option{
+		{Value: "goshtoso", Label: "Goshtoso"},
+		{Value: "minimal", Label: "Minimal"},
+		{Value: "modern", Label: "Modern"},
+		{Value: "arctic", Label: "Arctic"},
+		{Value: "high-contrast", Label: "High Contrast"},
+		{Value: "neo-brutalism", Label: "Neo Brutalism"},
+		{Value: "news", Label: "News"},
+		{Value: "industrial", Label: "Industrial"},
+		{Value: "90s", Label: "90s"},
+		{Value: "pastel", Label: "Pastel"},
+		{Value: "christmas", Label: "Christmas"},
+		{Value: "halloween", Label: "Halloween"},
+		{Value: "zombie", Label: "Halloween II"},
+		{Value: "prototype", Label: "Prototype"},
+		{Value: "totvs", Label: "TOTVS"},
+		{Value: "dracula", Label: "Dracula"},
+	}
 }
 
-func getThemeOptions() []themeOption {
-	return []themeOption{
-		{Key: "goshtoso", Label: "Goshtoso"},
-		{Key: "minimal", Label: "Minimal"},
-		{Key: "modern", Label: "Modern"},
-		{Key: "arctic", Label: "Arctic"},
-		{Key: "high-contrast", Label: "High Contrast"},
-		{Key: "neo-brutalism", Label: "Neo Brutalism"},
-		{Key: "news", Label: "News"},
-		{Key: "industrial", Label: "Industrial"},
-		{Key: "90s", Label: "90s"},
-		{Key: "pastel", Label: "Pastel"},
-		{Key: "christmas", Label: "Christmas"},
-		{Key: "halloween", Label: "Halloween"},
-		{Key: "zombie", Label: "Halloween II"},
-		{Key: "prototype", Label: "Prototype"},
-		{Key: "dracula", Label: "Dracula"},
-	}
+func themeSelectIcon() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var24 == nil {
+			templ_7745c5c3_Var24 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"size-4 shrink-0\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01\"></path></svg>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
 }
 
 var _ = templruntime.GeneratedTemplate

--- a/site/tests/e2e/combobox_bfcache_test.go
+++ b/site/tests/e2e/combobox_bfcache_test.go
@@ -32,7 +32,7 @@ func TestCombobox_BFCache_RestoresSelection(t *testing.T) {
 	trigger := page.Locator("#industry-trigger").First()
 	require.NoError(t, trigger.Click())
 
-	firstOption := page.Locator("[role=option]").First()
+	firstOption := page.Locator("#combobox-industry [role=option]").First()
 	require.NoError(t, firstOption.Click())
 
 	labelBefore, err := trigger.InnerText()
@@ -55,7 +55,7 @@ func TestCombobox_BFCache_RestoresSelection(t *testing.T) {
 	assert.Equal(t, labelBefore, labelAfter, "trigger label must match before/after back navigation")
 
 	require.NoError(t, triggerAfter.Click())
-	optionCount, err := page.Locator("[role=option]").Count()
+	optionCount, err := page.Locator("#combobox-industry [role=option]").Count()
 	require.NoError(t, err)
 	assert.Greater(t, optionCount, 0, "dropdown must have options after bfcache restore")
 }

--- a/site/tests/e2e/theme_test.go
+++ b/site/tests/e2e/theme_test.go
@@ -204,30 +204,41 @@ func TestTheme_Switching(t *testing.T) {
 	themes := []struct {
 		key   string
 		label string
+		index int
 	}{
-		{"arctic", "Arctic"},
-		{"neo-brutalism", "Neo Brutalism"},
-		{"90s", "90s"},
-		{"minimal", "Minimal"},
+		{"arctic", "Arctic", 3},
+		{"neo-brutalism", "Neo Brutalism", 5},
+		{"90s", "90s", 8},
+		{"minimal", "Minimal", 1},
 	}
 
 	for _, theme := range themes {
 		t.Run("SwitchTo_"+theme.label, func(t *testing.T) {
-			// Open the theme dropdown
-			dropdownBtn := page.Locator("button:has(span.capitalize)")
-			err := dropdownBtn.Click()
-			require.NoError(t, err)
+			// Open the theme Select dropdown.
+			trigger := page.Locator("#site-theme-trigger")
+			clickUntil(t, page, trigger, `() => document.getElementById('site-theme-trigger')?.getAttribute('aria-expanded') === 'true'`)
 
-			// Click the theme button by its data-theme-key
-			themeBtn := page.Locator(fmt.Sprintf("button[data-theme-key='%s']", theme.key))
-			err = themeBtn.WaitFor(playwright.LocatorWaitForOptions{
-				State:   playwright.WaitForSelectorStateVisible,
+			// Click the theme option rendered by the Select component.
+			themeOptionID := fmt.Sprintf("site-theme-option-%d", theme.index)
+			themeOption := page.Locator("#" + themeOptionID)
+			err := themeOption.WaitFor(playwright.LocatorWaitForOptions{
+				State:   playwright.WaitForSelectorStateAttached,
 				Timeout: playwright.Float(2000),
 			})
 			require.NoError(t, err)
 
-			err = themeBtn.Click()
+			clicked, err := page.Evaluate(
+				`(id) => {
+					const el = document.getElementById(id);
+					if (!el) return false;
+					el.scrollIntoView({ block: 'nearest' });
+					el.click();
+					return true;
+				}`,
+				themeOptionID,
+			)
 			require.NoError(t, err)
+			require.Equal(t, true, clicked)
 
 			// Verify data-theme attribute changed
 			_, err = page.WaitForFunction(


### PR DESCRIPTION
## Summary
- replace the top-nav custom theme dropdown with the Select component
- extend Select so TriggerLeading works in normal data mode, restoring the theme icon
- scope E2E option locators to avoid matching the shared header Select

## Verification
- go test ./...
- go test ./site/tests/e2e/... -count=1 -timeout 15m
- go build -o bin/server ./site/cmd/server
- git diff --check HEAD