### PR TITLE
fix(css): limit Tailwind source scan

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -280,14 +280,6 @@
     --text-4xl--line-height: calc(2.5 / 2.25);
     --text-5xl: 3rem;
     --text-5xl--line-height: 1;
-    --text-6xl: 3.75rem;
-    --text-6xl--line-height: 1;
-    --text-7xl: 4.5rem;
-    --text-7xl--line-height: 1;
-    --text-8xl: 6rem;
-    --text-8xl--line-height: 1;
-    --text-9xl: 8rem;
-    --text-9xl--line-height: 1;
     --font-weight-normal: 400;
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
@@ -295,7 +287,6 @@
     --tracking-tight: -0.025em;
     --tracking-wide: 0.025em;
     --tracking-wider: 0.05em;
-    --tracking-widest: 0.1em;
     --leading-tight: 1.25;
     --leading-relaxed: 1.625;
     --radius-xs: 0.125rem;
@@ -316,7 +307,6 @@
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
     --font-title: 'Poppins', sans-serif;
-    --font-paragraph: 'Inter', sans-serif;
     --color-surface: var(--color-neutral-100);
     --color-surface-alt: var(--color-neutral-200);
     --color-on-surface: var(--color-neutral-800);
@@ -506,17 +496,11 @@
   }
 }
 @layer utilities {
-  .\@container {
-    container-type: inline-size;
-  }
   .pointer-events-auto {
     pointer-events: auto;
   }
   .pointer-events-none {
     pointer-events: none;
-  }
-  .\!visible {
-    visibility: visible !important;
   }
   .collapse {
     visibility: collapse;
@@ -628,9 +612,6 @@
   .right-full {
     right: 100%;
   }
-  .-bottom-10 {
-    bottom: calc(var(--spacing) * -10);
-  }
   .bottom-0 {
     bottom: calc(var(--spacing) * 0);
   }
@@ -672,9 +653,6 @@
   }
   .left-full {
     left: 100%;
-  }
-  .isolate {
-    isolation: isolate;
   }
   .z-10 {
     z-index: 10;
@@ -841,14 +819,8 @@
   .inline-flex {
     display: inline-flex;
   }
-  .inline-grid {
-    display: inline-grid;
-  }
   .table {
     display: table;
-  }
-  .table-row {
-    display: table-row;
   }
   .size-1\.5 {
     width: calc(var(--spacing) * 1.5);
@@ -958,9 +930,6 @@
   .h-16 {
     height: calc(var(--spacing) * 16);
   }
-  .h-36 {
-    height: calc(var(--spacing) * 36);
-  }
   .h-40 {
     height: calc(var(--spacing) * 40);
   }
@@ -975,9 +944,6 @@
   }
   .h-80 {
     height: calc(var(--spacing) * 80);
-  }
-  .h-\[70vh\] {
-    height: 70vh;
   }
   .h-\[78vh\] {
     height: 78vh;
@@ -1228,17 +1194,8 @@
   .flex-1 {
     flex: 1;
   }
-  .flex-shrink {
-    flex-shrink: 1;
-  }
-  .shrink {
-    flex-shrink: 1;
-  }
   .shrink-0 {
     flex-shrink: 0;
-  }
-  .grow {
-    flex-grow: 1;
   }
   .border-collapse {
     border-collapse: collapse;
@@ -1333,17 +1290,11 @@
   .animate-spin {
     animation: var(--animate-spin);
   }
-  .cursor-grab {
-    cursor: grab;
-  }
   .cursor-not-allowed {
     cursor: not-allowed;
   }
   .cursor-pointer {
     cursor: pointer;
-  }
-  .resize {
-    resize: both;
   }
   .resize-none {
     resize: none;
@@ -1570,14 +1521,6 @@
       border-color: var(--color-outline);
     }
   }
-  .divide-outline\/40 {
-    :where(& > :not(:last-child)) {
-      border-color: color-mix(in srgb, oklch(87% 0 0) 40%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        border-color: color-mix(in oklab, var(--color-outline) 40%, transparent);
-      }
-    }
-  }
   .self-center {
     align-self: center;
   }
@@ -1688,9 +1631,6 @@
   .border-danger {
     border-color: var(--color-danger);
   }
-  .border-gray-200 {
-    border-color: var(--color-gray-200);
-  }
   .border-info {
     border-color: var(--color-info);
   }
@@ -1759,12 +1699,6 @@
   }
   .bg-\[\#2276aa\] {
     background-color: #2276aa;
-  }
-  .bg-\[\#f5f0e6\] {
-    background-color: #f5f0e6;
-  }
-  .bg-\[rgb\(245_240_230\)\] {
-    background-color: rgb(245 240 230);
   }
   .bg-amber-50 {
     background-color: var(--color-amber-50);
@@ -2783,9 +2717,6 @@
     --tw-gradient-to: transparent;
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
-  .bg-clip-text {
-    background-clip: text;
-  }
   .fill-danger {
     fill: var(--color-danger);
   }
@@ -2930,9 +2861,6 @@
   .pt-10 {
     padding-top: calc(var(--spacing) * 10);
   }
-  .pt-12 {
-    padding-top: calc(var(--spacing) * 12);
-  }
   .pr-0\.5 {
     padding-right: calc(var(--spacing) * 0.5);
   }
@@ -3036,22 +2964,6 @@
     font-size: var(--text-5xl);
     line-height: var(--tw-leading, var(--text-5xl--line-height));
   }
-  .text-6xl {
-    font-size: var(--text-6xl);
-    line-height: var(--tw-leading, var(--text-6xl--line-height));
-  }
-  .text-7xl {
-    font-size: var(--text-7xl);
-    line-height: var(--tw-leading, var(--text-7xl--line-height));
-  }
-  .text-8xl {
-    font-size: var(--text-8xl);
-    line-height: var(--tw-leading, var(--text-8xl--line-height));
-  }
-  .text-9xl {
-    font-size: var(--text-9xl);
-    line-height: var(--tw-leading, var(--text-9xl--line-height));
-  }
   .text-base {
     font-size: var(--text-base);
     line-height: var(--tw-leading, var(--text-base--line-height));
@@ -3124,9 +3036,6 @@
   .text-pretty {
     text-wrap: pretty;
   }
-  .text-wrap {
-    text-wrap: wrap;
-  }
   .break-words {
     overflow-wrap: break-word;
   }
@@ -3144,9 +3053,6 @@
   }
   .text-danger {
     color: var(--color-danger);
-  }
-  .text-gray-500 {
-    color: var(--color-gray-500);
   }
   .text-green-500 {
     color: var(--color-green-500);
@@ -3289,20 +3195,11 @@
   .text-warning {
     color: var(--color-warning);
   }
-  .text-white {
-    color: var(--color-white);
-  }
-  .capitalize {
-    text-transform: capitalize;
-  }
   .lowercase {
     text-transform: lowercase;
   }
   .uppercase {
     text-transform: uppercase;
-  }
-  .italic {
-    font-style: italic;
   }
   .tabular-nums {
     --tw-numeric-spacing: tabular-nums;
@@ -3344,10 +3241,6 @@
   .opacity-100 {
     opacity: 100%;
   }
-  .shadow {
-    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
-    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-  }
   .shadow-lg {
     --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -3362,14 +3255,6 @@
   }
   .shadow-xl {
     --tw-shadow: 0 20px 25px -5px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 8px 10px -6px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
-    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-  }
-  .shadow\/elevation {
-    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
-    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-  }
-  .shadow\/glow {
-    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
   .ring {
@@ -3407,18 +3292,6 @@
   .outline-primary {
     outline-color: var(--color-primary);
   }
-  .blur {
-    --tw-blur: blur(8px);
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
-  .grayscale {
-    --tw-grayscale: grayscale(100%);
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
-  .invert {
-    --tw-invert: invert(100%);
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
@@ -3429,10 +3302,6 @@
   }
   .backdrop-blur-md {
     --tw-backdrop-blur: blur(var(--blur-md));
-    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
-    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
-  }
-  .backdrop-filter {
     -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
     backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
   }
@@ -5376,16 +5245,6 @@
       }
     }
   }
-  .dark\:divide-outline-dark\/40 {
-    &:where(.dark, .dark *) {
-      :where(& > :not(:last-child)) {
-        border-color: color-mix(in srgb, oklch(37.1% 0 0) 40%, transparent);
-        @supports (color: color-mix(in lab, red, red)) {
-          border-color: color-mix(in oklab, var(--color-outline-dark) 40%, transparent);
-        }
-      }
-    }
-  }
   .dark\:border-danger {
     &:where(.dark, .dark *) {
       border-color: var(--color-danger);
@@ -5604,14 +5463,6 @@
       background-color: color-mix(in srgb, oklch(70.7% 0.165 254.624) 10%, transparent);
       @supports (color: color-mix(in lab, red, red)) {
         background-color: color-mix(in oklab, var(--color-secondary-dark) 10%, transparent);
-      }
-    }
-  }
-  .dark\:bg-secondary-dark\/15 {
-    &:where(.dark, .dark *) {
-      background-color: color-mix(in srgb, oklch(70.7% 0.165 254.624) 15%, transparent);
-      @supports (color: color-mix(in lab, red, red)) {
-        background-color: color-mix(in oklab, var(--color-secondary-dark) 15%, transparent);
       }
     }
   }

--- a/css/main.css
+++ b/css/main.css
@@ -10,15 +10,15 @@
 /* ============================================
    TAILWIND IMPORT
    ============================================ */
-@import "tailwindcss";
+@import "tailwindcss" source(none);
 
 /* ============================================
    SOURCE SCANNING - For JIT engine
    ============================================ */
 @source "../components/**/*.templ";
 @source "../components/**/*.go";
-@source "../internal/**/*.templ";
-@source "../internal/**/*.go";
+@source "../site/internal/**/*.templ";
+@source "../site/internal/**/*.go";
 
 /* Safelist the full Tailwind palette so the theme page palette popover
    can render every swatch via `var(--color-{hue}-{shade})`. Without this

--- a/scripts/themegen/gen.go
+++ b/scripts/themegen/gen.go
@@ -17,7 +17,7 @@ func generateTheme(mainCSS string, imports map[string]string) string {
 	for line := range strings.SplitSeq(mainCSS, "\n") {
 		trimmed := strings.TrimSpace(line)
 		switch {
-		case trimmed == `@import "tailwindcss";`:
+		case strings.HasPrefix(trimmed, `@import "tailwindcss"`):
 			continue
 		case strings.HasPrefix(trimmed, `@source "`):
 			// path glob like @source "../components/**" — drop.

--- a/scripts/themegen/gen_test.go
+++ b/scripts/themegen/gen_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestGenerateTheme(t *testing.T) {
 	mainCSS := `@custom-variant dark (&:where(.dark, .dark *));
-@import "tailwindcss";
+@import "tailwindcss" source(none);
 @source "../components/**/*.templ";
 @source inline("md:w-64");
 @import "../all-themes.css";


### PR DESCRIPTION
## Summary
- disable Tailwind automatic source scanning so agent/docs markdown cannot affect generated CSS
- scan component and site source explicitly
- update themegen to strip Tailwind imports that include source options

## Test Plan
- git diff --cached --check
- go build -o bin/server ./site/cmd/server
- go test ./... -count=1
- go run ./scripts/themegen && .tools/tailwindcss-$(cat assets/tailwind.version) -i css/main.css -o assets/styles.css && git diff --quiet -- assets/styles.css assets/goshtoso-theme.css