### PR TITLE
ci: gate coverage badge drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,6 @@ jobs:
   coverage:
     name: Combined coverage
     runs-on: araihu
-    outputs:
-      coverage_percent: ${{ steps.coverage.outputs.coverage_percent }}
     steps:
       - uses: actions/checkout@v6
 
@@ -275,37 +273,7 @@ jobs:
 
           total_line="$(grep '^total:' .coverage/coverage-func.txt)"
           total_percent="$(printf '%s\n' "$total_line" | sed -E 's/.*\t([0-9.]+)%.*/\1/')"
-          color="#e05d44"
-          awk "BEGIN { exit !($total_percent >= 80) }" && color="#4c1" || true
-          awk "BEGIN { exit !($total_percent >= 60 && $total_percent < 80) }" && color="#97ca00" || true
-          awk "BEGIN { exit !($total_percent >= 40 && $total_percent < 60) }" && color="#dfb317" || true
-
-          mkdir -p badges
-          cat > badges/coverage.svg <<EOF
-          <svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: ${total_percent}%">
-            <title>coverage: ${total_percent}%</title>
-            <linearGradient id="s" x2="0" y2="100%">
-              <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
-              <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
-              <stop offset=".9" stop-opacity=".3"/>
-              <stop offset="1" stop-opacity=".5"/>
-            </linearGradient>
-            <clipPath id="r">
-              <rect width="106" height="20" rx="3" fill="#fff"/>
-            </clipPath>
-            <g clip-path="url(#r)">
-              <rect width="59" height="20" fill="#555"/>
-              <rect x="59" width="47" height="20" fill="${color}"/>
-              <rect width="106" height="20" fill="url(#s)"/>
-            </g>
-            <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
-              <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
-              <text x="30" y="14">coverage</text>
-              <text x="81.5" y="15" fill="#010101" fill-opacity=".3">${total_percent}%</text>
-              <text x="81.5" y="14">${total_percent}%</text>
-            </g>
-          </svg>
-          EOF
+          scripts/coveragebadge "$total_percent"
 
           echo "$total_line"
           {
@@ -315,63 +283,8 @@ jobs:
             echo "$total_line"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "coverage_percent=$total_percent" >> "$GITHUB_OUTPUT"
-
-  coverage-badge:
-    name: Update coverage badge
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: coverage
-    runs-on: araihu
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Update badge SVG
-        run: |
-          set -euo pipefail
-          total_percent="${{ needs.coverage.outputs.coverage_percent }}"
-          color="#e05d44"
-          awk "BEGIN { exit !($total_percent >= 80) }" && color="#4c1" || true
-          awk "BEGIN { exit !($total_percent >= 60 && $total_percent < 80) }" && color="#97ca00" || true
-          awk "BEGIN { exit !($total_percent >= 40 && $total_percent < 60) }" && color="#dfb317" || true
-
-          mkdir -p badges
-          cat > badges/coverage.svg <<EOF
-          <svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: ${total_percent}%">
-            <title>coverage: ${total_percent}%</title>
-            <linearGradient id="s" x2="0" y2="100%">
-              <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
-              <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
-              <stop offset=".9" stop-opacity=".3"/>
-              <stop offset="1" stop-opacity=".5"/>
-            </linearGradient>
-            <clipPath id="r">
-              <rect width="106" height="20" rx="3" fill="#fff"/>
-            </clipPath>
-            <g clip-path="url(#r)">
-              <rect width="59" height="20" fill="#555"/>
-              <rect x="59" width="47" height="20" fill="${color}"/>
-              <rect width="106" height="20" fill="url(#s)"/>
-            </g>
-            <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
-              <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
-              <text x="30" y="14">coverage</text>
-              <text x="81.5" y="15" fill="#010101" fill-opacity=".3">${total_percent}%</text>
-              <text x="81.5" y="14">${total_percent}%</text>
-            </g>
-          </svg>
-          EOF
-
-          if git diff --quiet -- badges/coverage.svg; then
-            echo "Coverage badge already current."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add badges/coverage.svg
-          git commit -m "ci: update coverage badge [skip ci]"
-          git push
+          git diff --exit-code -- badges/coverage.svg \
+            || { echo "::error::coverage badge is stale — run 'just coverage' and commit badges/coverage.svg"; exit 1; }
 
   deploy:
     name: Deploy to Fly.io

--- a/badges/coverage.svg
+++ b/badges/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 53.1%">
-  <title>coverage: 53.1%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 53.3%">
+  <title>coverage: 53.3%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="30" y="14">coverage</text>
-    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">53.1%</text>
-    <text x="81.5" y="14">53.1%</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">53.3%</text>
+    <text x="81.5" y="14">53.3%</text>
   </g>
 </svg>

--- a/justfile
+++ b/justfile
@@ -75,5 +75,9 @@ coverage:
     go tool cover -func=.coverage/coverage.out > .coverage/coverage-func.txt
     go tool cover -html=.coverage/coverage.out -o .coverage/coverage.html
 
-    grep '^total:' .coverage/coverage-func.txt
-    echo "coverage artifacts: .coverage/coverage.out .coverage/coverage-func.txt .coverage/coverage-percent.txt .coverage/coverage.html"
+    total_line="$(grep '^total:' .coverage/coverage-func.txt)"
+    total_percent="$(printf '%s\n' "$total_line" | sed -E 's/.*\t([0-9.]+)%.*/\1/')"
+    scripts/coveragebadge "$total_percent"
+
+    echo "$total_line"
+    echo "coverage artifacts: .coverage/coverage.out .coverage/coverage-func.txt .coverage/coverage-percent.txt .coverage/coverage.html badges/coverage.svg"

--- a/scripts/coveragebadge
+++ b/scripts/coveragebadge
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "usage: scripts/coveragebadge <percent> [output]" >&2
+  exit 2
+fi
+
+total_percent="$1"
+output="${2:-badges/coverage.svg}"
+
+color="#e05d44"
+awk "BEGIN { exit !($total_percent >= 80) }" && color="#4c1" || true
+awk "BEGIN { exit !($total_percent >= 60 && $total_percent < 80) }" && color="#97ca00" || true
+awk "BEGIN { exit !($total_percent >= 40 && $total_percent < 60) }" && color="#dfb317" || true
+
+mkdir -p "$(dirname "$output")"
+cat > "$output" <<EOF
+<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: ${total_percent}%">
+  <title>coverage: ${total_percent}%</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-opacity=".3"/>
+    <stop offset="1" stop-opacity=".5"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="106" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="59" height="20" fill="#555"/>
+    <rect x="59" width="47" height="20" fill="${color}"/>
+    <rect width="106" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+    <text x="30" y="14">coverage</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">${total_percent}%</text>
+    <text x="81.5" y="14">${total_percent}%</text>
+  </g>
+</svg>
+EOF


### PR DESCRIPTION
## Summary
- replace the direct main-push coverage badge job with a PR-time badge drift check
- share badge SVG generation between CI and `just coverage`
- update the committed badge to the current combined coverage value, 53.3%

## Verification
- `bash -n scripts/coveragebadge`
- `just coverage`