### PR TITLE
fix(form): clarify input affordance

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1730,6 +1730,12 @@
   .border-primary {
     border-color: var(--color-primary);
   }
+  .border-primary\/20 {
+    border-color: color-mix(in srgb, oklch(62.7% 0.265 303.9) 20%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-primary) 20%, transparent);
+    }
+  }
   .border-secondary {
     border-color: var(--color-secondary);
   }
@@ -2295,6 +2301,12 @@
     background-color: color-mix(in srgb, oklch(62.7% 0.265 303.9) 10%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-primary) 10%, transparent);
+    }
+  }
+  .bg-primary\/15 {
+    background-color: color-mix(in srgb, oklch(62.7% 0.265 303.9) 15%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-primary) 15%, transparent);
     }
   }
   .bg-purple-50 {
@@ -3258,6 +3270,12 @@
   }
   .text-primary {
     color: var(--color-primary);
+  }
+  .text-primary\/80 {
+    color: color-mix(in srgb, oklch(62.7% 0.265 303.9) 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-primary) 80%, transparent);
+    }
   }
   .text-red-700 {
     color: var(--color-red-700);
@@ -4774,14 +4792,19 @@
       cursor: not-allowed;
     }
   }
+  .disabled\:bg-surface-alt {
+    &:disabled {
+      background-color: var(--color-surface-alt);
+    }
+  }
+  .disabled\:text-on-surface-muted {
+    &:disabled {
+      color: var(--color-on-surface-muted);
+    }
+  }
   .disabled\:opacity-50 {
     &:disabled {
       opacity: 50%;
-    }
-  }
-  .disabled\:opacity-60 {
-    &:disabled {
-      opacity: 60%;
     }
   }
   .disabled\:opacity-75 {
@@ -4789,11 +4812,18 @@
       opacity: 75%;
     }
   }
-  .disabled\:hover\:opacity-60 {
+  .disabled\:placeholder\:text-on-surface-muted {
+    &:disabled {
+      &::placeholder {
+        color: var(--color-on-surface-muted);
+      }
+    }
+  }
+  .disabled\:hover\:opacity-50 {
     &:disabled {
       &:hover {
         @media (hover: hover) {
-          opacity: 60%;
+          opacity: 50%;
         }
       }
     }
@@ -5418,6 +5448,14 @@
       border-color: var(--color-primary-dark);
     }
   }
+  .dark\:border-primary-dark\/25 {
+    &:where(.dark, .dark *) {
+      border-color: color-mix(in srgb, oklch(71.4% 0.203 305.504) 25%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        border-color: color-mix(in oklab, var(--color-primary-dark) 25%, transparent);
+      }
+    }
+  }
   .dark\:border-secondary-dark {
     &:where(.dark, .dark *) {
       border-color: var(--color-secondary-dark);
@@ -5553,6 +5591,14 @@
       background-color: color-mix(in srgb, oklch(71.4% 0.203 305.504) 10%, transparent);
       @supports (color: color-mix(in lab, red, red)) {
         background-color: color-mix(in oklab, var(--color-primary-dark) 10%, transparent);
+      }
+    }
+  }
+  .dark\:bg-primary-dark\/20 {
+    &:where(.dark, .dark *) {
+      background-color: color-mix(in srgb, oklch(71.4% 0.203 305.504) 20%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-primary-dark) 20%, transparent);
       }
     }
   }
@@ -5850,6 +5896,14 @@
   .dark\:text-primary-dark {
     &:where(.dark, .dark *) {
       color: var(--color-primary-dark);
+    }
+  }
+  .dark\:text-primary-dark\/80 {
+    &:where(.dark, .dark *) {
+      color: color-mix(in srgb, oklch(71.4% 0.203 305.504) 80%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, var(--color-primary-dark) 80%, transparent);
+      }
     }
   }
   .dark\:text-red-300 {
@@ -6656,6 +6710,29 @@
         background-color: color-mix(in srgb, oklch(97% 0 0) 5%, transparent);
         @supports (color: color-mix(in lab, red, red)) {
           background-color: color-mix(in oklab, var(--color-surface) 5%, transparent);
+        }
+      }
+    }
+  }
+  .dark\:disabled\:bg-surface-dark-alt {
+    &:where(.dark, .dark *) {
+      &:disabled {
+        background-color: var(--color-surface-dark-alt);
+      }
+    }
+  }
+  .dark\:disabled\:text-on-surface-dark-muted {
+    &:where(.dark, .dark *) {
+      &:disabled {
+        color: var(--color-on-surface-dark-muted);
+      }
+    }
+  }
+  .dark\:disabled\:placeholder\:text-on-surface-dark-muted {
+    &:where(.dark, .dark *) {
+      &:disabled {
+        &::placeholder {
+          color: var(--color-on-surface-dark-muted);
         }
       }
     }

--- a/components/combobox/body_test.go
+++ b/components/combobox/body_test.go
@@ -273,6 +273,26 @@ func TestCombobox_RootDeclaresCloseOnSelectBehavior(t *testing.T) {
 	})
 }
 
+func TestCombobox_TriggerUsesActiveSurfaceVocabulary(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		state State
+	}{
+		{name: "placeholder", state: State{}},
+		{name: "selected", state: State{Selected: []string{"maas"}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			classes := triggerBtnClass(tt.state)
+			for _, want := range []string{
+				"bg-surface",
+				"text-on-surface-strong",
+			} {
+				assert.Contains(t, classes, want)
+			}
+		})
+	}
+}
+
 func TestCombobox_ServerMode_HasHXPost(t *testing.T) {
 	cfg := Config{
 		ID: "team", Name: "team", Mode: ModeMultiple,

--- a/components/combobox/combobox.templ
+++ b/components/combobox/combobox.templ
@@ -236,9 +236,9 @@ templ Combobox(cfg Config, state State) {
 
 func triggerBtnClass(state State) string {
 	if len(state.Selected) > 0 {
-		return "border-secondary bg-secondary/10 text-on-surface-strong dark:border-secondary-dark dark:bg-secondary-dark/15 dark:text-on-surface-dark-strong"
+		return "border-secondary bg-surface text-on-surface-strong dark:border-secondary-dark dark:bg-surface-dark dark:text-on-surface-dark-strong"
 	}
-	return "border-outline bg-surface-alt text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt/50 dark:text-on-surface-dark"
+	return "border-outline bg-surface text-on-surface-strong dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark-strong"
 }
 
 func triggerLabelClass(state State) string {

--- a/components/combobox/combobox_templ.go
+++ b/components/combobox/combobox_templ.go
@@ -1032,9 +1032,9 @@ func Combobox(cfg Config, state State) templ.Component {
 
 func triggerBtnClass(state State) string {
 	if len(state.Selected) > 0 {
-		return "border-secondary bg-secondary/10 text-on-surface-strong dark:border-secondary-dark dark:bg-secondary-dark/15 dark:text-on-surface-dark-strong"
+		return "border-secondary bg-surface text-on-surface-strong dark:border-secondary-dark dark:bg-surface-dark dark:text-on-surface-dark-strong"
 	}
-	return "border-outline bg-surface-alt text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt/50 dark:text-on-surface-dark"
+	return "border-outline bg-surface text-on-surface-strong dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark-strong"
 }
 
 func triggerLabelClass(state State) string {

--- a/components/select/types.go
+++ b/components/select/types.go
@@ -97,7 +97,7 @@ func (cfg Config) ContainerClasses() string {
 
 // SelectClasses returns CSS classes for the select element (legacy, kept for compatibility)
 func (cfg Config) SelectClasses() string {
-	base := "w-full appearance-none rounded-radius border bg-surface-alt px-4 py-2 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-75 dark:bg-surface-dark-alt/50 dark:focus-visible:outline-primary-dark"
+	base := "w-full appearance-none rounded-radius border bg-surface px-4 py-2 text-sm text-on-surface-strong focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:bg-surface-alt disabled:text-on-surface-muted disabled:opacity-50 dark:bg-surface-dark dark:text-on-surface-dark-strong dark:focus-visible:outline-primary-dark dark:disabled:bg-surface-dark-alt dark:disabled:text-on-surface-dark-muted"
 
 	switch cfg.State {
 	case StateError:
@@ -111,19 +111,19 @@ func (cfg Config) SelectClasses() string {
 
 // TriggerClasses returns CSS classes for the custom dropdown trigger button
 func (cfg Config) TriggerClasses() string {
-	base := "inline-flex w-full items-center justify-between gap-2 rounded-radius border px-4 py-2 text-sm transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:focus-visible:outline-primary-dark disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:opacity-60"
+	base := "inline-flex w-full items-center justify-between gap-2 rounded-radius border px-4 py-2 text-sm transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:focus-visible:outline-primary-dark disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:opacity-50"
 
 	if cfg.IsEffectivelyDisabled() {
-		return base + " border-outline bg-surface-alt/50 text-on-surface/50 cursor-not-allowed dark:border-outline-dark dark:bg-surface-dark-alt/30 dark:text-on-surface-dark/50"
+		return base + " border-outline bg-surface-alt text-on-surface-muted opacity-50 cursor-not-allowed dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark-muted"
 	}
 
 	switch cfg.State {
 	case StateError:
-		return base + " border-danger bg-surface-alt text-on-surface dark:bg-surface-dark-alt/50 dark:text-on-surface-dark"
+		return base + " border-danger bg-surface text-on-surface-strong dark:bg-surface-dark dark:text-on-surface-dark-strong"
 	case StateSuccess:
-		return base + " border-success bg-surface-alt text-on-surface dark:bg-surface-dark-alt/50 dark:text-on-surface-dark"
+		return base + " border-success bg-surface text-on-surface-strong dark:bg-surface-dark dark:text-on-surface-dark-strong"
 	default:
-		return base + " border-outline bg-surface-alt text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt/50 dark:text-on-surface-dark"
+		return base + " border-outline bg-surface text-on-surface-strong dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark-strong"
 	}
 }
 

--- a/components/select/types_test.go
+++ b/components/select/types_test.go
@@ -1,0 +1,35 @@
+package selectfield
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTriggerClassesUseActiveSurfaceVocabulary(t *testing.T) {
+	classes := Config{}.TriggerClasses()
+
+	for _, want := range []string{
+		"bg-surface",
+		"text-on-surface-strong",
+		"disabled:opacity-50",
+	} {
+		if !strings.Contains(classes, want) {
+			t.Fatalf("TriggerClasses() missing %q in %q", want, classes)
+		}
+	}
+}
+
+func TestDisabledTriggerClassesUseDisabledVocabulary(t *testing.T) {
+	classes := Config{Disabled: true}.TriggerClasses()
+
+	for _, want := range []string{
+		"bg-surface-alt",
+		"text-on-surface-muted",
+		"opacity-50",
+		"cursor-not-allowed",
+	} {
+		if !strings.Contains(classes, want) {
+			t.Fatalf("TriggerClasses() missing %q in %q", want, classes)
+		}
+	}
+}

--- a/components/tagslist/tagslist.templ
+++ b/components/tagslist/tagslist.templ
@@ -22,13 +22,13 @@ templ TagsList(cfg Config) {
 	>
 		<div class="flex flex-wrap gap-2" data-tagslist-chips>
 			<template x-for="(item, i) in items" x-bind:key="i">
-				<span class="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-full bg-primary/10 text-primary dark:bg-primary-dark/10 dark:text-primary-dark">
+				<span class="inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-full border border-primary/20 bg-primary/15 text-primary dark:border-primary-dark/25 dark:bg-primary-dark/20 dark:text-primary-dark">
 					<span x-text="item"></span>
 					if !cfg.Disabled {
 						<button
 							type="button"
 							x-on:click="items.splice(i, 1)"
-							class="cursor-pointer hover:opacity-70"
+							class="cursor-pointer rounded-full text-primary/80 hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:text-primary-dark/80 dark:hover:text-primary-dark dark:focus-visible:outline-primary-dark"
 							aria-label="Remove tag"
 						>
 							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-3" aria-hidden="true">
@@ -53,7 +53,7 @@ templ TagsList(cfg Config) {
 				<button
 					type="button"
 					x-on:click="addTag()"
-					class="cursor-pointer px-3 py-2 text-sm rounded-radius border border-dashed border-outline dark:border-outline-dark text-on-surface dark:text-on-surface-dark hover:bg-outline/10 dark:hover:bg-outline-dark/20"
+					class="cursor-pointer px-3 py-2 text-sm font-medium rounded-radius border border-outline-strong bg-surface text-on-surface-strong transition hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark-strong dark:bg-surface-dark dark:text-on-surface-dark-strong dark:hover:bg-surface-dark-alt dark:focus-visible:outline-primary-dark"
 					data-tagslist-add
 				>
 					{ cfg.GetAddLabel() }

--- a/components/tagslist/tagslist_templ.go
+++ b/components/tagslist/tagslist_templ.go
@@ -94,12 +94,12 @@ func TagsList(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" data-tagslist><div class=\"flex flex-wrap gap-2\" data-tagslist-chips><template x-for=\"(item, i) in items\" x-bind:key=\"i\"><span class=\"inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-full bg-primary/10 text-primary dark:bg-primary-dark/10 dark:text-primary-dark\"><span x-text=\"item\"></span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" data-tagslist><div class=\"flex flex-wrap gap-2\" data-tagslist-chips><template x-for=\"(item, i) in items\" x-bind:key=\"i\"><span class=\"inline-flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-full border border-primary/20 bg-primary/15 text-primary dark:border-primary-dark/25 dark:bg-primary-dark/20 dark:text-primary-dark\"><span x-text=\"item\"></span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if !cfg.Disabled {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<button type=\"button\" x-on:click=\"items.splice(i, 1)\" class=\"cursor-pointer hover:opacity-70\" aria-label=\"Remove tag\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 16 16\" fill=\"currentColor\" class=\"size-3\" aria-hidden=\"true\"><path d=\"M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z\"></path></svg></button> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<button type=\"button\" x-on:click=\"items.splice(i, 1)\" class=\"cursor-pointer rounded-full text-primary/80 hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:text-primary-dark/80 dark:hover:text-primary-dark dark:focus-visible:outline-primary-dark\" aria-label=\"Remove tag\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 16 16\" fill=\"currentColor\" class=\"size-3\" aria-hidden=\"true\"><path d=\"M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94 5.28 4.22Z\"></path></svg></button> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -122,7 +122,7 @@ func TagsList(cfg Config) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" x-on:keydown.enter.prevent=\"addTag()\" class=\"flex-1 px-3 py-2 text-sm rounded-radius border border-outline dark:border-outline-dark bg-surface dark:bg-surface-dark text-on-surface-strong dark:text-on-surface-dark-strong placeholder:text-on-surface-muted dark:placeholder:text-on-surface-dark-muted focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-primary-dark\" data-tagslist-input> <button type=\"button\" x-on:click=\"addTag()\" class=\"cursor-pointer px-3 py-2 text-sm rounded-radius border border-dashed border-outline dark:border-outline-dark text-on-surface dark:text-on-surface-dark hover:bg-outline/10 dark:hover:bg-outline-dark/20\" data-tagslist-add>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" x-on:keydown.enter.prevent=\"addTag()\" class=\"flex-1 px-3 py-2 text-sm rounded-radius border border-outline dark:border-outline-dark bg-surface dark:bg-surface-dark text-on-surface-strong dark:text-on-surface-dark-strong placeholder:text-on-surface-muted dark:placeholder:text-on-surface-dark-muted focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-primary-dark\" data-tagslist-input> <button type=\"button\" x-on:click=\"addTag()\" class=\"cursor-pointer px-3 py-2 text-sm font-medium rounded-radius border border-outline-strong bg-surface text-on-surface-strong transition hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark-strong dark:bg-surface-dark dark:text-on-surface-dark-strong dark:hover:bg-surface-dark-alt dark:focus-visible:outline-primary-dark\" data-tagslist-add>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/components/tagslist/tagslist_test.go
+++ b/components/tagslist/tagslist_test.go
@@ -1,0 +1,39 @@
+package tagslist
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestTagsListUsesActiveControlVocabulary(t *testing.T) {
+	var buf bytes.Buffer
+	err := TagsList(Config{
+		ID:     "tags",
+		Name:   "tags",
+		Values: []string{"production"},
+	}).Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	html := buf.String()
+	for _, want := range []string{
+		"bg-primary/15",
+		"border-primary/20",
+		"bg-surface",
+		"text-on-surface-strong",
+		"placeholder:text-on-surface-muted",
+		"border-outline-strong",
+		"hover:bg-surface-alt",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("TagsList render missing %q in %s", want, html)
+		}
+	}
+
+	if strings.Contains(html, "border-dashed") {
+		t.Fatalf("TagsList Add button should not use dashed inactive styling: %s", html)
+	}
+}

--- a/components/textarea/types.go
+++ b/components/textarea/types.go
@@ -63,7 +63,7 @@ func (cfg Config) LabelClasses() string {
 
 // TextareaClasses returns CSS classes for the textarea element
 func (cfg Config) TextareaClasses() string {
-	base := "w-full rounded-radius border bg-surface-alt px-2.5 py-2 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-75 dark:bg-surface-dark-alt/50 dark:focus-visible:outline-primary-dark"
+	base := "w-full rounded-radius border bg-surface px-2.5 py-2 text-sm text-on-surface-strong placeholder:text-on-surface-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:bg-surface-alt disabled:text-on-surface-muted disabled:placeholder:text-on-surface-muted disabled:opacity-50 dark:bg-surface-dark dark:text-on-surface-dark-strong dark:placeholder:text-on-surface-dark-muted dark:focus-visible:outline-primary-dark dark:disabled:bg-surface-dark-alt dark:disabled:text-on-surface-dark-muted dark:disabled:placeholder:text-on-surface-dark-muted"
 
 	switch cfg.State {
 	case StateError:

--- a/components/textarea/types_test.go
+++ b/components/textarea/types_test.go
@@ -1,0 +1,23 @@
+package textarea
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTextareaClassesUseActiveSurfaceVocabulary(t *testing.T) {
+	classes := Config{}.TextareaClasses()
+
+	for _, want := range []string{
+		"bg-surface",
+		"text-on-surface-strong",
+		"placeholder:text-on-surface-muted",
+		"disabled:opacity-50",
+		"disabled:bg-surface-alt",
+		"disabled:text-on-surface-muted",
+	} {
+		if !strings.Contains(classes, want) {
+			t.Fatalf("TextareaClasses() missing %q in %q", want, classes)
+		}
+	}
+}

--- a/components/textinput/textinput.templ
+++ b/components/textinput/textinput.templ
@@ -218,7 +218,7 @@ templ inputLabel(cfg Config) {
 
 // searchInputClasses returns special classes for search input (with left padding for icon)
 func searchInputClasses(cfg Config) string {
-	base := "w-full rounded-radius border bg-surface-alt py-2 pl-10 pr-2 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-75 dark:bg-surface-dark-alt/50 dark:focus-visible:outline-primary-dark"
+	base := "w-full rounded-radius border bg-surface py-2 pl-10 pr-2 text-sm text-on-surface-strong placeholder:text-on-surface-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:bg-surface-alt disabled:text-on-surface-muted disabled:placeholder:text-on-surface-muted disabled:opacity-50 dark:bg-surface-dark dark:text-on-surface-dark-strong dark:placeholder:text-on-surface-dark-muted dark:focus-visible:outline-primary-dark dark:disabled:bg-surface-dark-alt dark:disabled:text-on-surface-dark-muted dark:disabled:placeholder:text-on-surface-dark-muted"
 
 	switch cfg.State {
 	case StateError:

--- a/components/textinput/textinput_templ.go
+++ b/components/textinput/textinput_templ.go
@@ -1064,7 +1064,7 @@ func inputLabel(cfg Config) templ.Component {
 
 // searchInputClasses returns special classes for search input (with left padding for icon)
 func searchInputClasses(cfg Config) string {
-	base := "w-full rounded-radius border bg-surface-alt py-2 pl-10 pr-2 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-75 dark:bg-surface-dark-alt/50 dark:focus-visible:outline-primary-dark"
+	base := "w-full rounded-radius border bg-surface py-2 pl-10 pr-2 text-sm text-on-surface-strong placeholder:text-on-surface-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:bg-surface-alt disabled:text-on-surface-muted disabled:placeholder:text-on-surface-muted disabled:opacity-50 dark:bg-surface-dark dark:text-on-surface-dark-strong dark:placeholder:text-on-surface-dark-muted dark:focus-visible:outline-primary-dark dark:disabled:bg-surface-dark-alt dark:disabled:text-on-surface-dark-muted dark:disabled:placeholder:text-on-surface-dark-muted"
 
 	switch cfg.State {
 	case StateError:

--- a/components/textinput/types.go
+++ b/components/textinput/types.go
@@ -78,7 +78,7 @@ func (cfg Config) GetType() InputType {
 
 // InputClasses returns the CSS classes for the input element
 func (cfg Config) InputClasses() string {
-	base := "w-full rounded-radius border bg-surface-alt px-2 py-2 text-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-75 dark:bg-surface-dark-alt/50 dark:focus-visible:outline-primary-dark"
+	base := "w-full rounded-radius border bg-surface px-2 py-2 text-sm text-on-surface-strong placeholder:text-on-surface-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:bg-surface-alt disabled:text-on-surface-muted disabled:placeholder:text-on-surface-muted disabled:opacity-50 dark:bg-surface-dark dark:text-on-surface-dark-strong dark:placeholder:text-on-surface-dark-muted dark:focus-visible:outline-primary-dark dark:disabled:bg-surface-dark-alt dark:disabled:text-on-surface-dark-muted dark:disabled:placeholder:text-on-surface-dark-muted"
 
 	switch cfg.State {
 	case StateError:

--- a/components/textinput/types_test.go
+++ b/components/textinput/types_test.go
@@ -1,0 +1,40 @@
+package textinput
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInputClassesUseActiveSurfaceVocabulary(t *testing.T) {
+	classes := Config{}.InputClasses()
+
+	for _, want := range []string{
+		"bg-surface",
+		"text-on-surface-strong",
+		"placeholder:text-on-surface-muted",
+		"disabled:opacity-50",
+		"disabled:bg-surface-alt",
+		"disabled:text-on-surface-muted",
+	} {
+		if !strings.Contains(classes, want) {
+			t.Fatalf("InputClasses() missing %q in %q", want, classes)
+		}
+	}
+}
+
+func TestSearchInputClassesUseActiveSurfaceVocabulary(t *testing.T) {
+	classes := searchInputClasses(Config{})
+
+	for _, want := range []string{
+		"bg-surface",
+		"text-on-surface-strong",
+		"placeholder:text-on-surface-muted",
+		"disabled:opacity-50",
+		"disabled:bg-surface-alt",
+		"disabled:text-on-surface-muted",
+	} {
+		if !strings.Contains(classes, want) {
+			t.Fatalf("searchInputClasses() missing %q in %q", want, classes)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- make enabled form controls read as active with base surfaces and stronger text
- make disabled text, textarea, select, and combobox states visibly muted
- strengthen TagsList chips and Add button contrast

## Test Plan
- go test -count=1 ./components/textinput ./components/textarea ./components/combobox ./components/select ./components/tagslist
- go build -o bin/server ./site/cmd/server
- git diff --check
- go test ./...