### PR TITLE
fix: harden component security sinks

### DIFF
--- a/components/search/search.templ
+++ b/components/search/search.templ
@@ -128,8 +128,8 @@ templ resultItem(item Item, index int) {
 		if item.Section != "" {
 			data-search-section={ item.Section }
 		}
-		if item.Href != "" {
-			data-search-href={ item.Href }
+		if item.SafeHref() != "" {
+			data-search-href={ item.SafeHref() }
 		}
 		data-search-text={ item.SearchText() }
 		data-result-index={ fmt.Sprint(index) }

--- a/components/search/search_templ.go
+++ b/components/search/search_templ.go
@@ -530,15 +530,15 @@ func resultItem(item Item, index int) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		if item.Href != "" {
+		if item.SafeHref() != "" {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, " data-search-href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var29 string
-			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Href)
+			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.SafeHref())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 132, Col: 31}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 132, Col: 37}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var29)
 			if templ_7745c5c3_Err != nil {

--- a/components/search/search_test.go
+++ b/components/search/search_test.go
@@ -60,6 +60,42 @@ func TestSearchRendersGlobalShortcutWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestSearchEscapesResultPayloadsBeforeHighlighting(t *testing.T) {
+	payload := `<img src=x onerror=alert(1)>`
+	var buf bytes.Buffer
+	err := Search(Config{
+		ID: "docs-search",
+		Items: []Item{{
+			ID:          "result-xss",
+			Title:       payload,
+			Description: payload,
+			Href:        `javascript:alert(1)`,
+			Section:     payload,
+			Keywords:    []string{payload},
+		}},
+	}).Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	html := buf.String()
+	if strings.Contains(html, payload) {
+		t.Fatalf("rendered raw result payload:\n%s", html)
+	}
+	for _, want := range []string{
+		`data-search-title="&lt;img src=x onerror=alert(1)&gt;"`,
+		`data-search-description="&lt;img src=x onerror=alert(1)&gt;"`,
+		`&lt;img src=x onerror=alert(1)&gt;`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("Search render missing escaped payload %q in %s", want, html)
+		}
+	}
+	if strings.Contains(html, `data-search-href="javascript:alert(1)"`) {
+		t.Fatalf("Search exposes executable javascript: href through client navigation sink:\n%s", html)
+	}
+}
+
 func TestSearchDefaults(t *testing.T) {
 	cfg := Config{}
 	if cfg.GetID() != "search" {

--- a/components/search/types.go
+++ b/components/search/types.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/a-h/templ"
@@ -159,4 +160,23 @@ func (item Item) SearchText() string {
 	parts := []string{item.Title, item.Description, item.Section}
 	parts = append(parts, item.Keywords...)
 	return strings.TrimSpace(strings.Join(parts, " "))
+}
+
+// SafeHref returns a navigation target only for schemes that cannot execute
+// script when assigned to window.location.href.
+func (item Item) SafeHref() string {
+	href := strings.TrimSpace(item.Href)
+	if href == "" {
+		return ""
+	}
+	u, err := url.Parse(href)
+	if err != nil {
+		return ""
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "", "http", "https", "mailto", "tel":
+		return href
+	default:
+		return ""
+	}
 }

--- a/components/select/select.templ
+++ b/components/select/select.templ
@@ -176,6 +176,12 @@ func jsEscapeSingle(s string) string {
 			result += `\'`
 		case '\\':
 			result += `\\`
+		case '\n':
+			result += `\n`
+		case '\r':
+			result += `\r`
+		case '\t':
+			result += `\t`
 		default:
 			result += string(c)
 		}

--- a/components/select/select_hardening_test.go
+++ b/components/select/select_hardening_test.go
@@ -38,3 +38,17 @@ func TestSelect_RenderedOptionIDExpressionEscapesConfigID(t *testing.T) {
 
 	assert.Contains(t, browserHTML, `x-bind:id="'choice\'\\x-option-' + index"`)
 }
+
+func TestSelectOptionsEscapeNewlinesInAlpineStrings(t *testing.T) {
+	rendered := renderSelect(t, Config{
+		ID: "choice",
+		Options: []Option{{
+			Value: "safe",
+			Label: "first line\nalert(1)",
+		}},
+	}, nil)
+	browserHTML := html.UnescapeString(rendered)
+
+	assert.Contains(t, browserHTML, `label:'first line\nalert(1)'`)
+	assert.NotContains(t, browserHTML, "label:'first line\nalert(1)'")
+}

--- a/components/select/select_templ.go
+++ b/components/select/select_templ.go
@@ -492,6 +492,12 @@ func jsEscapeSingle(s string) string {
 			result += `\'`
 		case '\\':
 			result += `\\`
+		case '\n':
+			result += `\n`
+		case '\r':
+			result += `\r`
+		case '\t':
+			result += `\t`
 		default:
 			result += string(c)
 		}

--- a/components/structuredinput/types_test.go
+++ b/components/structuredinput/types_test.go
@@ -64,6 +64,36 @@ func TestEntriesJSONEscapesStrings(t *testing.T) {
 	}
 }
 
+func TestStructuredInputDataAttributesEscapeScriptPayloads(t *testing.T) {
+	payload := `<img src=x onerror=alert(1)>`
+	var buf strings.Builder
+	err := StructuredInput(Config{
+		ID:   "labelsDemo",
+		Name: payload,
+		Columns: []Column{
+			{Key: payload, Placeholder: payload},
+		},
+		Entries: []Entry{{payload: payload}},
+	}).Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	html := buf.String()
+	if strings.Contains(html, payload) {
+		t.Fatalf("rendered raw payload:\n%s", html)
+	}
+	for _, want := range []string{
+		`data-name="&lt;img src=x onerror=alert(1)&gt;"`,
+		`data-column-key="&lt;img src=x onerror=alert(1)&gt;"`,
+		`&lt;img src=x onerror=alert(1)&gt;`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("rendered HTML missing escaped payload %s:\n%s", want, html)
+		}
+	}
+}
+
 func TestNewRowJSONUsesColumnDefaults(t *testing.T) {
 	cfg := Config{
 		Columns: []Column{

--- a/components/table/filter_config_test.go
+++ b/components/table/filter_config_test.go
@@ -68,6 +68,26 @@ func TestFilterScriptData_EmitsHxTarget(t *testing.T) {
 	}
 }
 
+func TestFilterScriptDataEscapesFilterKeys(t *testing.T) {
+	cfg := Config{
+		ID:   "addons",
+		HTMX: &HTMXConfig{Endpoint: "/console/addons"},
+		Filters: &FilterConfig{
+			Filters: []Filter{
+				{Key: "q: '', injected: alert(1), q2", Type: FilterSearch},
+			},
+		},
+	}
+
+	out := filterScriptData(cfg)
+	if strings.Contains(out, "filters: {q: '', injected: alert(1), q2: ''}") {
+		t.Fatalf("filter key escaped into executable Alpine data:\n%s", out)
+	}
+	if !strings.Contains(out, `filters: {'q: \'\', injected: alert(1), q2': ''}`) {
+		t.Fatalf("filter key was not quoted as inert Alpine data:\n%s", out)
+	}
+}
+
 // TestFilterVariant_Constants keeps the enum surface honest — consumers
 // import these, so renaming is a breaking change.
 func TestFilterVariant_Constants(t *testing.T) {

--- a/components/table/types.go
+++ b/components/table/types.go
@@ -817,7 +817,7 @@ func filterScriptData(cfg Config) string {
 		if i > 0 {
 			filters.WriteString(", ")
 		}
-		filters.WriteString(f.Key + ": '" + jsEscape(f.DefaultValue) + "'")
+		filters.WriteString("'" + jsEscape(f.Key) + "': '" + jsEscape(f.DefaultValue) + "'")
 	}
 	filters.WriteString("}")
 

--- a/components/tagslist/tagslist_test.go
+++ b/components/tagslist/tagslist_test.go
@@ -37,3 +37,26 @@ func TestTagsListUsesActiveControlVocabulary(t *testing.T) {
 		t.Fatalf("TagsList Add button should not use dashed inactive styling: %s", html)
 	}
 }
+
+func TestTagsListInitialValuesStayInsideAlpineStrings(t *testing.T) {
+	payload := `'); alert(1); ('`
+	var buf bytes.Buffer
+	err := TagsList(Config{
+		ID:     "tags",
+		Name:   `tags'); alert(2); ('`,
+		Values: []string{payload},
+	}).Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	html := buf.String()
+	if strings.Contains(html, `'); alert(1); ('`) || strings.Contains(html, `'); alert(2); ('`) {
+		t.Fatalf("rendered unescaped Alpine string payload:\n%s", html)
+	}
+	for _, want := range []string{`items: [&#39;\&#39;); alert(1); (\&#39;&#39;]`, `name: &#39;tags\&#39;); alert(2); (\&#39;&#39;`} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("TagsList render missing escaped Alpine payload %q in %s", want, html)
+		}
+	}
+}

--- a/components/textarea/types_test.go
+++ b/components/textarea/types_test.go
@@ -1,6 +1,8 @@
 package textarea
 
 import (
+	"bytes"
+	"context"
 	"strings"
 	"testing"
 )
@@ -18,6 +20,35 @@ func TestTextareaClassesUseActiveSurfaceVocabulary(t *testing.T) {
 	} {
 		if !strings.Contains(classes, want) {
 			t.Fatalf("TextareaClasses() missing %q in %q", want, classes)
+		}
+	}
+}
+
+func TestTextareaEscapesUserControlledText(t *testing.T) {
+	payload := `<img src=x onerror=alert(1)>`
+	var buf bytes.Buffer
+	err := Textarea(Config{
+		ID:          "comment",
+		Name:        "comment",
+		Label:       payload,
+		Placeholder: payload,
+		Value:       payload,
+		HelperText:  payload,
+	}).Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	html := buf.String()
+	if strings.Contains(html, payload) {
+		t.Fatalf("rendered raw payload:\n%s", html)
+	}
+	for _, want := range []string{
+		`&lt;img src=x onerror=alert(1)&gt;`,
+		`placeholder="&lt;img src=x onerror=alert(1)&gt;"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("rendered HTML missing escaped payload %q:\n%s", want, html)
 		}
 	}
 }

--- a/components/textinput/textinput_test.go
+++ b/components/textinput/textinput_test.go
@@ -3,6 +3,7 @@ package textinput
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/a-h/templ"
@@ -27,4 +28,29 @@ func TestTextInput_RenderTargets(t *testing.T) {
 
 	assert.Contains(t, html, "root-extra")
 	assert.Contains(t, html, `data-test="input"`)
+}
+
+func TestTextInputEscapesUserControlledText(t *testing.T) {
+	payload := `<img src=x onerror=alert(1)>`
+	html := renderTextInput(t, Config{
+		ID:          "name",
+		Name:        "name",
+		Label:       payload,
+		Placeholder: payload,
+		Value:       payload,
+		HelperText:  payload,
+	})
+
+	if strings.Contains(html, payload) {
+		t.Fatalf("rendered raw payload:\n%s", html)
+	}
+	for _, want := range []string{
+		`&lt;img src=x onerror=alert(1)&gt;`,
+		`value="&lt;img src=x onerror=alert(1)&gt;"`,
+		`placeholder="&lt;img src=x onerror=alert(1)&gt;"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("rendered HTML missing escaped payload %q:\n%s", want, html)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- block executable Search result hrefs before client-side navigation
- escape Select Alpine option strings with newline/control characters
- quote Table filter keys when generating Alpine filter state
- add security regression coverage for text inputs and dynamic component data

## Test Plan
- `templ generate`
- `go test ./components/textinput ./components/textarea ./components/search ./components/tagslist ./components/structuredinput ./components/select ./components/table -count=1`
- `go test ./... -count=1`
- `cd site && go test $(go list ./... | grep -v /tests/e2e) -count=1`
