### PR TITLE
refactor: complete component API naming pass

### DIFF
--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -22,7 +22,7 @@ import "github.com/araihu/goshtoso/components/accordion"  // package accordion
 | `AllowMultiple` | `bool` | AllowMultiple allows multiple items to be open simultaneously |
 | `Variant` | `Variant` | Variant determines the visual style |
 | `ID` | `string` | ID is the container ID for accessibility |
-| `RootClass` | `string` | Class allows additional CSS classes |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the accordion root. |
 
 **AccordionItem**
 
@@ -51,11 +51,8 @@ import "github.com/araihu/goshtoso/components/alert"  // package alert
 |-------|------|-------------|
 | `PrimaryLabel` | `string` | PrimaryLabel is the primary action button label |
 | `PrimaryOnClick` | `string` | PrimaryOnClick is the Alpine.js action for the primary button |
-| `PrimaryHxGet` | `string` | PrimaryHxGet triggers an HTMX GET request on the primary button |
-| `PrimaryHxPost` | `string` | PrimaryHxPost triggers an HTMX POST request on the primary button |
-| `PrimaryHxTarget` | `string` | PrimaryHxTarget is the HTMX target selector for the primary button |
-| `PrimaryHxSwap` | `string` | PrimaryHxSwap is the HTMX swap strategy for the primary button |
-| `DismissText` | `string` | DismissText is the secondary dismiss button label (defaults to "Dismiss") |
+| `PrimaryHTMX` | `*HTMXConfig` | PrimaryHTMX configures HTMX behavior for the primary button. |
+| `DismissLabel` | `string` | DismissLabel is the secondary dismiss button label (defaults to "Dismiss") |
 
 **Config**
 
@@ -68,7 +65,16 @@ import "github.com/araihu/goshtoso/components/alert"  // package alert
 | `Link` | `*LinkConfig` | Link adds a link action to the alert |
 | `Action` | `*ActionConfig` | Action adds primary + dismiss action buttons |
 | `ListItems` | `[]string` | ListItems adds a bullet list below the description |
-| `RootClass` | `string` | Class allows additional CSS classes |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the alert root. |
+
+**HTMXConfig**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Get` | `string` | Get triggers an HTMX GET request. |
+| `Post` | `string` | Post triggers an HTMX POST request. |
+| `Target` | `string` | Target is the HTMX target selector. |
+| `Swap` | `string` | Swap is the HTMX swap strategy. |
 
 **LinkConfig**
 
@@ -107,7 +113,7 @@ import "github.com/araihu/goshtoso/components/avatar"  // package avatar
 | `BorderColor` | `string` | BorderColor is the border color (defaults to variant color if empty) |
 | `Status` | `Status` | Status adds a status indicator dot |
 | `Icon` | `templ.Component` | Icon is an optional icon component (replaces initials in the base layer) |
-| `RootClass` | `string` | Class allows additional CSS classes |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the avatar root. |
 | `SrcExpr` | `string` | SrcExpr is an Alpine expression evaluated in the parent scope that yields |
 | `Reactive` | `bool` | Reactive defers the size + status-indicator size classes to the parent |
 | `ReactiveRadius` | `bool` | ReactiveRadius defers square-avatar radius classes to the parent Alpine |
@@ -118,7 +124,7 @@ import "github.com/araihu/goshtoso/components/avatar"  // package avatar
 |-------|------|-------------|
 | `Items` | `[]Config` | Items are rendered as overlapping avatars from left to right. |
 | `Label` | `string` | Label describes the group for assistive technology. |
-| `RootClass` | `string` | Class allows additional CSS classes on the stack root. |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the stack root. |
 | `Reactive` | `bool` | Reactive defers each avatar's size classes to the parent Alpine scope. |
 
 ## badge
@@ -144,7 +150,7 @@ import "github.com/araihu/goshtoso/components/badge"  // package badge
 | `Icon` | `templ.Component` | Icon is an optional icon component |
 | `Indicator` | `bool` | Indicator adds a colored dot indicator |
 | `IndicatorColor` | `string` | IndicatorColor overrides the default indicator color |
-| `RootClass` | `string` | Class allows additional CSS classes |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the badge root. |
 
 ## banner
 
@@ -177,7 +183,7 @@ import "github.com/araihu/goshtoso/components/banner"  // package banner
 | `CTA` | `*CTAConfig` | CTA is the call-to-action button config (optional) |
 | `CookieBanner` | `bool` | CookieBanner enables cookie consent mode |
 | `CookieConfig` | `*CookieBannerConfig` | CookieConfig holds cookie banner specific settings |
-| `RootClass` | `string` | Class allows additional CSS classes |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the banner root. |
 
 **CookieBannerConfig**
 
@@ -185,8 +191,8 @@ import "github.com/araihu/goshtoso/components/banner"  // package banner
 |-------|------|-------------|
 | `Title` | `string` | Title of the cookie banner |
 | `Icon` | `templ.Component` | Icon is an optional icon (emoji or component) |
-| `AcceptText` | `string` | AcceptText is the accept button text |
-| `RejectText` | `string` | RejectText is the reject button text |
+| `AcceptLabel` | `string` | AcceptLabel is the accept button label |
+| `RejectLabel` | `string` | RejectLabel is the reject button label |
 | `AcceptAction` | `string` | AcceptAction is the Alpine.js action for accept |
 | `RejectAction` | `string` | RejectAction is the Alpine.js action for reject |
 
@@ -207,7 +213,7 @@ import "github.com/araihu/goshtoso/components/breadcrumbs"  // package breadcrum
 | `Items` | `[]Item` | Items are the intermediate breadcrumb links (not the current page) |
 | `Current` | `string` | Current is the label for the current page (rendered as bold text, no link) |
 | `Separator` | `SeparatorStyle` | Separator controls the separator style (default: Chevron) |
-| `NavClass` | `string` | Class allows additional CSS classes on the outer <nav> |
+| `NavClass` | `string` | NavClass allows additional CSS classes on the outer <nav>. |
 | `NavAttrs` | `templ.Attributes` | NavAttrs are extra HTML attributes on the <nav> element |
 
 **Item**
@@ -250,7 +256,7 @@ import "github.com/araihu/goshtoso/components/button"  // package button
 | `Type` | `string` | Type is the HTML button type attribute (e.g. "button", "submit"). |
 | `Disabled` | `bool` | Disabled disables the button, preventing interaction. |
 | `ID` | `string` | ID is the HTML id attribute for the button element. |
-| `RootClass` | `string` | Class is additional CSS classes appended to the button. |
+| `RootClass` | `string` | RootClass is additional CSS classes appended to the button. |
 | `HTMX` | `*HTMXConfig` | HTMX is an optional HTMX config for server-side interaction. |
 | `Alpine` | `*AlpineConfig` | Alpine is an optional Alpine.js config for client-side behavior. |
 | `LoadingText` | `string` | LoadingText is the text shown during an HTMX request. |
@@ -297,7 +303,7 @@ import "github.com/araihu/goshtoso/components/card"  // package card
 | `Rating` | `int` | Rating is the product rating 0-5 (for ecommerce/testimonial cards) |
 | `Variant` | `Variant` | Variant determines the card style |
 | `Layout` | `Layout` | Layout determines vertical or horizontal layout |
-| `RootClass` | `string` | Class allows additional CSS classes |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the card root. |
 
 ## carousel
 
@@ -326,7 +332,7 @@ import "github.com/araihu/goshtoso/components/carousel"  // package carousel
 | `Touch` | `bool` | Touch enables swipe gesture support |
 | `AspectRatio` | `string` | AspectRatio sets a fixed aspect ratio (e.g. "3/1"), empty = min-h-[50svh] |
 | `Height` | `string` | Height overrides the slides container height (e.g. "h-48 lg:h-64" for card variant) |
-| `RootClass` | `string` | Class allows additional CSS classes on the container |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the container. |
 | `HTMX` | `*HTMXConfig` | HTMX enables lazy loading of carousel content (nil = static mode) |
 
 **HTMXConfig**
@@ -346,8 +352,8 @@ import "github.com/araihu/goshtoso/components/carousel"  // package carousel
 | `ImgAlt` | `string` | ImgAlt is the image alt text |
 | `Title` | `string` | Title is the slide heading (used by WithText, WithCTA) |
 | `Description` | `string` | Description is the slide body text (used by WithText, WithCTA) |
-| `CTAUrl` | `string` | CTAUrl is the call-to-action link (used by WithCTA) |
-| `CTAText` | `string` | CTAText is the call-to-action button label (used by WithCTA) |
+| `CTAHref` | `string` | CTAHref is the call-to-action link (used by WithCTA) |
+| `CTALabel` | `string` | CTALabel is the call-to-action button label (used by WithCTA) |
 
 ## chatbubble
 
@@ -376,8 +382,8 @@ import "github.com/araihu/goshtoso/components/chatbubble"  // package chatbubble
 | `Grouped` | `bool` | Grouped marks a consecutive message: tighten spacing, hide avatar + name. |
 | `Sender` | `string` | Sender, for Side=Auto, is emitted as data-sender for client mine-detection. |
 | `IsBot` | `bool` | IsBot renders a small BOT badge by the name. |
-| `RootClass` | `string` | Class allows additional CSS classes on the row. |
-| `RootAttrs` | `templ.Attributes` | Attrs allows arbitrary HTML attributes on the row element (e.g. hx-*). |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the row. |
+| `RootAttrs` | `templ.Attributes` | RootAttrs allows arbitrary HTML attributes on the row element (e.g. hx-*). |
 
 ## checkbox
 
@@ -514,7 +520,7 @@ import "github.com/araihu/goshtoso/components/drawer"  // package drawer
 | `Width` | `Width` | Width preset. Default: WidthMD. |
 | `BodyID` | `string` | BodyID is the id attribute of the inner content container. Exposed so |
 | `Persistent` | `bool` | Persistent disables click-backdrop and Esc-to-close. Default: false. |
-| `PanelClass` | `string` | Class allows extra CSS classes on the panel (not the overlay). |
+| `PanelClass` | `string` | PanelClass allows extra CSS classes on the panel (not the overlay). |
 
 ## dropdown
 
@@ -582,8 +588,8 @@ import "github.com/araihu/goshtoso/components/fileinput"  // package fileinput
 | `HelperText` | `string` | HelperText shown below the drop zone (e.g. "PNG, JPG, WebP - Max 5MB") |
 | `Required` | `bool` | Required marks the input as required |
 | `Disabled` | `bool` | Disabled disables the input |
-| `RootClass` | `string` | Class allows additional CSS classes on the outer container |
-| `InputAttrs` | `templ.Attributes` | Attrs are extra attributes applied to the <input> element (e.g. hx-post, x-on:change) |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the outer container. |
+| `InputAttrs` | `templ.Attributes` | InputAttrs are extra attributes applied to the <input> element (e.g. hx-post, x-on:change). |
 
 ## form
 
@@ -616,7 +622,7 @@ import "github.com/araihu/goshtoso/components/form"  // package form
 | `ID` | `string` | ID is the HTML form ID (required for external submit via form="..." attribute) |
 | `Action` | `string` | Action is the POST action URL for native form submission |
 | `Method` | `string` | Method is the HTTP method ("post" default, "get", "dialog") |
-| `RootClass` | `string` | Class allows additional CSS classes on the form element |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the form element. |
 | `HTMX` | `*HTMXConfig` | HTMX enables HTMX-based submission (alternative to native Action) |
 | `PreventEnterSubmit` | `*bool` | PreventEnterSubmit prevents Enter key from submitting the form. |
 | `Footer` | `*FooterConfig` | Footer renders Cancel + Submit buttons at the bottom. |
@@ -630,7 +636,7 @@ import "github.com/araihu/goshtoso/components/form"  // package form
 | `Required` | `bool` | Required shows a red asterisk next to the label |
 | `Errors` | `[]string` | Errors are validation error messages displayed below the field |
 | `Hints` | `[]string` | Hints are helper text messages displayed below errors |
-| `RootClass` | `string` | Class allows additional CSS classes on the wrapper |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the wrapper. |
 | `Validation` | `*ValidationConfig` | Validation enables HTMX-based field validation |
 | `Input` | `*textinput.Config` | Built-in Goshtoso field types (mutually exclusive — first non-nil wins). |
 | `Combobox` | `*combobox.Config` |  |
@@ -663,8 +669,8 @@ import "github.com/araihu/goshtoso/components/form"  // package form
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `SubmitText` | `string` | SubmitText is the submit button label (e.g. "Create", "Save") |
-| `CancelText` | `string` | CancelText is the cancel button label (e.g. "Cancel") |
+| `SubmitLabel` | `string` | SubmitLabel is the submit button label (e.g. "Create", "Save") |
+| `CancelLabel` | `string` | CancelLabel is the cancel button label (e.g. "Cancel") |
 | `CancelHref` | `string` | CancelHref is the cancel link URL (plain navigation) |
 | `CancelHTMX` | `*CancelHTMXConfig` | CancelHTMX enables HTMX-powered cancel (SPA navigation). Overrides CancelHref when set. |
 | `SubmitDisabled` | `string` | SubmitDisabled is an Alpine.js expression for x-bind:disabled on submit |
@@ -685,7 +691,7 @@ import "github.com/araihu/goshtoso/components/form"  // package form
 | `Title` | `string` | Title is the summary heading. Default: "Validation failed". |
 | `Items` | `[]FormErrorItem` | Items is the list of errors to render. |
 | `Hint` | `string` | Hint is an optional short explanation under the title |
-| `RootClass` | `string` | Class allows extra CSS classes on the wrapper. |
+| `RootClass` | `string` | RootClass allows extra CSS classes on the wrapper. |
 
 **HTMXConfig**
 
@@ -705,7 +711,7 @@ import "github.com/araihu/goshtoso/components/form"  // package form
 |-------|------|-------------|
 | `ID` | `string` | ID is the section element ID (used for HTMX targeting) |
 | `Title` | `string` | Title is the section heading |
-| `RootClass` | `string` | Class allows additional CSS classes |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the wrapper. |
 | `OOB` | `bool` | OOB enables hx-swap-oob="true" for HTMX out-of-band updates |
 | `Columns` | `string` | Columns controls the grid layout: "1" for single column, "2" (default) for responsive 2-column |
 
@@ -715,7 +721,7 @@ import "github.com/araihu/goshtoso/components/form"  // package form
 |-------|------|-------------|
 | `ID` | `string` | ID is the subsection element ID |
 | `Title` | `string` | Title is the subsection heading |
-| `RootClass` | `string` | Class allows additional CSS classes |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the root. |
 | `Columns` | `string` | Columns controls the grid layout: "1" for single column, "2" (default) |
 
 **ValidationConfig**
@@ -791,10 +797,7 @@ import "github.com/araihu/goshtoso/components/modal"  // package modal
 | Field | Type | Description |
 |-------|------|-------------|
 | `OnClick` | `string` | OnClick is a custom Alpine.js expression (appended after modal close) |
-| `HxGet` | `string` | HxGet triggers an HTMX GET request |
-| `HxPost` | `string` | HxPost triggers an HTMX POST request |
-| `HxTarget` | `string` | HxTarget is the HTMX target selector |
-| `HxSwap` | `string` | HxSwap is the HTMX swap strategy |
+| `HTMX` | `*HTMXConfig` | HTMX configures server-side action behavior. |
 
 **Config**
 
@@ -810,7 +813,16 @@ import "github.com/araihu/goshtoso/components/modal"  // package modal
 | `SecondaryAction` | `*ButtonAction` | SecondaryAction holds optional HTMX/JS actions for the secondary button |
 | `Variant` | `Variant` | Variant determines the color scheme (used for alert mode and trigger button) |
 | `AlertMode` | `bool` | AlertMode renders the alert-style modal (icon header, centered body, single CTA) |
-| `PanelClass` | `string` | Class allows additional CSS classes on the dialog |
+| `PanelClass` | `string` | PanelClass allows additional CSS classes on the dialog. |
+
+**HTMXConfig**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Get` | `string` | Get triggers an HTMX GET request. |
+| `Post` | `string` | Post triggers an HTMX POST request. |
+| `Target` | `string` | Target is the HTMX target selector. |
+| `Swap` | `string` | Swap is the HTMX swap strategy. |
 
 ## navbar
 
@@ -839,7 +851,7 @@ import "github.com/araihu/goshtoso/components/navbar"  // package navbar
 | `Actions` | `[]ActionItem` | Actions are custom components (e.g., dark mode toggle, theme selector) |
 | `User` | `*UserProfile` | User holds user profile data for the avatar dropdown (nil = no avatar) |
 | `UserMenu` | `[]UserMenuItem` | UserMenu contains dropdown items under the avatar |
-| `NavClass` | `string` | Class allows additional CSS classes on the outer <nav> |
+| `NavClass` | `string` | NavClass allows additional CSS classes on the outer <nav>. |
 | `NavAttrs` | `templ.Attributes` | NavAttrs are extra HTML attributes on the <nav> element |
 
 **NavLink**
@@ -888,7 +900,7 @@ import "github.com/araihu/goshtoso/components/pagination"  // package pagination
 | `CurrentPage` | `int` | CurrentPage is the 1-indexed current page number |
 | `TotalPages` | `int` | TotalPages is the total number of pages |
 | `BaseURL` | `string` | BaseURL is the base URL for page links (appends ?page=N) |
-| `NavClass` | `string` | Class allows additional CSS classes on the nav element |
+| `NavClass` | `string` | NavClass allows additional CSS classes on the nav element. |
 | `HTMX` | `*HTMXConfig` | HTMX configures in-place HTMX pagination. |
 
 **HTMXConfig**
@@ -931,7 +943,7 @@ import "github.com/araihu/goshtoso/components/palette"  // package palette
 | `HideNeutral` | `bool` | HideNeutral hides the white/black quick swatches (shown by default). |
 | `HideReset` | `bool` | HideReset hides the Reset action (shown by default). |
 | `ShowHex` | `bool` | ShowHex adds a native color input + hex text field (off by default). |
-| `RootClass` | `string` | Class appends classes to the wrapper. |
+| `RootClass` | `string` | RootClass appends classes to the wrapper. |
 | `LazyWhen` | `string` | LazyWhen is an Alpine expression; when non-empty, the swatch grid is |
 
 ## radio
@@ -972,10 +984,10 @@ import "github.com/araihu/goshtoso/components/radio"  // package radio
 | `BadgeColor` | `string` | BadgeColor wraps the label in a semi-solid badge. |
 | `Container` | `bool` | Container wraps the radio in a bordered container, showing the radio |
 | `Segmented` | `bool` | Segmented renders a true segmented-control pill: the input is sr-only |
-| `RootClass` | `string` | Class is appended to the label root element |
+| `RootClass` | `string` | RootClass is appended to the label root element. |
 | `HTMX` | `*HTMXConfig` | HTMX wires server interactions on change. |
 | `Alpine` | `*AlpineConfig` | Alpine wires client-side state. |
-| `InputAttrs` | `templ.Attributes` | Attrs is an escape hatch applied LAST to the input — wins on conflict. |
+| `InputAttrs` | `templ.Attributes` | InputAttrs is an escape hatch applied last to the input; wins on conflict. |
 
 **GroupConfig**
 
@@ -1068,10 +1080,10 @@ import "github.com/araihu/goshtoso/components/select"  // package selectfield
 | `HelperText` | `string` | HelperText is shown below the select (e.g., error or success message) |
 | `Disabled` | `bool` | Disabled disables the select |
 | `Autocomplete` | `string` | Autocomplete sets the autocomplete attribute |
-| `RootClass` | `string` | Class allows additional CSS classes on the wrapper |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the wrapper. |
 | `Alpine` | `*AlpineConfig` | Alpine wires client-side state. |
 | `Readonly` | `bool` | Readonly renders the select as disabled (grayed out) + hidden input with value so it still submits |
-| `InputAttrs` | `templ.Attributes` | Attrs allows arbitrary HTML attributes on the <select> element (e.g., hx-post, hx-indicator) |
+| `InputAttrs` | `templ.Attributes` | InputAttrs allows arbitrary HTML attributes on the <select> element (e.g., hx-post, hx-indicator). |
 | `Shell` | `bool` | Shell enables "shell mode": the Select renders its trigger + dropdown |
 | `TriggerLeading` | `templ.Component` | TriggerLeading is optional content rendered at the start of the trigger. |
 | `ValueExpr` | `string` | ValueExpr is an Alpine expression (x-text) for the trigger's value text |
@@ -1105,7 +1117,7 @@ import "github.com/araihu/goshtoso/components/sidebar"  // package sidebar
 | `LogoHref` | `string` | LogoHref is the link for the logo (default: "/") |
 | `ShowSearch` | `bool` | ShowSearch enables the search input |
 | `SearchPlaceholder` | `string` | SearchPlaceholder is the placeholder text for search |
-| `RootClass` | `string` | Class allows additional CSS classes |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the sidebar root. |
 | `SearchSlot` | `templ.Component` | SearchSlot replaces the default search input with a custom component. |
 | `FooterSlot` | `templ.Component` | FooterSlot renders content at the bottom of the sidebar (e.g., profile menu). |
 
@@ -1148,7 +1160,7 @@ import "github.com/araihu/goshtoso/components/spinner"  // package spinner
 |-------|------|-------------|
 | `Variant` | `Variant` | Variant determines the color scheme |
 | `Size` | `Size` | Size of the spinner |
-| `RootClass` | `string` | Class allows additional CSS classes |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the spinner root. |
 
 ## steps
 
@@ -1271,7 +1283,7 @@ import "github.com/araihu/goshtoso/components/table"  // package table
 | `Rows` | `[]Row` | Rows holds the table data |
 | `Variant` | `Variant` | Variant determines the table style |
 | `ShowCheckbox` | `bool` | ShowCheckbox adds a select-all checkbox column |
-| `RootClass` | `string` | Class allows additional CSS classes on the container |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the container. |
 | `SortBy` | `string` | --- Sorting --- |
 | `SortDir` | `SortDir` | SortDir is the current sort direction ("asc" or "desc") |
 | `HTMX` | `*HTMXConfig` | --- HTMX Integration --- |
@@ -1291,7 +1303,7 @@ import "github.com/araihu/goshtoso/components/table"  // package table
 | `Type` | `FilterType` | Type is the control type (search, select, toggle) |
 | `Placeholder` | `string` | Placeholder for search/select inputs |
 | `Options` | `[]FilterOption` | Options for select-type filters (static) |
-| `HTMXOptionsURL` | `string` | HTMXOptionsURL loads select options dynamically via HTMX on load |
+| `OptionsHTMX` | `*FilterOptionsHTMXConfig` | OptionsHTMX loads select options dynamically via HTMX on load |
 | `DefaultValue` | `string` | DefaultValue is the initial value |
 
 **FilterConfig**
@@ -1302,8 +1314,14 @@ import "github.com/araihu/goshtoso/components/table"  // package table
 | `Collapsible` | `bool` | Collapsible enables a toggle to show/hide the filter bar. |
 | `InitiallyExpanded` | `bool` | InitiallyExpanded controls whether filters start visible (default: true). |
 | `Variant` | `FilterVariant` | Variant selects the layout (bar vs inline). See FilterVariant. |
-| `HxTarget` | `string` | HxTarget overrides the CSS selector that filter changes swap into. |
-| `HxSwap` | `string` | HxSwap overrides the htmx swap strategy used when filters apply. |
+| `HTMX` | `*FilterHTMXConfig` | HTMX configures filter request behavior. |
+
+**FilterHTMXConfig**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Target` | `string` | Target overrides the CSS selector that filter changes swap into. |
+| `Swap` | `string` | Swap overrides the htmx swap strategy used when filters apply. |
 
 **FilterOption**
 
@@ -1311,6 +1329,12 @@ import "github.com/araihu/goshtoso/components/table"  // package table
 |-------|------|-------------|
 | `Value` | `string` |  |
 | `Label` | `string` |  |
+
+**FilterOptionsHTMXConfig**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Get` | `string` | Get is the URL to load select options from. |
 
 **HTMXConfig**
 
@@ -1346,15 +1370,21 @@ import "github.com/araihu/goshtoso/components/table"  // package table
 | `Link` | `string` | Link makes the row clickable — navigates when clicked. |
 | `LinkMode` | `LinkMode` | LinkMode controls how Link navigates. Default (empty) = SPA swap of #main-content-area. |
 | `OnClick` | `string` | OnClick is a JS/Alpine expression executed on row click. |
-| `HXGet` | `string` | HXGet triggers an HTMX GET request when the row is clicked. |
-| `HXPost` | `string` | HXPost triggers an HTMX POST request when the row is clicked. |
-| `HXTarget` | `string` | HXTarget is the CSS selector for the HTMX swap target (used with HXGet/HXPost). |
-| `HXSwap` | `string` | HXSwap is the HTMX swap strategy (used with HXGet/HXPost). Defaults to "innerHTML". |
-| `HXPushURL` | `bool` | HXPushURL pushes the request URL into browser history when HXGet/HXPost |
+| `HTMX` | `*RowHTMXConfig` | HTMX configures row-level HTMX click behavior. |
 | `AlpineAttrs` | `map[string]string` | AlpineAttrs is a pass-through for per-row Alpine directives (e.g. |
 | `Expandable` | `bool` | Expandable shows a chevron toggle and an expandable detail section below the row |
 | `Detail` | `templ.Component` | Detail is rendered in the expanded panel below the row when Expandable is true |
 | `Actions` | `templ.Component` | Actions is rendered in a trailing actions column (e.g., edit/delete buttons) |
+
+**RowHTMXConfig**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Get` | `string` | Get triggers an HTMX GET request when the row is clicked. |
+| `Post` | `string` | Post triggers an HTMX POST request when the row is clicked. |
+| `Target` | `string` | Target is the CSS selector for the HTMX swap target. |
+| `Swap` | `string` | Swap is the HTMX swap strategy. Defaults to "innerHTML". |
+| `PushURL` | `bool` | PushURL pushes the request URL into browser history. |
 
 ## tabs
 
@@ -1371,7 +1401,7 @@ import "github.com/araihu/goshtoso/components/tabs"  // package tabs
 | `ID` | `string` | ID is a unique identifier for this tabs instance (used for ARIA attributes) |
 | `Tabs` | `[]Tab` | Tabs is the list of tabs to render |
 | `DefaultTab` | `string` | DefaultTab is the ID of the initially selected tab (defaults to first tab) |
-| `RootClass` | `string` | Class allows additional CSS classes on the container |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the container. |
 | `SyncHash` | `bool` | SyncHash syncs the active tab with the URL fragment (hash). |
 
 **Tab**
@@ -1411,7 +1441,7 @@ import "github.com/araihu/goshtoso/components/tagslist"  // package tagslist
 | `Placeholder` | `string` | Placeholder is shown in the add-tag input |
 | `AddActionLabel` | `string` | AddActionLabel is the add button text (default: "Add") |
 | `Disabled` | `bool` | Disabled renders chips only (no remove buttons, no input row) |
-| `RootClass` | `string` | Class allows additional CSS classes on the outer container |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the outer container. |
 
 ## textarea
 
@@ -1437,8 +1467,8 @@ import "github.com/araihu/goshtoso/components/textarea"  // package textarea
 | `ReadOnly` | `bool` | ReadOnly makes the textarea read-only |
 | `State` | `State` | State is the validation state (default/error/success) |
 | `HelperText` | `string` | HelperText is the helper or error text below the textarea |
-| `RootClass` | `string` | Class allows additional CSS classes on the container |
-| `InputAttrs` | `templ.Attributes` | Attrs allows arbitrary HTML attributes on the <textarea> element (e.g. onkeydown, hx-*). |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the container. |
+| `InputAttrs` | `templ.Attributes` | InputAttrs allows arbitrary HTML attributes on the <textarea> element (e.g. onkeydown, hx-*). |
 
 ## textinput
 
@@ -1470,8 +1500,8 @@ import "github.com/araihu/goshtoso/components/textinput"  // package textinput
 | `Pattern` | `string` | Pattern is an HTML pattern attribute for regex validation (e.g. "[a-z0-9]{6}") |
 | `MaxLength` | `int` | MaxLength limits the number of characters (0 = no limit) |
 | `Readonly` | `bool` | Readonly makes the input non-editable but still submittable |
-| `RootClass` | `string` | Class allows additional CSS classes on the container |
-| `InputAttrs` | `templ.Attributes` | Attrs allows arbitrary HTML attributes on the <input> element (e.g., hx-post, hx-indicator) |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the container. |
+| `InputAttrs` | `templ.Attributes` | InputAttrs allows arbitrary HTML attributes on the <input> element (e.g., hx-post, hx-indicator). |
 
 ## toast
 
@@ -1492,11 +1522,8 @@ import "github.com/araihu/goshtoso/components/toast"  // package toast
 | `Message` | `string` | Message is the notification body text |
 | `Sender` | `*Sender` | Sender is used only for the Message variant |
 | `DisplayDuration` | `int` | DisplayDuration in milliseconds (default 8000); negative keeps a server-rendered toast visible until dismissed manually. |
-| `ActionText` | `string` | ActionText, when set, renders an inline action button in the toast (e.g. |
-| `ActionHxGet` | `string` | ActionHxGet / ActionHxPost is the HTMX request URL the action button fires. |
-| `ActionHxPost` | `string` |  |
-| `ActionHxTarget` | `string` | ActionHxTarget / ActionHxSwap configure the action button's HTMX swap. |
-| `ActionHxSwap` | `string` |  |
+| `ActionLabel` | `string` | ActionLabel, when set, renders an inline action button in the toast (e.g. |
+| `ActionHTMX` | `*HTMXConfig` | ActionHTMX configures the action button's HTMX request. |
 
 **ContainerConfig**
 
@@ -1504,6 +1531,15 @@ import "github.com/araihu/goshtoso/components/toast"  // package toast
 |-------|------|-------------|
 | `ID` | `string` | ID is the element ID for HTMX OOB targeting (default "toast-container") |
 | `DisplayDuration` | `int` | DisplayDuration in milliseconds (default 8000) |
+
+**HTMXConfig**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Get` | `string` | Get is the HTMX GET request URL the action button fires. |
+| `Post` | `string` | Post is the HTMX POST request URL the action button fires. |
+| `Target` | `string` | Target configures the action button's HTMX swap target. |
+| `Swap` | `string` | Swap configures the action button's HTMX swap strategy. |
 
 **Sender**
 
@@ -1535,8 +1571,8 @@ import "github.com/araihu/goshtoso/components/toggle"  // package toggle
 | `Disabled` | `bool` | Disabled disables the toggle |
 | `Name` | `string` | Name is the form field name |
 | `Value` | `string` | Value makes the checkbox submit this value when checked, turning the toggle into a real form control. |
-| `RootClass` | `string` | Class allows additional CSS classes on the label |
-| `InputAttrs` | `templ.Attributes` | Attrs are extra attributes applied to the <input> element |
+| `RootClass` | `string` | RootClass allows additional CSS classes on the label. |
+| `InputAttrs` | `templ.Attributes` | InputAttrs are extra attributes applied to the <input> element. |
 
 ## tooltip
 

--- a/components/accordion/types.go
+++ b/components/accordion/types.go
@@ -27,7 +27,7 @@ type AccordionConfig struct {
 	Variant Variant
 	// ID is the container ID for accessibility
 	ID string
-	// Class allows additional CSS classes
+	// RootClass allows additional CSS classes on the accordion root.
 	RootClass string
 }
 

--- a/components/alert/alert.templ
+++ b/components/alert/alert.templ
@@ -76,7 +76,7 @@ templ linkAlert(cfg Config) {
 
 // actionAlert renders an alert with action buttons
 templ actionAlert(cfg Config) {
-	{{ dismissText := cfg.Action.DismissText }}
+	{{ dismissText := cfg.Action.DismissLabel }}
 	{{ if dismissText == "" { dismissText = "Dismiss" } }}
 	<div class={ cfg.ContainerClasses() } role="alert">
 		<div class={ cfg.InnerClasses() }>
@@ -93,17 +93,17 @@ templ actionAlert(cfg Config) {
 						if cfg.Action.PrimaryOnClick != "" {
 							@click={ cfg.Action.PrimaryOnClick }
 						}
-						if cfg.Action.PrimaryHxGet != "" {
-							hx-get={ cfg.Action.PrimaryHxGet }
+						if cfg.Action.PrimaryHTMX != nil && cfg.Action.PrimaryHTMX.Get != "" {
+							hx-get={ cfg.Action.PrimaryHTMX.Get }
 						}
-						if cfg.Action.PrimaryHxPost != "" {
-							hx-post={ cfg.Action.PrimaryHxPost }
+						if cfg.Action.PrimaryHTMX != nil && cfg.Action.PrimaryHTMX.Post != "" {
+							hx-post={ cfg.Action.PrimaryHTMX.Post }
 						}
-						if cfg.Action.PrimaryHxTarget != "" {
-							hx-target={ cfg.Action.PrimaryHxTarget }
+						if cfg.Action.PrimaryHTMX != nil && cfg.Action.PrimaryHTMX.Target != "" {
+							hx-target={ cfg.Action.PrimaryHTMX.Target }
 						}
-						if cfg.Action.PrimaryHxSwap != "" {
-							hx-swap={ cfg.Action.PrimaryHxSwap }
+						if cfg.Action.PrimaryHTMX != nil && cfg.Action.PrimaryHTMX.Swap != "" {
+							hx-swap={ cfg.Action.PrimaryHTMX.Swap }
 						}
 					>
 						{ cfg.Action.PrimaryLabel }

--- a/components/alert/alert_templ.go
+++ b/components/alert/alert_templ.go
@@ -531,7 +531,7 @@ func actionAlert(cfg Config) templ.Component {
 			templ_7745c5c3_Var33 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		dismissText := cfg.Action.DismissText
+		dismissText := cfg.Action.DismissLabel
 		if dismissText == "" {
 			dismissText = "Dismiss"
 		}
@@ -676,15 +676,15 @@ func actionAlert(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		if cfg.Action.PrimaryHxGet != "" {
+		if cfg.Action.PrimaryHTMX != nil && cfg.Action.PrimaryHTMX.Get != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, " hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var45 string
-			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Action.PrimaryHxGet)
+			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Action.PrimaryHTMX.Get)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/alert/alert.templ`, Line: 97, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/alert/alert.templ`, Line: 97, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var45)
 			if templ_7745c5c3_Err != nil {
@@ -695,15 +695,15 @@ func actionAlert(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		if cfg.Action.PrimaryHxPost != "" {
+		if cfg.Action.PrimaryHTMX != nil && cfg.Action.PrimaryHTMX.Post != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, " hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var46 string
-			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Action.PrimaryHxPost)
+			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Action.PrimaryHTMX.Post)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/alert/alert.templ`, Line: 100, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/alert/alert.templ`, Line: 100, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var46)
 			if templ_7745c5c3_Err != nil {
@@ -714,15 +714,15 @@ func actionAlert(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		if cfg.Action.PrimaryHxTarget != "" {
+		if cfg.Action.PrimaryHTMX != nil && cfg.Action.PrimaryHTMX.Target != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, " hx-target=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var47 string
-			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Action.PrimaryHxTarget)
+			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Action.PrimaryHTMX.Target)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/alert/alert.templ`, Line: 103, Col: 45}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/alert/alert.templ`, Line: 103, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var47)
 			if templ_7745c5c3_Err != nil {
@@ -733,15 +733,15 @@ func actionAlert(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		if cfg.Action.PrimaryHxSwap != "" {
+		if cfg.Action.PrimaryHTMX != nil && cfg.Action.PrimaryHTMX.Swap != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, " hx-swap=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var48 string
-			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Action.PrimaryHxSwap)
+			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.Action.PrimaryHTMX.Swap)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/alert/alert.templ`, Line: 106, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/alert/alert.templ`, Line: 106, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var48)
 			if templ_7745c5c3_Err != nil {

--- a/components/alert/types.go
+++ b/components/alert/types.go
@@ -18,22 +18,28 @@ type LinkConfig struct {
 	Href string
 }
 
+// HTMXConfig holds HTMX attributes for an alert action button.
+type HTMXConfig struct {
+	// Get triggers an HTMX GET request.
+	Get string
+	// Post triggers an HTMX POST request.
+	Post string
+	// Target is the HTMX target selector.
+	Target string
+	// Swap is the HTMX swap strategy.
+	Swap string
+}
+
 // ActionConfig holds configuration for alert action buttons
 type ActionConfig struct {
 	// PrimaryLabel is the primary action button label
 	PrimaryLabel string
 	// PrimaryOnClick is the Alpine.js action for the primary button
 	PrimaryOnClick string
-	// PrimaryHxGet triggers an HTMX GET request on the primary button
-	PrimaryHxGet string
-	// PrimaryHxPost triggers an HTMX POST request on the primary button
-	PrimaryHxPost string
-	// PrimaryHxTarget is the HTMX target selector for the primary button
-	PrimaryHxTarget string
-	// PrimaryHxSwap is the HTMX swap strategy for the primary button
-	PrimaryHxSwap string
-	// DismissText is the secondary dismiss button label (defaults to "Dismiss")
-	DismissText string
+	// PrimaryHTMX configures HTMX behavior for the primary button.
+	PrimaryHTMX *HTMXConfig
+	// DismissLabel is the secondary dismiss button label (defaults to "Dismiss")
+	DismissLabel string
 }
 
 // Config holds configuration for the alert component
@@ -52,7 +58,7 @@ type Config struct {
 	Action *ActionConfig
 	// ListItems adds a bullet list below the description
 	ListItems []string
-	// Class allows additional CSS classes
+	// RootClass allows additional CSS classes on the alert root.
 	RootClass string
 }
 

--- a/components/avatar/types.go
+++ b/components/avatar/types.go
@@ -98,7 +98,7 @@ type Config struct {
 	Status Status
 	// Icon is an optional icon component (replaces initials in the base layer)
 	Icon templ.Component
-	// Class allows additional CSS classes
+	// RootClass allows additional CSS classes on the avatar root.
 	RootClass string
 	// SrcExpr is an Alpine expression evaluated in the parent scope that yields
 	// the image src at runtime (e.g. "avatarSrc"). When set, the image layer is
@@ -134,7 +134,7 @@ type StackConfig struct {
 	Items []Config
 	// Label describes the group for assistive technology.
 	Label string
-	// Class allows additional CSS classes on the stack root.
+	// RootClass allows additional CSS classes on the stack root.
 	RootClass string
 	// Reactive defers each avatar's size classes to the parent Alpine scope.
 	Reactive bool

--- a/components/badge/types.go
+++ b/components/badge/types.go
@@ -49,7 +49,7 @@ type Config struct {
 	Indicator bool
 	// IndicatorColor overrides the default indicator color
 	IndicatorColor string
-	// Class allows additional CSS classes
+	// RootClass allows additional CSS classes on the badge root.
 	RootClass string
 }
 

--- a/components/banner/banner.templ
+++ b/components/banner/banner.templ
@@ -82,7 +82,7 @@ templ simpleBanner(cfg Config) {
 // cookieBanner renders a cookie consent banner
 templ cookieBanner(cfg Config) {
 	{{ cookieCfg := cfg.CookieConfig }}
-	{{ if cookieCfg == nil { cookieCfg = &CookieBannerConfig{Title: "Cookie Consent", AcceptText: "Accept", RejectText: "Decline"} } }}
+	{{ if cookieCfg == nil { cookieCfg = &CookieBannerConfig{Title: "Cookie Consent", AcceptLabel: "Accept", RejectLabel: "Decline"} } }}
 	
 	<div 
 		x-data="{ show: true }"
@@ -116,14 +116,14 @@ templ cookieBanner(cfg Config) {
 				class="cursor-pointer whitespace-nowrap p-2 text-center text-xs font-medium tracking-wide text-on-surface transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:opacity-100 active:outline-offset-0 dark:text-on-surface-dark dark:focus-visible:outline-primary-dark rounded-radius"
 				@click={ cookieCfg.RejectAction }
 			>
-				{ cookieCfg.RejectText }
+				{ cookieCfg.RejectLabel }
 			</button>
 			<button 
 				type="button"
 				class="cursor-pointer whitespace-nowrap bg-primary px-4 py-2 border border-primary text-center text-xs font-medium tracking-wide text-on-primary transition hover:opacity-75 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:opacity-100 active:outline-offset-0 dark:bg-primary-dark dark:text-on-primary-dark dark:border-primary-dark dark:focus-visible:outline-primary-dark rounded-radius"
 				@click={ cookieCfg.AcceptAction }
 			>
-				{ cookieCfg.AcceptText }
+				{ cookieCfg.AcceptLabel }
 			</button>
 		</div>
 	</div>

--- a/components/banner/banner_templ.go
+++ b/components/banner/banner_templ.go
@@ -347,7 +347,7 @@ func cookieBanner(cfg Config) templ.Component {
 		ctx = templ.ClearChildren(ctx)
 		cookieCfg := cfg.CookieConfig
 		if cookieCfg == nil {
-			cookieCfg = &CookieBannerConfig{Title: "Cookie Consent", AcceptText: "Accept", RejectText: "Decline"}
+			cookieCfg = &CookieBannerConfig{Title: "Cookie Consent", AcceptLabel: "Accept", RejectLabel: "Decline"}
 		}
 		var templ_7745c5c3_Var21 = []any{cfg.CookieContainerClasses()}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var21...)
@@ -430,9 +430,9 @@ func cookieBanner(cfg Config) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var26 string
-		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(cookieCfg.RejectText)
+		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(cookieCfg.RejectLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/banner/banner.templ`, Line: 119, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/banner/banner.templ`, Line: 119, Col: 27}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
@@ -456,9 +456,9 @@ func cookieBanner(cfg Config) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var28 string
-		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(cookieCfg.AcceptText)
+		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(cookieCfg.AcceptLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/banner/banner.templ`, Line: 126, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/banner/banner.templ`, Line: 126, Col: 27}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {

--- a/components/banner/types.go
+++ b/components/banner/types.go
@@ -40,7 +40,7 @@ type Config struct {
 	CookieBanner bool
 	// CookieConfig holds cookie banner specific settings
 	CookieConfig *CookieBannerConfig
-	// Class allows additional CSS classes
+	// RootClass allows additional CSS classes on the banner root.
 	RootClass string
 }
 
@@ -60,10 +60,10 @@ type CookieBannerConfig struct {
 	Title string
 	// Icon is an optional icon (emoji or component)
 	Icon templ.Component
-	// AcceptText is the accept button text
-	AcceptText string
-	// RejectText is the reject button text
-	RejectText string
+	// AcceptLabel is the accept button label
+	AcceptLabel string
+	// RejectLabel is the reject button label
+	RejectLabel string
 	// AcceptAction is the Alpine.js action for accept
 	AcceptAction string
 	// RejectAction is the Alpine.js action for reject

--- a/components/breadcrumbs/types.go
+++ b/components/breadcrumbs/types.go
@@ -34,7 +34,7 @@ type Config struct {
 	Current string
 	// Separator controls the separator style (default: Chevron)
 	Separator SeparatorStyle
-	// Class allows additional CSS classes on the outer <nav>
+	// NavClass allows additional CSS classes on the outer <nav>.
 	NavClass string
 	// NavAttrs are extra HTML attributes on the <nav> element
 	NavAttrs templ.Attributes

--- a/components/button/types.go
+++ b/components/button/types.go
@@ -78,7 +78,7 @@ type Config struct {
 	Disabled bool
 	// ID is the HTML id attribute for the button element.
 	ID string
-	// Class is additional CSS classes appended to the button.
+	// RootClass is additional CSS classes appended to the button.
 	RootClass string
 	// HTMX is an optional HTMX config for server-side interaction.
 	HTMX *HTMXConfig

--- a/components/card/types.go
+++ b/components/card/types.go
@@ -40,7 +40,7 @@ type Config struct {
 	Variant Variant
 	// Layout determines vertical or horizontal layout
 	Layout Layout
-	// Class allows additional CSS classes
+	// RootClass allows additional CSS classes on the card root.
 	RootClass string
 }
 

--- a/components/carousel/types.go
+++ b/components/carousel/types.go
@@ -31,10 +31,10 @@ type Slide struct {
 	Title string
 	// Description is the slide body text (used by WithText, WithCTA)
 	Description string
-	// CTAUrl is the call-to-action link (used by WithCTA)
-	CTAUrl string
-	// CTAText is the call-to-action button label (used by WithCTA)
-	CTAText string
+	// CTAHref is the call-to-action link (used by WithCTA)
+	CTAHref string
+	// CTALabel is the call-to-action button label (used by WithCTA)
+	CTALabel string
 }
 
 // AutoplayConfig enables automatic slide rotation
@@ -71,7 +71,7 @@ type Config struct {
 	AspectRatio string
 	// Height overrides the slides container height (e.g. "h-48 lg:h-64" for card variant)
 	Height string
-	// Class allows additional CSS classes on the container
+	// RootClass allows additional CSS classes on the container.
 	RootClass string
 	// HTMX enables lazy loading of carousel content (nil = static mode)
 	HTMX *HTMXConfig
@@ -209,11 +209,11 @@ func slidesToJSON(slides []Slide) string {
 		if s.Description != "" {
 			fmt.Fprintf(&b, ",description:'%s'", jsEscape(s.Description))
 		}
-		if s.CTAUrl != "" {
-			fmt.Fprintf(&b, ",ctaUrl:'%s'", jsEscape(s.CTAUrl))
+		if s.CTAHref != "" {
+			fmt.Fprintf(&b, ",ctaUrl:'%s'", jsEscape(s.CTAHref))
 		}
-		if s.CTAText != "" {
-			fmt.Fprintf(&b, ",ctaText:'%s'", jsEscape(s.CTAText))
+		if s.CTALabel != "" {
+			fmt.Fprintf(&b, ",ctaText:'%s'", jsEscape(s.CTALabel))
 		}
 		b.WriteString("}")
 	}

--- a/components/chatbubble/types.go
+++ b/components/chatbubble/types.go
@@ -47,9 +47,9 @@ type Config struct {
 	Sender string
 	// IsBot renders a small BOT badge by the name.
 	IsBot bool
-	// Class allows additional CSS classes on the row.
+	// RootClass allows additional CSS classes on the row.
 	RootClass string
-	// Attrs allows arbitrary HTML attributes on the row element (e.g. hx-*).
+	// RootAttrs allows arbitrary HTML attributes on the row element (e.g. hx-*).
 	RootAttrs templ.Attributes
 }
 

--- a/components/drawer/types.go
+++ b/components/drawer/types.go
@@ -52,7 +52,7 @@ type Config struct {
 	// Persistent disables click-backdrop and Esc-to-close. Default: false.
 	Persistent bool
 
-	// Class allows extra CSS classes on the panel (not the overlay).
+	// PanelClass allows extra CSS classes on the panel (not the overlay).
 	PanelClass string
 }
 

--- a/components/fileinput/types.go
+++ b/components/fileinput/types.go
@@ -30,9 +30,9 @@ type Config struct {
 	Required bool
 	// Disabled disables the input
 	Disabled bool
-	// Class allows additional CSS classes on the outer container
+	// RootClass allows additional CSS classes on the outer container.
 	RootClass string
-	// Attrs are extra attributes applied to the <input> element (e.g. hx-post, x-on:change)
+	// InputAttrs are extra attributes applied to the <input> element (e.g. hx-post, x-on:change).
 	InputAttrs templ.Attributes
 }
 

--- a/components/form/errors.templ
+++ b/components/form/errors.templ
@@ -22,7 +22,7 @@ type FormErrorsConfig struct {
 	// Hint is an optional short explanation under the title
 	// (e.g. "Fix the fields marked in red and try again").
 	Hint string
-	// Class allows extra CSS classes on the wrapper.
+	// RootClass allows extra CSS classes on the wrapper.
 	RootClass string
 }
 

--- a/components/form/errors_templ.go
+++ b/components/form/errors_templ.go
@@ -30,7 +30,7 @@ type FormErrorsConfig struct {
 	// Hint is an optional short explanation under the title
 	// (e.g. "Fix the fields marked in red and try again").
 	Hint string
-	// Class allows extra CSS classes on the wrapper.
+	// RootClass allows extra CSS classes on the wrapper.
 	RootClass string
 }
 

--- a/components/form/form.templ
+++ b/components/form/form.templ
@@ -18,7 +18,7 @@ import (
 //	@form.Form(form.Config{
 //	    ID:     "my-form",
 //	    Action: "/api/submit",
-//	    Footer: &form.FooterConfig{SubmitText: "Save", CancelText: "Cancel", CancelHref: "/"},
+//	    Footer: &form.FooterConfig{SubmitLabel: "Save", CancelLabel: "Cancel", CancelHref: "/"},
 //	}) {
 //	    @form.Section(...) { ... }
 //	}
@@ -333,7 +333,7 @@ templ fieldHints(hints []string) {
 // formFooter renders the sticky footer with Cancel and Submit buttons
 templ formFooter(cfg FooterConfig) {
 	<div class={ cfg.footerClasses() }>
-		if cfg.CancelText != "" {
+		if cfg.CancelLabel != "" {
 			<a
 				if cfg.CancelHTMX != nil {
 					if cfg.CancelHTMX.Get != "" {
@@ -357,7 +357,7 @@ templ formFooter(cfg FooterConfig) {
 				}
 				class="inline-flex cursor-pointer items-center justify-center px-6 py-2.5 rounded-radius text-sm font-medium text-on-surface dark:text-on-surface-dark bg-surface dark:bg-surface-dark border border-outline dark:border-outline-dark hover:bg-surface-alt dark:hover:bg-surface-dark-alt transition"
 			>
-				{ cfg.CancelText }
+					{ cfg.CancelLabel }
 			</a>
 		}
 		<button
@@ -367,7 +367,7 @@ templ formFooter(cfg FooterConfig) {
 				x-bind:disabled={ cfg.SubmitDisabled }
 			}
 		>
-			{ cfg.SubmitText }
+				{ cfg.SubmitLabel }
 		</button>
 	</div>
 }

--- a/components/form/form_templ.go
+++ b/components/form/form_templ.go
@@ -26,7 +26,7 @@ import (
 //	@form.Form(form.Config{
 //	    ID:     "my-form",
 //	    Action: "/api/submit",
-//	    Footer: &form.FooterConfig{SubmitText: "Save", CancelText: "Cancel", CancelHref: "/"},
+//	    Footer: &form.FooterConfig{SubmitLabel: "Save", CancelLabel: "Cancel", CancelHref: "/"},
 //	}) {
 //	    @form.Section(...) { ... }
 //	}
@@ -1375,7 +1375,7 @@ func formFooter(cfg FooterConfig) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if cfg.CancelText != "" {
+		if cfg.CancelLabel != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 119, "<a")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -1488,9 +1488,9 @@ func formFooter(cfg FooterConfig) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var74 string
-			templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.CancelText)
+			templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.CancelLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/form/form.templ`, Line: 360, Col: 20}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/form/form.templ`, Line: 360, Col: 22}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 			if templ_7745c5c3_Err != nil {
@@ -1529,9 +1529,9 @@ func formFooter(cfg FooterConfig) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var76 string
-		templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.SubmitText)
+		templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.SubmitLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/form/form.templ`, Line: 370, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/form/form.templ`, Line: 370, Col: 21}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
 		if templ_7745c5c3_Err != nil {

--- a/components/form/types.go
+++ b/components/form/types.go
@@ -21,7 +21,7 @@ type Config struct {
 	Action string
 	// Method is the HTTP method ("post" default, "get", "dialog")
 	Method string
-	// Class allows additional CSS classes on the form element
+	// RootClass allows additional CSS classes on the form element.
 	RootClass string
 	// HTMX enables HTMX-based submission (alternative to native Action)
 	HTMX *HTMXConfig
@@ -62,10 +62,10 @@ type HTMXConfig struct {
 
 // FooterConfig configures the form footer with action buttons
 type FooterConfig struct {
-	// SubmitText is the submit button label (e.g. "Create", "Save")
-	SubmitText string
-	// CancelText is the cancel button label (e.g. "Cancel")
-	CancelText string
+	// SubmitLabel is the submit button label (e.g. "Create", "Save")
+	SubmitLabel string
+	// CancelLabel is the cancel button label (e.g. "Cancel")
+	CancelLabel string
 	// CancelHref is the cancel link URL (plain navigation)
 	CancelHref string
 	// CancelHTMX enables HTMX-powered cancel (SPA navigation). Overrides CancelHref when set.
@@ -99,7 +99,7 @@ type SectionConfig struct {
 	ID string
 	// Title is the section heading
 	Title string
-	// Class allows additional CSS classes
+	// RootClass allows additional CSS classes on the wrapper.
 	RootClass string
 	// OOB enables hx-swap-oob="true" for HTMX out-of-band updates
 	OOB bool
@@ -170,7 +170,7 @@ type SubSectionConfig struct {
 	ID string
 	// Title is the subsection heading
 	Title string
-	// Class allows additional CSS classes
+	// RootClass allows additional CSS classes on the root.
 	RootClass string
 	// Columns controls the grid layout: "1" for single column, "2" (default)
 	Columns string
@@ -198,7 +198,7 @@ type FieldGroupConfig struct {
 	Errors []string
 	// Hints are helper text messages displayed below errors
 	Hints []string
-	// Class allows additional CSS classes on the wrapper
+	// RootClass allows additional CSS classes on the wrapper.
 	RootClass string
 	// Validation enables HTMX-based field validation
 	Validation *ValidationConfig

--- a/components/modal/modal.templ
+++ b/components/modal/modal.templ
@@ -127,17 +127,17 @@ templ primaryButton(stateVar string, text string, action *ButtonAction) {
 		x-on:click={ buttonClickExpr(stateVar, action) }
 		type="button"
 		class="whitespace-nowrap rounded-radius bg-primary border border-primary dark:border-primary-dark px-4 py-2 text-center text-sm font-medium tracking-wide text-on-primary transition hover:opacity-75 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:opacity-100 active:outline-offset-0 dark:bg-primary-dark dark:text-on-primary-dark dark:focus-visible:outline-primary-dark"
-		if action != nil && action.HxGet != "" {
-			hx-get={ action.HxGet }
+		if action != nil && action.HTMX != nil && action.HTMX.Get != "" {
+			hx-get={ action.HTMX.Get }
 		}
-		if action != nil && action.HxPost != "" {
-			hx-post={ action.HxPost }
+		if action != nil && action.HTMX != nil && action.HTMX.Post != "" {
+			hx-post={ action.HTMX.Post }
 		}
-		if action != nil && action.HxTarget != "" {
-			hx-target={ action.HxTarget }
+		if action != nil && action.HTMX != nil && action.HTMX.Target != "" {
+			hx-target={ action.HTMX.Target }
 		}
-		if action != nil && action.HxSwap != "" {
-			hx-swap={ action.HxSwap }
+		if action != nil && action.HTMX != nil && action.HTMX.Swap != "" {
+			hx-swap={ action.HTMX.Swap }
 		}
 	>
 		{ text }
@@ -150,17 +150,17 @@ templ secondaryButton(stateVar string, text string, action *ButtonAction) {
 		x-on:click={ buttonClickExpr(stateVar, action) }
 		type="button"
 		class="whitespace-nowrap rounded-radius px-4 py-2 text-center text-sm font-medium tracking-wide text-on-surface transition hover:opacity-75 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:opacity-100 active:outline-offset-0 dark:text-on-surface-dark dark:focus-visible:outline-primary-dark"
-		if action != nil && action.HxGet != "" {
-			hx-get={ action.HxGet }
+		if action != nil && action.HTMX != nil && action.HTMX.Get != "" {
+			hx-get={ action.HTMX.Get }
 		}
-		if action != nil && action.HxPost != "" {
-			hx-post={ action.HxPost }
+		if action != nil && action.HTMX != nil && action.HTMX.Post != "" {
+			hx-post={ action.HTMX.Post }
 		}
-		if action != nil && action.HxTarget != "" {
-			hx-target={ action.HxTarget }
+		if action != nil && action.HTMX != nil && action.HTMX.Target != "" {
+			hx-target={ action.HTMX.Target }
 		}
-		if action != nil && action.HxSwap != "" {
-			hx-swap={ action.HxSwap }
+		if action != nil && action.HTMX != nil && action.HTMX.Swap != "" {
+			hx-swap={ action.HTMX.Swap }
 		}
 	>
 		{ text }
@@ -173,17 +173,17 @@ templ alertCTAButton(stateVar string, text string, classes string, action *Butto
 		x-on:click={ buttonClickExpr(stateVar, action) }
 		type="button"
 		class={ classes }
-		if action != nil && action.HxGet != "" {
-			hx-get={ action.HxGet }
+		if action != nil && action.HTMX != nil && action.HTMX.Get != "" {
+			hx-get={ action.HTMX.Get }
 		}
-		if action != nil && action.HxPost != "" {
-			hx-post={ action.HxPost }
+		if action != nil && action.HTMX != nil && action.HTMX.Post != "" {
+			hx-post={ action.HTMX.Post }
 		}
-		if action != nil && action.HxTarget != "" {
-			hx-target={ action.HxTarget }
+		if action != nil && action.HTMX != nil && action.HTMX.Target != "" {
+			hx-target={ action.HTMX.Target }
 		}
-		if action != nil && action.HxSwap != "" {
-			hx-swap={ action.HxSwap }
+		if action != nil && action.HTMX != nil && action.HTMX.Swap != "" {
+			hx-swap={ action.HTMX.Swap }
 		}
 	>
 		{ text }

--- a/components/modal/modal_templ.go
+++ b/components/modal/modal_templ.go
@@ -698,15 +698,15 @@ func primaryButton(stateVar string, text string, action *ButtonAction) templ.Com
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if action != nil && action.HxGet != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Get != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, " hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var46 string
-			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxGet)
+			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Get)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 131, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 131, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var46)
 			if templ_7745c5c3_Err != nil {
@@ -717,15 +717,15 @@ func primaryButton(stateVar string, text string, action *ButtonAction) templ.Com
 				return templ_7745c5c3_Err
 			}
 		}
-		if action != nil && action.HxPost != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Post != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, " hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var47 string
-			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxPost)
+			templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Post)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 134, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 134, Col: 29}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var47)
 			if templ_7745c5c3_Err != nil {
@@ -736,15 +736,15 @@ func primaryButton(stateVar string, text string, action *ButtonAction) templ.Com
 				return templ_7745c5c3_Err
 			}
 		}
-		if action != nil && action.HxTarget != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Target != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, " hx-target=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var48 string
-			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxTarget)
+			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Target)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 137, Col: 30}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 137, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var48)
 			if templ_7745c5c3_Err != nil {
@@ -755,15 +755,15 @@ func primaryButton(stateVar string, text string, action *ButtonAction) templ.Com
 				return templ_7745c5c3_Err
 			}
 		}
-		if action != nil && action.HxSwap != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Swap != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, " hx-swap=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var49 string
-			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxSwap)
+			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Swap)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 140, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 140, Col: 29}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var49)
 			if templ_7745c5c3_Err != nil {
@@ -834,15 +834,15 @@ func secondaryButton(stateVar string, text string, action *ButtonAction) templ.C
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if action != nil && action.HxGet != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Get != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, " hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var53 string
-			templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxGet)
+			templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Get)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 154, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 154, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var53)
 			if templ_7745c5c3_Err != nil {
@@ -853,15 +853,15 @@ func secondaryButton(stateVar string, text string, action *ButtonAction) templ.C
 				return templ_7745c5c3_Err
 			}
 		}
-		if action != nil && action.HxPost != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Post != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, " hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var54 string
-			templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxPost)
+			templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Post)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 157, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 157, Col: 29}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var54)
 			if templ_7745c5c3_Err != nil {
@@ -872,15 +872,15 @@ func secondaryButton(stateVar string, text string, action *ButtonAction) templ.C
 				return templ_7745c5c3_Err
 			}
 		}
-		if action != nil && action.HxTarget != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Target != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, " hx-target=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var55 string
-			templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxTarget)
+			templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Target)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 160, Col: 30}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 160, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var55)
 			if templ_7745c5c3_Err != nil {
@@ -891,15 +891,15 @@ func secondaryButton(stateVar string, text string, action *ButtonAction) templ.C
 				return templ_7745c5c3_Err
 			}
 		}
-		if action != nil && action.HxSwap != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Swap != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, " hx-swap=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var56 string
-			templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxSwap)
+			templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Swap)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 163, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 163, Col: 29}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var56)
 			if templ_7745c5c3_Err != nil {
@@ -988,15 +988,15 @@ func alertCTAButton(stateVar string, text string, classes string, action *Button
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if action != nil && action.HxGet != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Get != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, " hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var62 string
-			templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxGet)
+			templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Get)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 177, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 177, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var62)
 			if templ_7745c5c3_Err != nil {
@@ -1007,15 +1007,15 @@ func alertCTAButton(stateVar string, text string, classes string, action *Button
 				return templ_7745c5c3_Err
 			}
 		}
-		if action != nil && action.HxPost != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Post != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, " hx-post=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var63 string
-			templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxPost)
+			templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Post)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 180, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 180, Col: 29}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var63)
 			if templ_7745c5c3_Err != nil {
@@ -1026,15 +1026,15 @@ func alertCTAButton(stateVar string, text string, classes string, action *Button
 				return templ_7745c5c3_Err
 			}
 		}
-		if action != nil && action.HxTarget != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Target != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, " hx-target=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var64 string
-			templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxTarget)
+			templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Target)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 183, Col: 30}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 183, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var64)
 			if templ_7745c5c3_Err != nil {
@@ -1045,15 +1045,15 @@ func alertCTAButton(stateVar string, text string, classes string, action *Button
 				return templ_7745c5c3_Err
 			}
 		}
-		if action != nil && action.HxSwap != "" {
+		if action != nil && action.HTMX != nil && action.HTMX.Swap != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, " hx-swap=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var65 string
-			templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HxSwap)
+			templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.ResolveAttributeValue(action.HTMX.Swap)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 186, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/modal/modal.templ`, Line: 186, Col: 29}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var65)
 			if templ_7745c5c3_Err != nil {

--- a/components/modal/types.go
+++ b/components/modal/types.go
@@ -16,18 +16,24 @@ const (
 	Danger  Variant = "danger"
 )
 
+// HTMXConfig holds HTMX attributes for a modal action button.
+type HTMXConfig struct {
+	// Get triggers an HTMX GET request.
+	Get string
+	// Post triggers an HTMX POST request.
+	Post string
+	// Target is the HTMX target selector.
+	Target string
+	// Swap is the HTMX swap strategy.
+	Swap string
+}
+
 // ButtonAction holds optional HTMX and Alpine.js actions for a button
 type ButtonAction struct {
 	// OnClick is a custom Alpine.js expression (appended after modal close)
 	OnClick string
-	// HxGet triggers an HTMX GET request
-	HxGet string
-	// HxPost triggers an HTMX POST request
-	HxPost string
-	// HxTarget is the HTMX target selector
-	HxTarget string
-	// HxSwap is the HTMX swap strategy
-	HxSwap string
+	// HTMX configures server-side action behavior.
+	HTMX *HTMXConfig
 }
 
 // Config holds configuration for the modal component
@@ -52,7 +58,7 @@ type Config struct {
 	Variant Variant
 	// AlertMode renders the alert-style modal (icon header, centered body, single CTA)
 	AlertMode bool
-	// Class allows additional CSS classes on the dialog
+	// PanelClass allows additional CSS classes on the dialog.
 	PanelClass string
 }
 

--- a/components/navbar/types.go
+++ b/components/navbar/types.go
@@ -73,7 +73,7 @@ type Config struct {
 	User *UserProfile
 	// UserMenu contains dropdown items under the avatar
 	UserMenu []UserMenuItem
-	// Class allows additional CSS classes on the outer <nav>
+	// NavClass allows additional CSS classes on the outer <nav>.
 	NavClass string
 	// NavAttrs are extra HTML attributes on the <nav> element
 	NavAttrs templ.Attributes

--- a/components/pagination/types.go
+++ b/components/pagination/types.go
@@ -40,7 +40,7 @@ type Config struct {
 	TotalPages int
 	// BaseURL is the base URL for page links (appends ?page=N)
 	BaseURL string
-	// Class allows additional CSS classes on the nav element
+	// NavClass allows additional CSS classes on the nav element.
 	NavClass string
 
 	// HTMX configures in-place HTMX pagination.

--- a/components/palette/types.go
+++ b/components/palette/types.go
@@ -44,7 +44,7 @@ type Config struct {
 	HideReset bool
 	// ShowHex adds a native color input + hex text field (off by default).
 	ShowHex bool
-	// Class appends classes to the wrapper.
+	// RootClass appends classes to the wrapper.
 	RootClass string
 	// LazyWhen is an Alpine expression; when non-empty, the swatch grid is
 	// wrapped in <template x-if=...> so it mounts only when the expression is

--- a/components/radio/types.go
+++ b/components/radio/types.go
@@ -13,7 +13,7 @@
 //     cfg.Alpine (Model/OnChange/BindChecked/BindDisabled/Data).
 //   - Both → set both. HTMX hits the server while Alpine updates local
 //     state. Useful for optimistic UI / hybrid flows.
-//   - Attrs → generic templ.Attributes escape hatch for any
+//   - InputAttrs → generic templ.Attributes escape hatch for any
 //     hx-*/x-*/data-*/aria-* not modelled above. Rendered LAST so the
 //     caller can always override.
 package radio
@@ -111,14 +111,14 @@ type Config struct {
 	// (or any flex container with `divide-x` for connected segments).
 	// When set, Container is ignored.
 	Segmented bool
-	// Class is appended to the label root element
+	// RootClass is appended to the label root element.
 	RootClass string
 
 	// HTMX wires server interactions on change.
 	HTMX *HTMXConfig
 	// Alpine wires client-side state.
 	Alpine *AlpineConfig
-	// Attrs is an escape hatch applied LAST to the input — wins on conflict.
+	// InputAttrs is an escape hatch applied last to the input; wins on conflict.
 	InputAttrs templ.Attributes
 }
 

--- a/components/select/types.go
+++ b/components/select/types.go
@@ -65,13 +65,13 @@ type Config struct {
 	Disabled bool
 	// Autocomplete sets the autocomplete attribute
 	Autocomplete string
-	// Class allows additional CSS classes on the wrapper
+	// RootClass allows additional CSS classes on the wrapper.
 	RootClass string
 	// Alpine wires client-side state.
 	Alpine *AlpineConfig
 	// Readonly renders the select as disabled (grayed out) + hidden input with value so it still submits
 	Readonly bool
-	// Attrs allows arbitrary HTML attributes on the <select> element (e.g., hx-post, hx-indicator)
+	// InputAttrs allows arbitrary HTML attributes on the <select> element (e.g., hx-post, hx-indicator).
 	InputAttrs templ.Attributes
 	// Shell enables "shell mode": the Select renders its trigger + dropdown
 	// chrome but hosts arbitrary templ children as the dropdown body instead

--- a/components/sidebar/types.go
+++ b/components/sidebar/types.go
@@ -43,7 +43,7 @@ type Config struct {
 	ShowSearch bool
 	// SearchPlaceholder is the placeholder text for search
 	SearchPlaceholder string
-	// Class allows additional CSS classes
+	// RootClass allows additional CSS classes on the sidebar root.
 	RootClass string
 	// SearchSlot replaces the default search input with a custom component.
 	// When set, ShowSearch is ignored.

--- a/components/spinner/types.go
+++ b/components/spinner/types.go
@@ -29,7 +29,7 @@ type Config struct {
 	Variant Variant
 	// Size of the spinner
 	Size Size
-	// Class allows additional CSS classes
+	// RootClass allows additional CSS classes on the spinner root.
 	RootClass string
 }
 

--- a/components/table/filter_config_test.go
+++ b/components/table/filter_config_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TestFilterConfig_ResolvedHxTarget pins the override contract: explicit
-// HxTarget wins over the default "#{tbody-id}" resolution. The modal
+// HTMX.Target wins over the default "#{tbody-id}" resolution. The modal
 // migration in tks-console depends on this — filter input must swap the
 // full modal body, not the table tbody that lives inside it.
 func TestFilterConfig_ResolvedHxTarget(t *testing.T) {
@@ -25,8 +25,8 @@ func TestFilterConfig_ResolvedHxTarget(t *testing.T) {
 			want:   "#clusters-tbody",
 		},
 		{
-			name:   "explicit HxTarget wins",
-			filter: FilterConfig{HxTarget: "#install-modal-body"},
+			name:   "explicit HTMX.Target wins",
+			filter: FilterConfig{HTMX: &FilterHTMXConfig{Target: "#install-modal-body"}},
 			cfg:    Config{ID: "clusters"},
 			want:   "#install-modal-body",
 		},
@@ -44,14 +44,14 @@ func TestFilterConfig_ResolvedHxTarget(t *testing.T) {
 // TestFilterScriptData_EmitsHxTarget guards against regressions in the
 // Alpine.data template: the emitted `applyFilters()` body must use the
 // resolved target string, not the raw ID. Without this, adding the
-// HxTarget override silently had no effect because the Sprintf still
+// HTMX.Target override silently had no effect because the Sprintf still
 // referenced tbody.
 func TestFilterScriptData_EmitsHxTarget(t *testing.T) {
 	cfg := Config{
 		ID:   "addon-picker",
 		HTMX: &HTMXConfig{Endpoint: "/console/clusters/cid/addons/install"},
 		Filters: &FilterConfig{
-			HxTarget: "#install-modal-body",
+			HTMX: &FilterHTMXConfig{Target: "#install-modal-body"},
 			Filters: []Filter{
 				{Key: "q", Type: FilterSearch},
 			},
@@ -79,7 +79,7 @@ func TestFilterVariant_Constants(t *testing.T) {
 	}
 }
 
-// TestFilterConfig_ResolvedHxSwap mirrors the HxTarget override contract for
+// TestFilterConfig_ResolvedHxSwap mirrors the HTMX.Target override contract for
 // swap strategy. Default is "innerHTML"; consumers can opt into "outerHTML"
 // when the swap target is itself a wrapper that the server re-renders
 // whole-cloth (catalog grid with empty-state on the wrapper).
@@ -90,8 +90,8 @@ func TestFilterConfig_ResolvedHxSwap(t *testing.T) {
 		want   string
 	}{
 		{name: "default falls back to innerHTML", filter: FilterConfig{}, want: "innerHTML"},
-		{name: "explicit outerHTML wins", filter: FilterConfig{HxSwap: "outerHTML"}, want: "outerHTML"},
-		{name: "arbitrary swap mode passes through", filter: FilterConfig{HxSwap: "morphdom"}, want: "morphdom"},
+		{name: "explicit outerHTML wins", filter: FilterConfig{HTMX: &FilterHTMXConfig{Swap: "outerHTML"}}, want: "outerHTML"},
+		{name: "arbitrary swap mode passes through", filter: FilterConfig{HTMX: &FilterHTMXConfig{Swap: "morphdom"}}, want: "morphdom"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -111,9 +111,11 @@ func TestFilterScriptData_EmitsHxSwap(t *testing.T) {
 		ID:   "addons-catalog-table",
 		HTMX: &HTMXConfig{Endpoint: "/console/addons"},
 		Filters: &FilterConfig{
-			HxTarget: "#addons-catalog",
-			HxSwap:   "outerHTML",
-			Filters:  []Filter{{Key: "search", Type: FilterSearch}},
+			HTMX: &FilterHTMXConfig{
+				Target: "#addons-catalog",
+				Swap:   "outerHTML",
+			},
+			Filters: []Filter{{Key: "search", Type: FilterSearch}},
 		},
 	}
 	out := filterScriptData(cfg)
@@ -126,7 +128,7 @@ func TestFilterScriptData_EmitsHxSwap(t *testing.T) {
 }
 
 // TestFilterScriptData_DefaultSwap pins the default swap behavior so we don't
-// regress callers that omit HxSwap.
+// regress callers that omit HTMX.Swap.
 func TestFilterScriptData_DefaultSwap(t *testing.T) {
 	cfg := Config{
 		ID:      "clusters",

--- a/components/table/table.templ
+++ b/components/table/table.templ
@@ -204,7 +204,7 @@ templ filterScript(cfg Config) {
 //
 // hx-preserve + stable id keep the input element (and its focus + caret
 // position) intact across HTMX swaps that include the filter bar in the
-// swap target — e.g. when consumers configure HxTarget at a wrapper that
+// swap target — e.g. when consumers configure HTMX.Target at a wrapper that
 // re-renders the filter row whole-cloth (catalog with empty-state branch).
 // On the common tbody-only swap path the attribute is a no-op since the
 // filter inputs aren't part of the target.
@@ -233,16 +233,16 @@ templ filterSelectInput(cfg Config, filter Filter) {
 		x-model={ "filters." + filter.Key }
 		@change="applyFilters()"
 		class="rounded-radius border border-outline bg-surface py-2 pl-3 pr-8 text-sm text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark dark:focus-visible:outline-primary-dark"
-		if filter.HTMXOptionsURL != "" {
-			hx-get={ filter.HTMXOptionsURL }
-			hx-trigger="load"
-			hx-swap="innerHTML"
-		}
-	>
-		if filter.HTMXOptionsURL == "" {
-			for _, opt := range filter.Options {
-				<option value={ opt.Value }>{ opt.Label }</option>
+			if filter.OptionsHTMX != nil && filter.OptionsHTMX.Get != "" {
+				hx-get={ filter.OptionsHTMX.Get }
+				hx-trigger="load"
+				hx-swap="innerHTML"
 			}
+		>
+			if filter.OptionsHTMX == nil || filter.OptionsHTMX.Get == "" {
+				for _, opt := range filter.Options {
+					<option value={ opt.Value }>{ opt.Label }</option>
+				}
 		} else {
 			<option value="">Loading...</option>
 		}
@@ -375,9 +375,9 @@ func hasMoreRows(cfg Config) bool {
 templ TableRow(cfg Config, row Row) {
 	<tr
 		class={ cfg.RowClasses() + interactiveRowClasses(row) }
-		if row.Expandable && row.Link == "" && row.OnClick == "" && row.HXGet == "" && row.HXPost == "" {
-			x-on:click={ fmt.Sprintf("openRows['%s'] = !openRows['%s']", row.ID, row.ID) }
-		}
+			if row.Expandable && row.Link == "" && row.OnClick == "" && !row.HasHTMXAction() {
+				x-on:click={ fmt.Sprintf("openRows['%s'] = !openRows['%s']", row.ID, row.ID) }
+			}
 		if row.Link != "" {
 			{ rowLinkAttrs(row)... }
 		}
@@ -514,7 +514,7 @@ func interactiveRowClasses(row Row) string {
 	return ""
 }
 
-// rowActionAttrs returns HTMX/JS attributes for row click actions (OnClick, HXGet, HXPost).
+// rowActionAttrs returns HTMX/JS attributes for row click actions (OnClick, HTMX.Get, HTMX.Post).
 // Link and Expandable are handled separately in the template.
 func rowActionAttrs(row Row) templ.Attributes {
 	if row.Link != "" {
@@ -526,32 +526,32 @@ func rowActionAttrs(row Row) templ.Attributes {
 			"onclick": row.OnClick,
 		}
 	}
-	if row.HXGet != "" {
+	if row.HTMX != nil && row.HTMX.Get != "" {
 		attrs := templ.Attributes{
-			"hx-get":    row.HXGet,
-			"hx-target": row.HXTarget,
+			"hx-get":    row.HTMX.Get,
+			"hx-target": row.HTMX.Target,
 		}
-		if row.HXSwap != "" {
-			attrs["hx-swap"] = row.HXSwap
+		if row.HTMX.Swap != "" {
+			attrs["hx-swap"] = row.HTMX.Swap
 		} else {
 			attrs["hx-swap"] = "innerHTML"
 		}
-		if row.HXPushURL {
+		if row.HTMX.PushURL {
 			attrs["hx-push-url"] = "true"
 		}
 		return attrs
 	}
-	if row.HXPost != "" {
+	if row.HTMX != nil && row.HTMX.Post != "" {
 		attrs := templ.Attributes{
-			"hx-post":   row.HXPost,
-			"hx-target": row.HXTarget,
+			"hx-post":   row.HTMX.Post,
+			"hx-target": row.HTMX.Target,
 		}
-		if row.HXSwap != "" {
-			attrs["hx-swap"] = row.HXSwap
+		if row.HTMX.Swap != "" {
+			attrs["hx-swap"] = row.HTMX.Swap
 		} else {
 			attrs["hx-swap"] = "innerHTML"
 		}
-		if row.HXPushURL {
+		if row.HTMX.PushURL {
 			attrs["hx-push-url"] = "true"
 		}
 		return attrs
@@ -562,7 +562,7 @@ func rowActionAttrs(row Row) templ.Attributes {
 // rowA11yAttrs gives keyboard and assistive-tech affordances to a row whose
 // whole area is clickable. Without these, a screen reader announces the row
 // as plain text and keyboard users can't Tab to it. Only emitted when the
-// row has a row-level target (Link / OnClick / HXGet / HXPost) — rows whose
+// row has a row-level target (Link / OnClick / HTMX.Get / HTMX.Post) — rows whose
 // interactions live inside nested controls (Actions column, Expandable with
 // its own toggle) keep native cell focus order.
 func rowA11yAttrs(row Row) templ.Attributes {

--- a/components/table/table_templ.go
+++ b/components/table/table_templ.go
@@ -710,7 +710,7 @@ func filterScript(cfg Config) templ.Component {
 //
 // hx-preserve + stable id keep the input element (and its focus + caret
 // position) intact across HTMX swaps that include the filter bar in the
-// swap target — e.g. when consumers configure HxTarget at a wrapper that
+// swap target — e.g. when consumers configure HTMX.Target at a wrapper that
 // re-renders the filter row whole-cloth (catalog with empty-state branch).
 // On the common tbody-only swap path the attribute is a no-op since the
 // filter inputs aren't part of the target.
@@ -834,15 +834,15 @@ func filterSelectInput(cfg Config, filter Filter) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if filter.HTMXOptionsURL != "" {
+		if filter.OptionsHTMX != nil && filter.OptionsHTMX.Get != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, " hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var39 string
-			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.ResolveAttributeValue(filter.HTMXOptionsURL)
+			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.ResolveAttributeValue(filter.OptionsHTMX.Get)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/table/table.templ`, Line: 237, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/table/table.templ`, Line: 237, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var39)
 			if templ_7745c5c3_Err != nil {
@@ -857,7 +857,7 @@ func filterSelectInput(cfg Config, filter Filter) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if filter.HTMXOptionsURL == "" {
+		if filter.OptionsHTMX == nil || filter.OptionsHTMX.Get == "" {
 			for _, opt := range filter.Options {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<option value=\"")
 				if templ_7745c5c3_Err != nil {
@@ -866,7 +866,7 @@ func filterSelectInput(cfg Config, filter Filter) templ.Component {
 				var templ_7745c5c3_Var40 string
 				templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.ResolveAttributeValue(opt.Value)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/table/table.templ`, Line: 244, Col: 29}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/table/table.templ`, Line: 244, Col: 30}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var40)
 				if templ_7745c5c3_Err != nil {
@@ -879,7 +879,7 @@ func filterSelectInput(cfg Config, filter Filter) templ.Component {
 				var templ_7745c5c3_Var41 string
 				templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(opt.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/table/table.templ`, Line: 244, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/table/table.templ`, Line: 244, Col: 44}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 				if templ_7745c5c3_Err != nil {
@@ -1573,7 +1573,7 @@ func TableRow(cfg Config, row Row) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if row.Expandable && row.Link == "" && row.OnClick == "" && row.HXGet == "" && row.HXPost == "" {
+		if row.Expandable && row.Link == "" && row.OnClick == "" && !row.HasHTMXAction() {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, " x-on:click=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -1581,7 +1581,7 @@ func TableRow(cfg Config, row Row) templ.Component {
 			var templ_7745c5c3_Var78 string
 			templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("openRows['%s'] = !openRows['%s']", row.ID, row.ID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/table/table.templ`, Line: 379, Col: 79}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/table/table.templ`, Line: 379, Col: 80}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var78)
 			if templ_7745c5c3_Err != nil {
@@ -1973,7 +1973,7 @@ func interactiveRowClasses(row Row) string {
 	return ""
 }
 
-// rowActionAttrs returns HTMX/JS attributes for row click actions (OnClick, HXGet, HXPost).
+// rowActionAttrs returns HTMX/JS attributes for row click actions (OnClick, HTMX.Get, HTMX.Post).
 // Link and Expandable are handled separately in the template.
 func rowActionAttrs(row Row) templ.Attributes {
 	if row.Link != "" {
@@ -1985,32 +1985,32 @@ func rowActionAttrs(row Row) templ.Attributes {
 			"onclick": row.OnClick,
 		}
 	}
-	if row.HXGet != "" {
+	if row.HTMX != nil && row.HTMX.Get != "" {
 		attrs := templ.Attributes{
-			"hx-get":    row.HXGet,
-			"hx-target": row.HXTarget,
+			"hx-get":    row.HTMX.Get,
+			"hx-target": row.HTMX.Target,
 		}
-		if row.HXSwap != "" {
-			attrs["hx-swap"] = row.HXSwap
+		if row.HTMX.Swap != "" {
+			attrs["hx-swap"] = row.HTMX.Swap
 		} else {
 			attrs["hx-swap"] = "innerHTML"
 		}
-		if row.HXPushURL {
+		if row.HTMX.PushURL {
 			attrs["hx-push-url"] = "true"
 		}
 		return attrs
 	}
-	if row.HXPost != "" {
+	if row.HTMX != nil && row.HTMX.Post != "" {
 		attrs := templ.Attributes{
-			"hx-post":   row.HXPost,
-			"hx-target": row.HXTarget,
+			"hx-post":   row.HTMX.Post,
+			"hx-target": row.HTMX.Target,
 		}
-		if row.HXSwap != "" {
-			attrs["hx-swap"] = row.HXSwap
+		if row.HTMX.Swap != "" {
+			attrs["hx-swap"] = row.HTMX.Swap
 		} else {
 			attrs["hx-swap"] = "innerHTML"
 		}
-		if row.HXPushURL {
+		if row.HTMX.PushURL {
 			attrs["hx-push-url"] = "true"
 		}
 		return attrs
@@ -2021,7 +2021,7 @@ func rowActionAttrs(row Row) templ.Attributes {
 // rowA11yAttrs gives keyboard and assistive-tech affordances to a row whose
 // whole area is clickable. Without these, a screen reader announces the row
 // as plain text and keyboard users can't Tab to it. Only emitted when the
-// row has a row-level target (Link / OnClick / HXGet / HXPost) — rows whose
+// row has a row-level target (Link / OnClick / HTMX.Get / HTMX.Post) — rows whose
 // interactions live inside nested controls (Actions column, Expandable with
 // its own toggle) keep native cell focus order.
 func rowA11yAttrs(row Row) templ.Attributes {

--- a/components/table/types.go
+++ b/components/table/types.go
@@ -86,19 +86,9 @@ type Row struct {
 	// Use for opening modals, toggling state, etc.
 	// Ignored when Link is set (Link takes precedence).
 	OnClick string
-	// HXGet triggers an HTMX GET request when the row is clicked.
+	// HTMX configures row-level HTMX click behavior.
 	// Ignored when Link or OnClick is set.
-	HXGet string
-	// HXPost triggers an HTMX POST request when the row is clicked.
-	// Ignored when Link, OnClick, or HXGet is set.
-	HXPost string
-	// HXTarget is the CSS selector for the HTMX swap target (used with HXGet/HXPost).
-	HXTarget string
-	// HXSwap is the HTMX swap strategy (used with HXGet/HXPost). Defaults to "innerHTML".
-	HXSwap string
-	// HXPushURL pushes the request URL into browser history when HXGet/HXPost
-	// navigates. Off by default. Link-mode rows always push and ignore this.
-	HXPushURL bool
+	HTMX *RowHTMXConfig
 	// AlpineAttrs is a pass-through for per-row Alpine directives (e.g.
 	// `x-show`, `x-data`, `x-bind:class`). Keys become HTML attribute names
 	// verbatim; values go through templ's attribute escaping. Use for
@@ -112,10 +102,29 @@ type Row struct {
 	Actions templ.Component
 }
 
+// RowHTMXConfig holds HTMX attributes for row-level click behavior.
+type RowHTMXConfig struct {
+	// Get triggers an HTMX GET request when the row is clicked.
+	Get string
+	// Post triggers an HTMX POST request when the row is clicked.
+	Post string
+	// Target is the CSS selector for the HTMX swap target.
+	Target string
+	// Swap is the HTMX swap strategy. Defaults to "innerHTML".
+	Swap string
+	// PushURL pushes the request URL into browser history.
+	PushURL bool
+}
+
 // IsActionable returns true if the row has any interactive behavior
 // (link, click handler, HTMX action, expandable, or custom actions).
 func (r Row) IsActionable() bool {
-	return r.Link != "" || r.OnClick != "" || r.HXGet != "" || r.HXPost != "" || r.Expandable || r.Actions != nil
+	return r.Link != "" || r.OnClick != "" || r.HasHTMXAction() || r.Expandable || r.Actions != nil
+}
+
+// HasHTMXAction reports whether the row has a row-level HTMX verb.
+func (r Row) HasHTMXAction() bool {
+	return r.HTMX != nil && (r.HTMX.Get != "" || r.HTMX.Post != "")
 }
 
 // ClickableRole returns the ARIA role to advertise for a clickable row, or
@@ -127,7 +136,7 @@ func (r Row) ClickableRole() string {
 	if r.Link != "" {
 		return "link"
 	}
-	if r.OnClick != "" || r.HXGet != "" || r.HXPost != "" {
+	if r.OnClick != "" || r.HasHTMXAction() {
 		return "button"
 	}
 	return ""
@@ -286,10 +295,16 @@ type Filter struct {
 	Placeholder string
 	// Options for select-type filters (static)
 	Options []FilterOption
-	// HTMXOptionsURL loads select options dynamically via HTMX on load
-	HTMXOptionsURL string
+	// OptionsHTMX loads select options dynamically via HTMX on load
+	OptionsHTMX *FilterOptionsHTMXConfig
 	// DefaultValue is the initial value
 	DefaultValue string
+}
+
+// FilterOptionsHTMXConfig holds HTMX attributes for dynamic select options.
+type FilterOptionsHTMXConfig struct {
+	// Get is the URL to load select options from.
+	Get string
 }
 
 // FilterVariant switches the filter bar layout. FilterVariantBar (the
@@ -317,33 +332,39 @@ type FilterConfig struct {
 	InitiallyExpanded bool
 	// Variant selects the layout (bar vs inline). See FilterVariant.
 	Variant FilterVariant
-	// HxTarget overrides the CSS selector that filter changes swap into.
+	// HTMX configures filter request behavior.
+	HTMX *FilterHTMXConfig
+}
+
+// FilterHTMXConfig holds HTMX attributes for filter requests.
+type FilterHTMXConfig struct {
+	// Target overrides the CSS selector that filter changes swap into.
 	// Default (empty) resolves to "#{tbody-id}". Use when the table sits
 	// inside a larger fragment that should be re-rendered as a unit — for
 	// example, a modal body that includes both the table and surrounding
 	// header text, or a cluster-picker card that needs pager state reset.
-	HxTarget string
-	// HxSwap overrides the htmx swap strategy used when filters apply.
+	Target string
+	// Swap overrides the htmx swap strategy used when filters apply.
 	// Default (empty) resolves to "innerHTML". Use "outerHTML" when the
-	// HxTarget is itself the wrapper that the server re-renders (e.g. a
+	// Target is itself the wrapper that the server re-renders (e.g. a
 	// catalog grid whose empty-state lives on the wrapper element).
-	HxSwap string
+	Swap string
 }
 
 // ResolvedHxTarget returns the CSS selector that filter changes should swap
-// into. Caller-provided HxTarget wins; falls back to "#{tbody-id}".
+// into. Caller-provided Target wins; falls back to "#{tbody-id}".
 func (c *FilterConfig) ResolvedHxTarget(cfg Config) string {
-	if c != nil && c.HxTarget != "" {
-		return c.HxTarget
+	if c != nil && c.HTMX != nil && c.HTMX.Target != "" {
+		return c.HTMX.Target
 	}
 	return "#" + cfg.TbodyID()
 }
 
 // ResolvedHxSwap returns the htmx swap strategy filter requests should use.
-// Caller-provided HxSwap wins; falls back to "innerHTML".
+// Caller-provided Swap wins; falls back to "innerHTML".
 func (c *FilterConfig) ResolvedHxSwap() string {
-	if c != nil && c.HxSwap != "" {
-		return c.HxSwap
+	if c != nil && c.HTMX != nil && c.HTMX.Swap != "" {
+		return c.HTMX.Swap
 	}
 	return "innerHTML"
 }
@@ -370,7 +391,7 @@ type Config struct {
 	Variant Variant
 	// ShowCheckbox adds a select-all checkbox column
 	ShowCheckbox bool
-	// Class allows additional CSS classes on the container
+	// RootClass allows additional CSS classes on the container.
 	RootClass string
 
 	// --- Sorting ---

--- a/components/tabs/types.go
+++ b/components/tabs/types.go
@@ -43,7 +43,7 @@ type Config struct {
 	Tabs []Tab
 	// DefaultTab is the ID of the initially selected tab (defaults to first tab)
 	DefaultTab string
-	// Class allows additional CSS classes on the container
+	// RootClass allows additional CSS classes on the container.
 	RootClass string
 	// SyncHash syncs the active tab with the URL fragment (hash).
 	// When true: reads hash on init to select tab, updates hash on tab change.

--- a/components/tagslist/types.go
+++ b/components/tagslist/types.go
@@ -18,7 +18,7 @@ type Config struct {
 	AddActionLabel string
 	// Disabled renders chips only (no remove buttons, no input row)
 	Disabled bool
-	// Class allows additional CSS classes on the outer container
+	// RootClass allows additional CSS classes on the outer container.
 	RootClass string
 }
 

--- a/components/textarea/types.go
+++ b/components/textarea/types.go
@@ -33,9 +33,9 @@ type Config struct {
 	State State
 	// HelperText is the helper or error text below the textarea
 	HelperText string
-	// Class allows additional CSS classes on the container
+	// RootClass allows additional CSS classes on the container.
 	RootClass string
-	// Attrs allows arbitrary HTML attributes on the <textarea> element (e.g. onkeydown, hx-*).
+	// InputAttrs allows arbitrary HTML attributes on the <textarea> element (e.g. onkeydown, hx-*).
 	InputAttrs templ.Attributes
 }
 

--- a/components/textinput/types.go
+++ b/components/textinput/types.go
@@ -62,9 +62,9 @@ type Config struct {
 	MaxLength int
 	// Readonly makes the input non-editable but still submittable
 	Readonly bool
-	// Class allows additional CSS classes on the container
+	// RootClass allows additional CSS classes on the container.
 	RootClass string
-	// Attrs allows arbitrary HTML attributes on the <input> element (e.g., hx-post, hx-indicator)
+	// InputAttrs allows arbitrary HTML attributes on the <input> element (e.g., hx-post, hx-indicator).
 	InputAttrs templ.Attributes
 }
 

--- a/components/toast/toast.templ
+++ b/components/toast/toast.templ
@@ -269,19 +269,19 @@ templ serverVariantToast(cfg Config, durationStr string) {
 					<button
 						type="button"
 						class="w-fit text-sm font-semibold underline underline-offset-2 hover:opacity-75"
-						if cfg.ActionHxGet != "" {
-							hx-get={ cfg.ActionHxGet }
+						if cfg.ActionHTMX != nil && cfg.ActionHTMX.Get != "" {
+							hx-get={ cfg.ActionHTMX.Get }
 						}
-						if cfg.ActionHxPost != "" {
-							hx-post={ cfg.ActionHxPost }
+						if cfg.ActionHTMX != nil && cfg.ActionHTMX.Post != "" {
+							hx-post={ cfg.ActionHTMX.Post }
 						}
-						if cfg.ActionHxTarget != "" {
-							hx-target={ cfg.ActionHxTarget }
+						if cfg.ActionHTMX != nil && cfg.ActionHTMX.Target != "" {
+							hx-target={ cfg.ActionHTMX.Target }
 						}
-						if cfg.ActionHxSwap != "" {
-							hx-swap={ cfg.ActionHxSwap }
+						if cfg.ActionHTMX != nil && cfg.ActionHTMX.Swap != "" {
+							hx-swap={ cfg.ActionHTMX.Swap }
 						}
-					>{ cfg.ActionText }</button>
+					>{ cfg.ActionLabel }</button>
 				}
 			</div>
 			<!-- Dismiss Button -->

--- a/components/toast/toast_templ.go
+++ b/components/toast/toast_templ.go
@@ -638,15 +638,15 @@ func serverVariantToast(cfg Config, durationStr string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if cfg.ActionHxGet != "" {
+			if cfg.ActionHTMX != nil && cfg.ActionHTMX.Get != "" {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, " hx-get=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var32 string
-				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ActionHxGet)
+				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ActionHTMX.Get)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 273, Col: 31}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 273, Col: 34}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
 				if templ_7745c5c3_Err != nil {
@@ -657,15 +657,15 @@ func serverVariantToast(cfg Config, durationStr string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			if cfg.ActionHxPost != "" {
+			if cfg.ActionHTMX != nil && cfg.ActionHTMX.Post != "" {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, " hx-post=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var33 string
-				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ActionHxPost)
+				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ActionHTMX.Post)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 276, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 276, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var33)
 				if templ_7745c5c3_Err != nil {
@@ -676,15 +676,15 @@ func serverVariantToast(cfg Config, durationStr string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			if cfg.ActionHxTarget != "" {
+			if cfg.ActionHTMX != nil && cfg.ActionHTMX.Target != "" {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, " hx-target=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var34 string
-				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ActionHxTarget)
+				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ActionHTMX.Target)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 279, Col: 37}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 279, Col: 40}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var34)
 				if templ_7745c5c3_Err != nil {
@@ -695,15 +695,15 @@ func serverVariantToast(cfg Config, durationStr string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			if cfg.ActionHxSwap != "" {
+			if cfg.ActionHTMX != nil && cfg.ActionHTMX.Swap != "" {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, " hx-swap=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var35 string
-				templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ActionHxSwap)
+				templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ActionHTMX.Swap)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 282, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 282, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var35)
 				if templ_7745c5c3_Err != nil {
@@ -719,9 +719,9 @@ func serverVariantToast(cfg Config, durationStr string) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var36 string
-			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.ActionText)
+			templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.ActionLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 284, Col: 22}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/toast/toast.templ`, Line: 284, Col: 23}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 			if templ_7745c5c3_Err != nil {

--- a/components/toast/types.go
+++ b/components/toast/types.go
@@ -32,6 +32,18 @@ type Sender struct {
 	Avatar string
 }
 
+// HTMXConfig holds HTMX attributes for a toast action button.
+type HTMXConfig struct {
+	// Get is the HTMX GET request URL the action button fires.
+	Get string
+	// Post is the HTMX POST request URL the action button fires.
+	Post string
+	// Target configures the action button's HTMX swap target.
+	Target string
+	// Swap configures the action button's HTMX swap strategy.
+	Swap string
+}
+
 // Config holds configuration for a single toast notification.
 // Used for server-side rendered toasts (including HTMX OOB swaps).
 type Config struct {
@@ -45,20 +57,16 @@ type Config struct {
 	Sender *Sender
 	// DisplayDuration in milliseconds (default 8000); negative keeps a server-rendered toast visible until dismissed manually.
 	DisplayDuration int
-	// ActionText, when set, renders an inline action button in the toast (e.g.
+	// ActionLabel, when set, renders an inline action button in the toast (e.g.
 	// "Undo"). Clicking it fires the configured HTMX request and dismisses the
 	// toast. The close (dismiss) button is always present regardless.
-	ActionText string
-	// ActionHxGet / ActionHxPost is the HTMX request URL the action button fires.
-	ActionHxGet  string
-	ActionHxPost string
-	// ActionHxTarget / ActionHxSwap configure the action button's HTMX swap.
-	ActionHxTarget string
-	ActionHxSwap   string
+	ActionLabel string
+	// ActionHTMX configures the action button's HTMX request.
+	ActionHTMX *HTMXConfig
 }
 
 // HasAction reports whether the toast should render an inline action button.
-func (cfg Config) HasAction() bool { return cfg.ActionText != "" }
+func (cfg Config) HasAction() bool { return cfg.ActionLabel != "" }
 
 // ContainerConfig holds configuration for the toast container.
 // The container is the fixed-position wrapper that holds stacking notifications.

--- a/components/toggle/types.go
+++ b/components/toggle/types.go
@@ -41,11 +41,11 @@ type Config struct {
 	// Value makes the checkbox submit this value when checked, turning the toggle into a real form control.
 	// Requires Name; when set, the always-off hidden input is omitted.
 	Value string
-	// Class allows additional CSS classes on the label
+	// RootClass allows additional CSS classes on the label.
 	RootClass string
-	// Attrs are extra attributes applied to the <input> element
+	// InputAttrs are extra attributes applied to the <input> element.
 	// (e.g. x-on:change, x-bind:checked for Alpine binding).
-	// Note: "checked" and "disabled" are already set from Config — use x-bind:checked / x-bind:disabled in Attrs for dynamic control rather than passing raw checked/disabled keys.
+	// Note: "checked" and "disabled" are already set from Config — use x-bind:checked / x-bind:disabled in InputAttrs for dynamic control rather than passing raw checked/disabled keys.
 	InputAttrs templ.Attributes
 }
 

--- a/site/internal/pages/demo/components/alert.templ
+++ b/site/internal/pages/demo/components/alert.templ
@@ -87,7 +87,7 @@ templ alertDemoContent() {
     Action: &alert.ActionConfig{
         PrimaryLabel:    "Update Now",
         PrimaryOnClick: "alert('Updating...')",
-        DismissText:    "Dismiss",
+        DismissLabel:   "Dismiss",
     },
 })`,
 		)
@@ -247,7 +247,7 @@ templ alertActionPreview() {
 					Variant:     alert.Info,
 					Action: &alert.ActionConfig{
 						PrimaryLabel: "Update Now",
-						DismissText: "Dismiss",
+						DismissLabel: "Dismiss",
 					},
 				})
 				@alert.Alert(alert.Config{
@@ -256,7 +256,7 @@ templ alertActionPreview() {
 					Variant:     alert.Success,
 					Action: &alert.ActionConfig{
 						PrimaryLabel: "Dashboard",
-						DismissText: "Dismiss",
+						DismissLabel: "Dismiss",
 					},
 				})
 				@alert.Alert(alert.Config{
@@ -265,7 +265,7 @@ templ alertActionPreview() {
 					Variant:     alert.Warning,
 					Action: &alert.ActionConfig{
 						PrimaryLabel: "Update Now",
-						DismissText: "Dismiss",
+						DismissLabel: "Dismiss",
 					},
 				})
 				@alert.Alert(alert.Config{
@@ -274,7 +274,7 @@ templ alertActionPreview() {
 					Variant:     alert.Danger,
 					Action: &alert.ActionConfig{
 						PrimaryLabel: "Try Again",
-						DismissText: "Dismiss",
+						DismissLabel: "Dismiss",
 					},
 				})
 			</div>

--- a/site/internal/pages/demo/components/alert_templ.go
+++ b/site/internal/pages/demo/components/alert_templ.go
@@ -151,7 +151,7 @@ func alertDemoContent() templ.Component {
     Action: &alert.ActionConfig{
         PrimaryLabel:    "Update Now",
         PrimaryOnClick: "alert('Updating...')",
-        DismissText:    "Dismiss",
+        DismissLabel:   "Dismiss",
     },
 })`,
 		).Render(ctx, templ_7745c5c3_Buffer)
@@ -489,7 +489,7 @@ func alertActionPreview() templ.Component {
 			Variant:     alert.Info,
 			Action: &alert.ActionConfig{
 				PrimaryLabel: "Update Now",
-				DismissText:  "Dismiss",
+				DismissLabel: "Dismiss",
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
@@ -501,7 +501,7 @@ func alertActionPreview() templ.Component {
 			Variant:     alert.Success,
 			Action: &alert.ActionConfig{
 				PrimaryLabel: "Dashboard",
-				DismissText:  "Dismiss",
+				DismissLabel: "Dismiss",
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
@@ -513,7 +513,7 @@ func alertActionPreview() templ.Component {
 			Variant:     alert.Warning,
 			Action: &alert.ActionConfig{
 				PrimaryLabel: "Update Now",
-				DismissText:  "Dismiss",
+				DismissLabel: "Dismiss",
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
@@ -525,7 +525,7 @@ func alertActionPreview() templ.Component {
 			Variant:     alert.Danger,
 			Action: &alert.ActionConfig{
 				PrimaryLabel: "Try Again",
-				DismissText:  "Dismiss",
+				DismissLabel: "Dismiss",
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {

--- a/site/internal/pages/demo/components/avatar.templ
+++ b/site/internal/pages/demo/components/avatar.templ
@@ -205,7 +205,7 @@ templ avatarDemoContent() {
 			{Name: "Icon", Type: "templ.Component", Default: "nil", Description: "Custom placeholder icon (overrides the default user icon)."},
 			{Name: "Reactive", Type: "bool", Default: "false", Description: "Read size classes from the parent Alpine scope (avatarSizeClass) instead of Size."},
 			{Name: "ReactiveRadius", Type: "bool", Default: "false", Description: "Read square radius classes from the parent Alpine scope (avatarRadiusClass)."},
-			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the avatar root."},
+			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the avatar root."},
 			{Name: "StackConfig.Items", Type: "[]avatar.Config", Default: "nil", Description: "Avatar configs rendered as an overlapping group."},
 			{Name: "StackConfig.Label", Type: "string", Default: `"Avatar group"`, Description: "Accessible label for the stacked avatar group."},
 			{Name: "StackConfig.RootClass", Type: "string", Default: `""`, Description: "Extra classes on the stack root."},

--- a/site/internal/pages/demo/components/avatar_templ.go
+++ b/site/internal/pages/demo/components/avatar_templ.go
@@ -308,7 +308,7 @@ func avatarDemoContent() templ.Component {
 			{Name: "Icon", Type: "templ.Component", Default: "nil", Description: "Custom placeholder icon (overrides the default user icon)."},
 			{Name: "Reactive", Type: "bool", Default: "false", Description: "Read size classes from the parent Alpine scope (avatarSizeClass) instead of Size."},
 			{Name: "ReactiveRadius", Type: "bool", Default: "false", Description: "Read square radius classes from the parent Alpine scope (avatarRadiusClass)."},
-			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the avatar root."},
+			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the avatar root."},
 			{Name: "StackConfig.Items", Type: "[]avatar.Config", Default: "nil", Description: "Avatar configs rendered as an overlapping group."},
 			{Name: "StackConfig.Label", Type: "string", Default: `"Avatar group"`, Description: "Accessible label for the stacked avatar group."},
 			{Name: "StackConfig.RootClass", Type: "string", Default: `""`, Description: "Extra classes on the stack root."},

--- a/site/internal/pages/demo/components/banner.templ
+++ b/site/internal/pages/demo/components/banner.templ
@@ -75,8 +75,8 @@ templ bannerDemoContent() {
     Description:         "We use cookies to improve your experience.",
     CookieConfig: &banner.CookieBannerConfig{
         Title:        "Cookie Settings",
-        AcceptText:   "Accept All",
-        RejectText:   "Decline",
+        AcceptLabel:  "Accept All",
+        RejectLabel:  "Decline",
         AcceptAction: "acceptCookies()",
         RejectAction: "show = false",
     },
@@ -154,8 +154,8 @@ templ bannerCookiePreview() {
 					Description:         "We use cookies to make your experience sweet and crispy. For more information, please read our Privacy Policy.",
 					CookieConfig: &banner.CookieBannerConfig{
 						Title:        "Cookie Time!",
-						AcceptText:   "Sounds Good!",
-						RejectText:   "No, thank you",
+						AcceptLabel:  "Sounds Good!",
+						RejectLabel:  "No, thank you",
 						AcceptAction: "show = false",
 						RejectAction: "show = false",
 					},

--- a/site/internal/pages/demo/components/banner_templ.go
+++ b/site/internal/pages/demo/components/banner_templ.go
@@ -139,8 +139,8 @@ func bannerDemoContent() templ.Component {
     Description:         "We use cookies to improve your experience.",
     CookieConfig: &banner.CookieBannerConfig{
         Title:        "Cookie Settings",
-        AcceptText:   "Accept All",
-        RejectText:   "Decline",
+        AcceptLabel:  "Accept All",
+        RejectLabel:  "Decline",
         AcceptAction: "acceptCookies()",
         RejectAction: "show = false",
     },
@@ -386,8 +386,8 @@ func bannerCookiePreview() templ.Component {
 			Description:  "We use cookies to make your experience sweet and crispy. For more information, please read our Privacy Policy.",
 			CookieConfig: &banner.CookieBannerConfig{
 				Title:        "Cookie Time!",
-				AcceptText:   "Sounds Good!",
-				RejectText:   "No, thank you",
+				AcceptLabel:  "Sounds Good!",
+				RejectLabel:  "No, thank you",
 				AcceptAction: "show = false",
 				RejectAction: "show = false",
 			},

--- a/site/internal/pages/demo/components/carousel.templ
+++ b/site/internal/pages/demo/components/carousel.templ
@@ -46,13 +46,13 @@ templ carouselDemoContent() {
 		@demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "With CTA Button",
-				Description: "Variant: carousel.WithCTA adds a call-to-action button using each slide's CTAUrl + CTAText.",
+				Description: "Variant: carousel.WithCTA adds a call-to-action button using each slide's CTAHref + CTALabel.",
 			},
 			carouselCTAPreview(),
 			`@carousel.Carousel(carousel.Config{
     Variant: carousel.WithCTA,
     Slides: []carousel.Slide{
-        {ImgSrc: "slide-1.webp", ImgAlt: "...", Title: "Build faster", Description: "Pre-built UI components.", CTAUrl: "#", CTAText: "Get Started"},
+        {ImgSrc: "slide-1.webp", ImgAlt: "...", Title: "Build faster", Description: "Pre-built UI components.", CTAHref: "#", CTALabel: "Get Started"},
     },
 })`,
 		)
@@ -121,7 +121,7 @@ templ carouselDemoContent() {
 	</div>
 	// API reference lives outside #carousel-fragment.
 	@demo.APIReference([]demo.PropDoc{
-		{Name: "Slides", Type: "[]Slide", Default: "nil", Description: "Slide data (ImgSrc, ImgAlt, Title, Description, CTAUrl, CTAText)."},
+		{Name: "Slides", Type: "[]Slide", Default: "nil", Description: "Slide data (ImgSrc, ImgAlt, Title, Description, CTAHref, CTALabel)."},
 		{Name: "Variant", Type: "Variant", Default: "Default", Description: `Style: "default", "with-text", "with-cta", "on-card".`},
 		{Name: "Autoplay", Type: "*AutoplayConfig", Default: "nil", Description: "Auto-advance config (Interval in ms)."},
 		{Name: "Touch", Type: "bool", Default: "false", Description: "Enable left/right swipe gestures."},
@@ -267,24 +267,24 @@ func ctaSlides() []carousel.Slide {
 			ImgAlt:      "Vibrant abstract painting with swirling blue and light pink hues on a canvas.",
 			Title:       "Build faster with components",
 			Description: "Pre-built, accessible UI components for your next project.",
-			CTAUrl:      "#",
-			CTAText:     "Get Started",
+			CTAHref:     "#",
+			CTALabel:    "Get Started",
 		},
 		{
 			ImgSrc:      "/assets/images/carousel/slide-2.webp",
 			ImgAlt:      "Vibrant abstract painting with swirling red, yellow, and pink hues on a canvas.",
 			Title:       "Dark mode included",
 			Description: "Every component supports light and dark themes out of the box.",
-			CTAUrl:      "#",
-			CTAText:     "View Themes",
+			CTAHref:     "#",
+			CTALabel:    "View Themes",
 		},
 		{
 			ImgSrc:      "/assets/images/carousel/slide-3.webp",
 			ImgAlt:      "Vibrant abstract painting with swirling blue and purple hues on a canvas.",
 			Title:       "Tailwind CSS powered",
 			Description: "Built with utility-first CSS for maximum flexibility.",
-			CTAUrl:      "#",
-			CTAText:     "Learn More",
+			CTAHref:     "#",
+			CTALabel:    "Learn More",
 		},
 	}
 }

--- a/site/internal/pages/demo/components/carousel_templ.go
+++ b/site/internal/pages/demo/components/carousel_templ.go
@@ -106,13 +106,13 @@ func carouselDemoContent() templ.Component {
 		templ_7745c5c3_Err = demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "With CTA Button",
-				Description: "Variant: carousel.WithCTA adds a call-to-action button using each slide's CTAUrl + CTAText.",
+				Description: "Variant: carousel.WithCTA adds a call-to-action button using each slide's CTAHref + CTALabel.",
 			},
 			carouselCTAPreview(),
 			`@carousel.Carousel(carousel.Config{
     Variant: carousel.WithCTA,
     Slides: []carousel.Slide{
-        {ImgSrc: "slide-1.webp", ImgAlt: "...", Title: "Build faster", Description: "Pre-built UI components.", CTAUrl: "#", CTAText: "Get Started"},
+        {ImgSrc: "slide-1.webp", ImgAlt: "...", Title: "Build faster", Description: "Pre-built UI components.", CTAHref: "#", CTALabel: "Get Started"},
     },
 })`,
 		).Render(ctx, templ_7745c5c3_Buffer)
@@ -196,7 +196,7 @@ func carouselDemoContent() templ.Component {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
-			{Name: "Slides", Type: "[]Slide", Default: "nil", Description: "Slide data (ImgSrc, ImgAlt, Title, Description, CTAUrl, CTAText)."},
+			{Name: "Slides", Type: "[]Slide", Default: "nil", Description: "Slide data (ImgSrc, ImgAlt, Title, Description, CTAHref, CTALabel)."},
 			{Name: "Variant", Type: "Variant", Default: "Default", Description: `Style: "default", "with-text", "with-cta", "on-card".`},
 			{Name: "Autoplay", Type: "*AutoplayConfig", Default: "nil", Description: "Auto-advance config (Interval in ms)."},
 			{Name: "Touch", Type: "bool", Default: "false", Description: "Enable left/right swipe gestures."},
@@ -595,24 +595,24 @@ func ctaSlides() []carousel.Slide {
 			ImgAlt:      "Vibrant abstract painting with swirling blue and light pink hues on a canvas.",
 			Title:       "Build faster with components",
 			Description: "Pre-built, accessible UI components for your next project.",
-			CTAUrl:      "#",
-			CTAText:     "Get Started",
+			CTAHref:     "#",
+			CTALabel:    "Get Started",
 		},
 		{
 			ImgSrc:      "/assets/images/carousel/slide-2.webp",
 			ImgAlt:      "Vibrant abstract painting with swirling red, yellow, and pink hues on a canvas.",
 			Title:       "Dark mode included",
 			Description: "Every component supports light and dark themes out of the box.",
-			CTAUrl:      "#",
-			CTAText:     "View Themes",
+			CTAHref:     "#",
+			CTALabel:    "View Themes",
 		},
 		{
 			ImgSrc:      "/assets/images/carousel/slide-3.webp",
 			ImgAlt:      "Vibrant abstract painting with swirling blue and purple hues on a canvas.",
 			Title:       "Tailwind CSS powered",
 			Description: "Built with utility-first CSS for maximum flexibility.",
-			CTAUrl:      "#",
-			CTAText:     "Learn More",
+			CTAHref:     "#",
+			CTALabel:    "Learn More",
 		},
 	}
 }

--- a/site/internal/pages/demo/components/combobox.templ
+++ b/site/internal/pages/demo/components/combobox.templ
@@ -130,7 +130,7 @@ var IndustryCfg = combobox.Config{
 		{Name: "OptionsEndpoint", Type: "string", Default: `""`, Description: "Server URL for fetching/searching options."},
 		{Name: "ClearEndpoint", Type: "string", Default: `""`, Description: "Server URL for clearing the selection."},
 		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
-		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the container."},
 	})
 }
 

--- a/site/internal/pages/demo/components/combobox_templ.go
+++ b/site/internal/pages/demo/components/combobox_templ.go
@@ -220,7 +220,7 @@ var IndustryCfg = combobox.Config{
 			{Name: "OptionsEndpoint", Type: "string", Default: `""`, Description: "Server URL for fetching/searching options."},
 			{Name: "ClearEndpoint", Type: "string", Default: `""`, Description: "Server URL for clearing the selection."},
 			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable interaction."},
-			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the container."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/site/internal/pages/demo/components/form.templ
+++ b/site/internal/pages/demo/components/form.templ
@@ -124,7 +124,7 @@ def.Bind() // wires up HTMX attributes and metadata
 @form.Form(form.Config{
     ID: "demo-validation",
     HTMX: &form.HTMXConfig{Post: "/api/components/form-validation", Target: "#form-result", Swap: "innerHTML"},
-    Footer: &form.FooterConfig{SubmitText: "Submit", CancelText: "Reset"},
+    Footer: &form.FooterConfig{SubmitLabel: "Submit", CancelLabel: "Reset"},
 }) {
     @form.Section(form.SectionConfig{Title: "Project Details"}) {
         @form.FieldGroup(*nameField)
@@ -217,8 +217,8 @@ templ formCompletePreview() {
 			ID:     "demo-form",
 				Action: "#",
 				Footer: &form.FooterConfig{
-					SubmitText: "Create Cluster",
-					CancelText: "Cancel",
+					SubmitLabel: "Create Cluster",
+					CancelLabel: "Cancel",
 					CancelHref: "#",
 				},
 			}) {

--- a/site/internal/pages/demo/components/form_templ.go
+++ b/site/internal/pages/demo/components/form_templ.go
@@ -196,7 +196,7 @@ def.Bind() // wires up HTMX attributes and metadata
 @form.Form(form.Config{
     ID: "demo-validation",
     HTMX: &form.HTMXConfig{Post: "/api/components/form-validation", Target: "#form-result", Swap: "innerHTML"},
-    Footer: &form.FooterConfig{SubmitText: "Submit", CancelText: "Reset"},
+    Footer: &form.FooterConfig{SubmitLabel: "Submit", CancelLabel: "Reset"},
 }) {
     @form.Section(form.SectionConfig{Title: "Project Details"}) {
         @form.FieldGroup(*nameField)
@@ -695,9 +695,9 @@ func formCompletePreview() templ.Component {
 			ID:     "demo-form",
 			Action: "#",
 			Footer: &form.FooterConfig{
-				SubmitText: "Create Cluster",
-				CancelText: "Cancel",
-				CancelHref: "#",
+				SubmitLabel: "Create Cluster",
+				CancelLabel: "Cancel",
+				CancelHref:  "#",
 			},
 		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {

--- a/site/internal/pages/demo/components/form_validation.templ
+++ b/site/internal/pages/demo/components/form_validation.templ
@@ -74,8 +74,8 @@ templ FormValidationFormSection(nameField *form.FieldGroupConfig, slugField *for
 			Swap:   "innerHTML",
 		},
 		Footer: &form.FooterConfig{
-			SubmitText: "Submit",
-			CancelText: "Reset",
+			SubmitLabel: "Submit",
+			CancelLabel: "Reset",
 			CancelHref: "/form",
 		},
 	}) {

--- a/site/internal/pages/demo/components/form_validation_templ.go
+++ b/site/internal/pages/demo/components/form_validation_templ.go
@@ -175,9 +175,9 @@ func FormValidationFormSection(nameField *form.FieldGroupConfig, slugField *form
 				Swap:   "innerHTML",
 			},
 			Footer: &form.FooterConfig{
-				SubmitText: "Submit",
-				CancelText: "Reset",
-				CancelHref: "/form",
+				SubmitLabel: "Submit",
+				CancelLabel: "Reset",
+				CancelHref:  "/form",
 			},
 		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {

--- a/site/internal/pages/demo/components/modal.templ
+++ b/site/internal/pages/demo/components/modal.templ
@@ -62,9 +62,7 @@ templ modalDemoContent() {
     PrimaryLabel:   "Confirm",
     SecondaryLabel: "Cancel",
     PrimaryAction: &modal.ButtonAction{
-        HxPost:   "/api/hello",
-        HxTarget: "#modal-htmx-result",
-        HxSwap:   "innerHTML",
+        HTMX: &modal.HTMXConfig{Post: "/api/hello", Target: "#modal-htmx-result", Swap: "innerHTML"},
     },
 })`,
 		)
@@ -172,9 +170,7 @@ templ modalHTMXPreview() {
 					PrimaryLabel:   "Confirm",
 					SecondaryLabel: "Cancel",
 					PrimaryAction: &modal.ButtonAction{
-						HxPost:   "/api/hello",
-						HxTarget: "#modal-htmx-result",
-						HxSwap:   "innerHTML",
+						HTMX: &modal.HTMXConfig{Post: "/api/hello", Target: "#modal-htmx-result", Swap: "innerHTML"},
 					},
 				})
 				<div id="modal-htmx-result" class="mt-2 text-sm min-h-[1.5rem]"></div>

--- a/site/internal/pages/demo/components/modal_templ.go
+++ b/site/internal/pages/demo/components/modal_templ.go
@@ -122,9 +122,7 @@ func modalDemoContent() templ.Component {
     PrimaryLabel:   "Confirm",
     SecondaryLabel: "Cancel",
     PrimaryAction: &modal.ButtonAction{
-        HxPost:   "/api/hello",
-        HxTarget: "#modal-htmx-result",
-        HxSwap:   "innerHTML",
+        HTMX: &modal.HTMXConfig{Post: "/api/hello", Target: "#modal-htmx-result", Swap: "innerHTML"},
     },
 })`,
 		).Render(ctx, templ_7745c5c3_Buffer)
@@ -335,9 +333,7 @@ func modalHTMXPreview() templ.Component {
 			PrimaryLabel:   "Confirm",
 			SecondaryLabel: "Cancel",
 			PrimaryAction: &modal.ButtonAction{
-				HxPost:   "/api/hello",
-				HxTarget: "#modal-htmx-result",
-				HxSwap:   "innerHTML",
+				HTMX: &modal.HTMXConfig{Post: "/api/hello", Target: "#modal-htmx-result", Swap: "innerHTML"},
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {

--- a/site/internal/pages/demo/components/pagination.templ
+++ b/site/internal/pages/demo/components/pagination.templ
@@ -108,7 +108,7 @@ templ paginationDemoContent() {
 		{Name: "BaseURL", Type: "string", Default: `""`, Description: "Base href for page links (page appended as a query/path)."},
 		{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "In-place HTMX navigation (Target, Swap)."},
 		{Name: "ID", Type: "string", Default: `""`, Description: "Optional element id on the nav."},
-		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
+		{Name: "NavClass", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
 	})
 }
 

--- a/site/internal/pages/demo/components/pagination_templ.go
+++ b/site/internal/pages/demo/components/pagination_templ.go
@@ -179,7 +179,7 @@ func paginationDemoContent() templ.Component {
 			{Name: "BaseURL", Type: "string", Default: `""`, Description: "Base href for page links (page appended as a query/path)."},
 			{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "In-place HTMX navigation (Target, Swap)."},
 			{Name: "ID", Type: "string", Default: `""`, Description: "Optional element id on the nav."},
-			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
+			{Name: "NavClass", Type: "string", Default: `""`, Description: "Extra classes on the nav."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/site/internal/pages/demo/components/palette.templ
+++ b/site/internal/pages/demo/components/palette.templ
@@ -63,7 +63,7 @@ templ paletteDemoContent() {
 			{Name: "HideNeutral", Type: "bool", Default: "false", Description: "Hide the neutral (gray) row."},
 			{Name: "HideReset", Type: "bool", Default: "false", Description: "Hide the reset/clear control."},
 			{Name: "ShowHex", Type: "bool", Default: "false", Description: "Show the hex value of the hovered/selected swatch."},
-			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the palette container."},
+			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the palette container."},
 		})
 	</div>
 }

--- a/site/internal/pages/demo/components/palette_templ.go
+++ b/site/internal/pages/demo/components/palette_templ.go
@@ -126,7 +126,7 @@ func paletteDemoContent() templ.Component {
 			{Name: "HideNeutral", Type: "bool", Default: "false", Description: "Hide the neutral (gray) row."},
 			{Name: "HideReset", Type: "bool", Default: "false", Description: "Hide the reset/clear control."},
 			{Name: "ShowHex", Type: "bool", Default: "false", Description: "Show the hex value of the hovered/selected swatch."},
-			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the palette container."},
+			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the palette container."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/site/internal/pages/demo/components/radio.templ
+++ b/site/internal/pages/demo/components/radio.templ
@@ -161,7 +161,7 @@ templ radioDemoContent() {
 		{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "Server interaction on change (Get/Post/Target/Swap/...)."},
 		{Name: "Alpine", Type: "*AlpineConfig", Default: "nil", Description: "Client-side state (Model/OnChange/BindChecked/...)."},
 		{Name: "InputAttrs", Type: "templ.Attributes", Default: "nil", Description: "Escape hatch applied last to the input; wins on conflict."},
-		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes appended to the label root."},
+		{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes appended to the label root."},
 	})
 }
 

--- a/site/internal/pages/demo/components/radio_templ.go
+++ b/site/internal/pages/demo/components/radio_templ.go
@@ -239,7 +239,7 @@ func radioDemoContent() templ.Component {
 			{Name: "HTMX", Type: "*HTMXConfig", Default: "nil", Description: "Server interaction on change (Get/Post/Target/Swap/...)."},
 			{Name: "Alpine", Type: "*AlpineConfig", Default: "nil", Description: "Client-side state (Model/OnChange/BindChecked/...)."},
 			{Name: "InputAttrs", Type: "templ.Attributes", Default: "nil", Description: "Escape hatch applied last to the input; wins on conflict."},
-			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes appended to the label root."},
+			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes appended to the label root."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/site/internal/pages/demo/components/select.templ
+++ b/site/internal/pages/demo/components/select.templ
@@ -137,8 +137,8 @@ templ selectDemoContent() {
 		{Name: "Readonly", Type: "bool", Default: "false", Description: "Non-editable but submittable."},
 		{Name: "Autocomplete", Type: "string", Default: `""`, Description: "HTML autocomplete attribute."},
 		{Name: "Alpine", Type: "*AlpineConfig", Default: "nil", Description: "Client-side Alpine bindings (Model, BindDisabled)."},
-		{Name: "Attrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the select."},
-		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		{Name: "InputAttrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the select."},
+		{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the container."},
 	})
 }
 

--- a/site/internal/pages/demo/components/select_templ.go
+++ b/site/internal/pages/demo/components/select_templ.go
@@ -210,8 +210,8 @@ func selectDemoContent() templ.Component {
 			{Name: "Readonly", Type: "bool", Default: "false", Description: "Non-editable but submittable."},
 			{Name: "Autocomplete", Type: "string", Default: `""`, Description: "HTML autocomplete attribute."},
 			{Name: "Alpine", Type: "*AlpineConfig", Default: "nil", Description: "Client-side Alpine bindings (Model, BindDisabled)."},
-			{Name: "Attrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the select."},
-			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+			{Name: "InputAttrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the select."},
+			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the container."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/site/internal/pages/demo/components/structuredinput.templ
+++ b/site/internal/pages/demo/components/structuredinput.templ
@@ -95,9 +95,9 @@ templ structuredInputDemoContent() {
 		{Name: "Columns", Type: "[]Column", Default: "nil", Description: "Column schema for every repeatable row."},
 		{Name: "Column.Separator", Type: "string", Default: `""`, Description: "Optional short visual separator rendered after a column, such as = or :."},
 		{Name: "Entries", Type: "[]Entry", Default: "nil", Description: "Initial row values keyed by column key."},
-		{Name: "AddLabel", Type: "string", Default: `"Add row"`, Description: "Label of the add-row button."},
+		{Name: "AddActionLabel", Type: "string", Default: `"Add row"`, Description: "Label of the add-row button."},
 		{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable controls and hide add/remove actions."},
-		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the container."},
 	})
 }
 

--- a/site/internal/pages/demo/components/structuredinput_templ.go
+++ b/site/internal/pages/demo/components/structuredinput_templ.go
@@ -161,9 +161,9 @@ func structuredInputDemoContent() templ.Component {
 			{Name: "Columns", Type: "[]Column", Default: "nil", Description: "Column schema for every repeatable row."},
 			{Name: "Column.Separator", Type: "string", Default: `""`, Description: "Optional short visual separator rendered after a column, such as = or :."},
 			{Name: "Entries", Type: "[]Entry", Default: "nil", Description: "Initial row values keyed by column key."},
-			{Name: "AddLabel", Type: "string", Default: `"Add row"`, Description: "Label of the add-row button."},
+			{Name: "AddActionLabel", Type: "string", Default: `"Add row"`, Description: "Label of the add-row button."},
 			{Name: "Disabled", Type: "bool", Default: "false", Description: "Disable controls and hide add/remove actions."},
-			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the container."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/site/internal/pages/demo/components/table.templ
+++ b/site/internal/pages/demo/components/table.templ
@@ -226,7 +226,7 @@ templ tableDemoContent() {
 		{Name: "Pagination", Type: "*PaginationConfig", Default: "nil", Description: "Pagination/infinite-scroll config (CurrentPage, TotalPages, PerPage, Mode, ...)."},
 		{Name: "Filters", Type: "*FilterConfig", Default: "nil", Description: "Filter bar config (Variant, Collapsible, Filters[]: search/select/toggle)."},
 		{Name: "ExtraQueryParams", Type: "string", Default: `""`, Description: "Extra query string appended to every HTMX request."},
-		{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the table container."},
+		{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the table container."},
 	})
 }
 

--- a/site/internal/pages/demo/components/table_templ.go
+++ b/site/internal/pages/demo/components/table_templ.go
@@ -306,7 +306,7 @@ func tableDemoContent() templ.Component {
 			{Name: "Pagination", Type: "*PaginationConfig", Default: "nil", Description: "Pagination/infinite-scroll config (CurrentPage, TotalPages, PerPage, Mode, ...)."},
 			{Name: "Filters", Type: "*FilterConfig", Default: "nil", Description: "Filter bar config (Variant, Collapsible, Filters[]: search/select/toggle)."},
 			{Name: "ExtraQueryParams", Type: "string", Default: `""`, Description: "Extra query string appended to every HTMX request."},
-			{Name: "Class", Type: "string", Default: `""`, Description: "Extra classes on the table container."},
+			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the table container."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/site/internal/server/todo_handler.go
+++ b/site/internal/server/todo_handler.go
@@ -228,10 +228,12 @@ func (s *Server) handleTodoDelete(w http.ResponseWriter, r *http.Request) {
 		// The toast itself carries the Undo action (no separate undo bar); the
 		// toast's own close button handles dismissal.
 		cfg.Message = deleted.Title
-		cfg.ActionText = "Undo"
-		cfg.ActionHxPost = examples.RestoreURL(*deleted)
-		cfg.ActionHxTarget = "#todo-list"
-		cfg.ActionHxSwap = "outerHTML"
+		cfg.ActionLabel = "Undo"
+		cfg.ActionHTMX = &toast.HTMXConfig{
+			Post:   examples.RestoreURL(*deleted),
+			Target: "#todo-list",
+			Swap:   "outerHTML",
+		}
 	}
 	_ = toast.OOBToast(cfg).Render(r.Context(), w)
 }

--- a/site/tests/e2e/profile_test.go
+++ b/site/tests/e2e/profile_test.go
@@ -160,7 +160,7 @@ func TestProfileDarkToggle(t *testing.T) {
 }
 
 // TestProfileThemePicker opens the theme Select and picks "Dracula", asserting
-// the root data-theme attribute updates. Proves the Select's AlpineModel
+// the root data-theme attribute updates. Proves the Select's Alpine.Model
 // ("theme") two-way binds to the app's root theme engine.
 func TestProfileThemePicker(t *testing.T) {
 	page := newIsolatedPage(t)


### PR DESCRIPTION
## Summary
- Complete the manual all-component API naming pass after the initial normalization work.
- Group remaining public htmx transport fields behind nested HTMX config structs.
- Rename remaining public label/href fields and update demos, tests, templ outputs, and generated component reference docs.

## Test Plan
- [x] `templ generate`
- [x] `go run ./cmd/skillgen`
- [x] `go test ./...`
- [x] `cd site && go test ./internal/... ./cmd/... -count=1`
- [x] `go build -o bin/server ./site/cmd/server`
- [x] `golangci-lint run`
- [x] `cd site && golangci-lint run`
