### PR TITLE
ci: refresh coverage badge to 53.9%

### DIFF
--- a/badges/coverage.svg
+++ b/badges/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 53.8%">
-  <title>coverage: 53.8%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 53.9%">
+  <title>coverage: 53.9%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="30" y="14">coverage</text>
-    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">53.8%</text>
-    <text x="81.5" y="14">53.8%</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">53.9%</text>
+    <text x="81.5" y="14">53.9%</text>
   </g>
 </svg>


### PR DESCRIPTION
## What

Regenerate `badges/coverage.svg` from 53.8% to 53.9%.

## Why

`main` CI is red. The `Combined coverage` job ([run 26981814409](https://github.com/araihu/goshtoso/actions/runs/26981814409)) fails its badge-drift gate (`.github/workflows/ci.yml:286-287`):

```
coverage badge is stale — run 'just coverage' and commit badges/coverage.svg
```

The link component (#75) raised combined coverage 53.8% → 53.9% but did not regenerate the badge. The gate recomputes coverage, regenerates the badge, then `git diff --exit-code` — the committed 53.8% badge no longer matches, so it exits 1.

All actual tests pass (E2E, unit). This is the badge gate only.

## How

```
scripts/coveragebadge 53.9
```

Matches CI's computed value exactly (only the percent text changes; color band unchanged).

## Follow-up (not in this PR)

The gate is fragile: a coverage change without a badge refresh breaks main *after* merge, and #75's own PR check should have been red too. Consider having CI auto-commit the badge, or computing/committing it in the PR rather than failing post-merge.