### PR TITLE
ci: add combined Go coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,10 +197,186 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  coverage:
+    name: Combined coverage
+    runs-on: araihu
+    outputs:
+      coverage_percent: ${{ steps.coverage.outputs.coverage_percent }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          # NFS-backed GOMODCACHE/GOCACHE already persist across runs on the
+          # self-hosted araihu runner. setup-go's own cache tars+uploads that
+          # same tree to the GHA cache backend on every go.sum change — a ~9min
+          # post-job step that buys nothing here. Disable it.
+          cache: false
+
+      - name: Install templ
+        run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}
+
+      - name: Install Tailwind CSS standalone
+        run: |
+          set -euo pipefail
+          ver="$(cat assets/tailwind.version)"
+          curl -fsSL -o /tmp/tailwindcss "https://github.com/tailwindlabs/tailwindcss/releases/download/v${ver}/tailwindcss-linux-x64"
+          chmod +x /tmp/tailwindcss
+          sudo mv /tmp/tailwindcss /usr/local/bin/tailwindcss
+
+      - name: Install Playwright + Chromium
+        run: |
+          go install github.com/playwright-community/playwright-go/cmd/playwright@${{ env.PLAYWRIGHT_VERSION }}
+          playwright install --with-deps chromium
+
+      - name: Generate templ + CSS
+        run: |
+          templ generate
+          tailwindcss -i css/main.css -o assets/styles.css
+
+      # The merged coverage profile uses Go's native 1.20+ coverage data format
+      # so package tests and the coverage-instrumented demo server can be
+      # combined into one statement-coverage number.
+      - name: Combined unit + E2E coverage
+        id: coverage
+        run: |
+          set -euo pipefail
+          root="$PWD"
+          root_coverpkg="github.com/araihu/goshtoso/..."
+          all_coverpkg="${root_coverpkg},github.com/araihu/goshtoso/site/..."
+
+          go work init . ./site
+
+          rm -rf .coverage
+          mkdir -p .coverage/unit-root .coverage/unit-site .coverage/e2e .coverage/merged
+
+          go test -cover -coverpkg="$root_coverpkg" ./... -count=1 \
+            -args -test.gocoverdir="$root/.coverage/unit-root"
+
+          (
+            cd site
+            site_pkgs="$(go list ./... | grep -v '/tests/e2e')"
+            go test -cover -coverpkg="$all_coverpkg" $site_pkgs -count=1 \
+              -args -test.gocoverdir="$root/.coverage/unit-site"
+
+            GOSHTOSO_E2E_COVERDIR="$root/.coverage/e2e" \
+            GOSHTOSO_E2E_COVERPKG="$all_coverpkg" \
+              go test ./tests/e2e/... -count=1 -timeout 15m
+          )
+
+          go tool covdata merge \
+            -i=.coverage/unit-root,.coverage/unit-site,.coverage/e2e \
+            -o=.coverage/merged
+          go tool covdata percent -i=.coverage/merged > .coverage/coverage-percent.txt
+          go tool covdata textfmt -i=.coverage/merged -o=.coverage/coverage.out
+          go tool cover -func=.coverage/coverage.out > .coverage/coverage-func.txt
+          go tool cover -html=.coverage/coverage.out -o .coverage/coverage.html
+
+          total_line="$(grep '^total:' .coverage/coverage-func.txt)"
+          total_percent="$(printf '%s\n' "$total_line" | sed -E 's/.*\t([0-9.]+)%.*/\1/')"
+          color="#e05d44"
+          awk "BEGIN { exit !($total_percent >= 80) }" && color="#4c1" || true
+          awk "BEGIN { exit !($total_percent >= 60 && $total_percent < 80) }" && color="#97ca00" || true
+          awk "BEGIN { exit !($total_percent >= 40 && $total_percent < 60) }" && color="#dfb317" || true
+
+          mkdir -p badges
+          cat > badges/coverage.svg <<EOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: ${total_percent}%">
+            <title>coverage: ${total_percent}%</title>
+            <linearGradient id="s" x2="0" y2="100%">
+              <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+              <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+              <stop offset=".9" stop-opacity=".3"/>
+              <stop offset="1" stop-opacity=".5"/>
+            </linearGradient>
+            <clipPath id="r">
+              <rect width="106" height="20" rx="3" fill="#fff"/>
+            </clipPath>
+            <g clip-path="url(#r)">
+              <rect width="59" height="20" fill="#555"/>
+              <rect x="59" width="47" height="20" fill="${color}"/>
+              <rect width="106" height="20" fill="url(#s)"/>
+            </g>
+            <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+              <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+              <text x="30" y="14">coverage</text>
+              <text x="81.5" y="15" fill="#010101" fill-opacity=".3">${total_percent}%</text>
+              <text x="81.5" y="14">${total_percent}%</text>
+            </g>
+          </svg>
+          EOF
+
+          echo "$total_line"
+          {
+            echo "### Combined Go coverage"
+            echo
+            echo '```text'
+            echo "$total_line"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "coverage_percent=$total_percent" >> "$GITHUB_OUTPUT"
+
+  coverage-badge:
+    name: Update coverage badge
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: coverage
+    runs-on: araihu
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Update badge SVG
+        run: |
+          set -euo pipefail
+          total_percent="${{ needs.coverage.outputs.coverage_percent }}"
+          color="#e05d44"
+          awk "BEGIN { exit !($total_percent >= 80) }" && color="#4c1" || true
+          awk "BEGIN { exit !($total_percent >= 60 && $total_percent < 80) }" && color="#97ca00" || true
+          awk "BEGIN { exit !($total_percent >= 40 && $total_percent < 60) }" && color="#dfb317" || true
+
+          mkdir -p badges
+          cat > badges/coverage.svg <<EOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: ${total_percent}%">
+            <title>coverage: ${total_percent}%</title>
+            <linearGradient id="s" x2="0" y2="100%">
+              <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+              <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+              <stop offset=".9" stop-opacity=".3"/>
+              <stop offset="1" stop-opacity=".5"/>
+            </linearGradient>
+            <clipPath id="r">
+              <rect width="106" height="20" rx="3" fill="#fff"/>
+            </clipPath>
+            <g clip-path="url(#r)">
+              <rect width="59" height="20" fill="#555"/>
+              <rect x="59" width="47" height="20" fill="${color}"/>
+              <rect width="106" height="20" fill="url(#s)"/>
+            </g>
+            <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+              <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+              <text x="30" y="14">coverage</text>
+              <text x="81.5" y="15" fill="#010101" fill-opacity=".3">${total_percent}%</text>
+              <text x="81.5" y="14">${total_percent}%</text>
+            </g>
+          </svg>
+          EOF
+
+          if git diff --quiet -- badges/coverage.svg; then
+            echo "Coverage badge already current."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add badges/coverage.svg
+          git commit -m "ci: update coverage badge [skip ci]"
+          git push
+
   deploy:
     name: Deploy to Fly.io
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    needs: [lint-build, unit-test, e2e]
+    needs: [lint-build, unit-test, e2e, coverage]
     runs-on: araihu
     concurrency: deploy-group
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ examples/getting-started/getting-started
 
 # Output of the go coverage tool
 *.out
+.coverage/
 
 # Dependency directories (Go vendor)
 vendor/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/araihu/goshtoso/actions/workflows/ci.yml"><img src="https://github.com/araihu/goshtoso/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/araihu/goshtoso/actions/workflows/ci.yml"><img src="badges/coverage.svg" alt="Coverage" /></a>
   <a href="https://pkg.go.dev/github.com/araihu/goshtoso"><img src="https://pkg.go.dev/badge/github.com/araihu/goshtoso.svg" alt="Go Reference" /></a>
   <a href="https://goreportcard.com/report/github.com/araihu/goshtoso"><img src="https://goreportcard.com/badge/github.com/araihu/goshtoso" alt="Go Report Card" /></a>
   <a href="https://github.com/araihu/goshtoso/releases"><img src="https://img.shields.io/github/v/tag/araihu/goshtoso?label=release&sort=semver" alt="Latest tag" /></a>

--- a/badges/coverage.svg
+++ b/badges/coverage.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 53.1%">
+  <title>coverage: 53.1%</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-opacity=".3"/>
+    <stop offset="1" stop-opacity=".5"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="106" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="59" height="20" fill="#555"/>
+    <rect x="59" width="47" height="20" fill="#dfb317"/>
+    <rect width="106" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+    <text x="30" y="14">coverage</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">53.1%</text>
+    <text x="81.5" y="14">53.1%</text>
+  </g>
+</svg>

--- a/justfile
+++ b/justfile
@@ -36,3 +36,44 @@ css:
 # versioned dirs and regenerate the URL constants. Mirrors `just css`.
 vendor-js:
     go run ./cmd/vendorgen -download
+
+# Run root unit tests, site unit tests, and E2E tests, then merge all Go
+# coverage data into .coverage/coverage.out and .coverage/coverage.html.
+coverage:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    root="$PWD"
+    root_coverpkg="github.com/araihu/goshtoso/..."
+    all_coverpkg="${root_coverpkg},github.com/araihu/goshtoso/site/..."
+
+    if [ ! -f go.work ]; then
+      go work init . ./site
+    fi
+
+    rm -rf .coverage
+    mkdir -p .coverage/unit-root .coverage/unit-site .coverage/e2e .coverage/merged
+
+    go test -cover -coverpkg="$root_coverpkg" ./... -count=1 \
+      -args -test.gocoverdir="$root/.coverage/unit-root"
+
+    (
+      cd site
+      site_pkgs="$(go list ./... | grep -v '/tests/e2e')"
+      go test -cover -coverpkg="$all_coverpkg" $site_pkgs -count=1 \
+        -args -test.gocoverdir="$root/.coverage/unit-site"
+
+      GOSHTOSO_E2E_COVERDIR="$root/.coverage/e2e" \
+      GOSHTOSO_E2E_COVERPKG="$all_coverpkg" \
+        go test ./tests/e2e/... -count=1 -timeout 15m
+    )
+
+    go tool covdata merge \
+      -i=.coverage/unit-root,.coverage/unit-site,.coverage/e2e \
+      -o=.coverage/merged
+    go tool covdata percent -i=.coverage/merged > .coverage/coverage-percent.txt
+    go tool covdata textfmt -i=.coverage/merged -o=.coverage/coverage.out
+    go tool cover -func=.coverage/coverage.out > .coverage/coverage-func.txt
+    go tool cover -html=.coverage/coverage.out -o .coverage/coverage.html
+
+    grep '^total:' .coverage/coverage-func.txt
+    echo "coverage artifacts: .coverage/coverage.out .coverage/coverage-func.txt .coverage/coverage-percent.txt .coverage/coverage.html"

--- a/site/cmd/server/main.go
+++ b/site/cmd/server/main.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
+	"syscall"
+	"time"
 
 	"github.com/araihu/goshtoso/site/internal/server"
 )
@@ -25,7 +30,32 @@ func main() {
 	log.Printf("Starting server on http://localhost%s", addr)
 	log.Printf("Accordion Component Demo: http://localhost%s/components/accordion", addr)
 
-	if err := http.ListenAndServe(addr, srv); err != nil {
+	httpServer := &http.Server{
+		Addr:    addr,
+		Handler: srv,
+	}
+
+	errs := make(chan error, 1)
+	go func() {
+		errs <- httpServer.ListenAndServe()
+	}()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(signals)
+
+	select {
+	case sig := <-signals:
+		log.Printf("Received %s, shutting down", sig)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := httpServer.Shutdown(ctx); err != nil {
+			log.Fatalf("Server shutdown error: %v", err)
+		}
+	case err := <-errs:
+		if errors.Is(err, http.ErrServerClosed) {
+			return
+		}
 		log.Fatalf("Server error: %v", err)
 	}
 }

--- a/site/tests/e2e/e2e_test.go
+++ b/site/tests/e2e/e2e_test.go
@@ -41,7 +41,15 @@ func freePort() (int, error) {
 func TestMain(m *testing.M) {
 	// Build server
 	projectRoot, _ := filepath.Abs("../..")
-	buildCmd := exec.Command("go", "build", "-o", "bin/server", "./cmd/server")
+	buildArgs := []string{"build", "-o", "bin/server"}
+	if coverDir := os.Getenv("GOSHTOSO_E2E_COVERDIR"); coverDir != "" {
+		buildArgs = append(buildArgs, "-cover")
+		if coverPkg := os.Getenv("GOSHTOSO_E2E_COVERPKG"); coverPkg != "" {
+			buildArgs = append(buildArgs, "-coverpkg="+coverPkg)
+		}
+	}
+	buildArgs = append(buildArgs, "./cmd/server")
+	buildCmd := exec.Command("go", buildArgs...)
 	buildCmd.Dir = projectRoot
 	if output, err := buildCmd.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to build server: %s\n%s\n", err, output)
@@ -60,6 +68,13 @@ func TestMain(m *testing.M) {
 	serverBin := filepath.Join(projectRoot, "bin", "server")
 	serverCmd = exec.Command(serverBin, "-port", fmt.Sprintf("%d", port))
 	serverCmd.Dir = projectRoot
+	if coverDir := os.Getenv("GOSHTOSO_E2E_COVERDIR"); coverDir != "" {
+		if err := os.MkdirAll(coverDir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to create coverage dir: %v\n", err)
+			os.Exit(1)
+		}
+		serverCmd.Env = append(os.Environ(), "GOCOVERDIR="+coverDir)
+	}
 	serverCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := serverCmd.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to start server: %v\n", err)


### PR DESCRIPTION
## Summary
- add a Combined coverage CI job that merges root unit, site unit, and Playwright E2E coverage via Go covdata
- add `just coverage` for the same local flow
- make the demo server shut down gracefully so instrumented E2E coverage counters flush

## Local verification
- `just coverage`
- total statement coverage: 53.1%

Coverage artifacts are generated as `coverage.out`, `coverage-func.txt`, `coverage-percent.txt`, and `coverage.html`.