### PR TITLE
test: cover component security sink variants

### DIFF
--- a/badges/coverage.svg
+++ b/badges/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 55.2%">
-  <title>coverage: 55.2%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 55.3%">
+  <title>coverage: 55.3%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="30" y="14">coverage</text>
-    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">55.2%</text>
-    <text x="81.5" y="14">55.2%</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">55.3%</text>
+    <text x="81.5" y="14">55.3%</text>
   </g>
 </svg>

--- a/components/avatar/avatar_test.go
+++ b/components/avatar/avatar_test.go
@@ -3,6 +3,7 @@ package avatar
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -110,6 +111,27 @@ func TestAvatarStackRendersOverlappingItems(t *testing.T) {
 	for _, want := range []string{"aria-label=\"Project members\"", "-ml-3", "ring-2", "Ada Lovelace", "Grace Hopper", "KT"} {
 		if !bytes.Contains([]byte(html), []byte(want)) {
 			t.Fatalf("avatar stack missing %q in rendered HTML:\n%s", want, html)
+		}
+	}
+}
+
+func TestAvatarEscapesSrcInAlpineErrorHandler(t *testing.T) {
+	var buf bytes.Buffer
+	err := Avatar(Config{
+		Src: "data:image/svg+xml,<svg viewBox='0 0 1 1'>\n\r\t\u2028\u2029",
+		Alt: "Injected avatar",
+	}).Render(context.Background(), &buf)
+	if err != nil {
+		t.Fatalf("render avatar: %v", err)
+	}
+
+	html := buf.String()
+	if strings.Contains(html, `console.warn(&#39;[avatar] failed to load image:&#39;, &#39;data:image/svg+xml,&lt;svg viewBox=&#39;0 0 1 1&#39;&gt;`) {
+		t.Fatalf("avatar rendered raw Src inside Alpine error handler:\n%s", html)
+	}
+	for _, want := range []string{`viewBox=\&#39;0 0 1 1\&#39;`, `\n\r\t\u2028\u2029`} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("avatar missing escaped Src fragment %q in rendered HTML:\n%s", want, html)
 		}
 	}
 }

--- a/components/avatar/types.go
+++ b/components/avatar/types.go
@@ -374,6 +374,16 @@ func jsEscapeSingle(s string) string {
 			result.WriteString(`\'`)
 		case '\\':
 			result.WriteString(`\\`)
+		case '\n':
+			result.WriteString(`\n`)
+		case '\r':
+			result.WriteString(`\r`)
+		case '\t':
+			result.WriteString(`\t`)
+		case '\u2028':
+			result.WriteString(`\u2028`)
+		case '\u2029':
+			result.WriteString(`\u2029`)
 		default:
 			result.WriteString(string(c))
 		}

--- a/components/carousel/carousel_hardening_test.go
+++ b/components/carousel/carousel_hardening_test.go
@@ -1,0 +1,28 @@
+package carousel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSlidesToJSONEscapesControlCharactersInAlpineStrings(t *testing.T) {
+	payload := "value'\n\r\t\\\u2028\u2029</script>"
+	out := slidesToJSON([]Slide{{
+		ImgSrc:      payload,
+		ImgAlt:      payload,
+		Title:       payload,
+		Description: payload,
+		CTAHref:     payload,
+		CTALabel:    payload,
+	}})
+
+	want := `value\'\n\r\t\\\u2028\u2029</script>`
+	for _, field := range []string{"imgSrc", "imgAlt", "title", "description", "ctaUrl", "ctaText"} {
+		if !strings.Contains(out, field+":'"+want+"'") {
+			t.Fatalf("slidesToJSON missing escaped %s payload in:\n%s", field, out)
+		}
+	}
+	if strings.Contains(out, "value'\n") || strings.Contains(out, "\r") || strings.Contains(out, "\u2028") || strings.Contains(out, "\u2029") {
+		t.Fatalf("slidesToJSON emitted raw JS line terminator:\n%s", out)
+	}
+}

--- a/components/carousel/types.go
+++ b/components/carousel/types.go
@@ -226,6 +226,10 @@ func jsEscape(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `'`, `\'`)
 	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\t", `\t`)
+	s = strings.ReplaceAll(s, "\u2028", `\u2028`)
+	s = strings.ReplaceAll(s, "\u2029", `\u2029`)
 	return s
 }
 

--- a/components/search/search_test.go
+++ b/components/search/search_test.go
@@ -96,6 +96,51 @@ func TestSearchEscapesResultPayloadsBeforeHighlighting(t *testing.T) {
 	}
 }
 
+func TestSearchSafeHrefFiltersExecutableNavigationTargets(t *testing.T) {
+	cases := []struct {
+		name string
+		href string
+		want string
+	}{
+		{name: "relative path", href: "/components/kbd", want: `/components/kbd`},
+		{name: "relative path trims whitespace", href: " /components/kbd ", want: `/components/kbd`},
+		{name: "https", href: "https://example.test/docs", want: `https://example.test/docs`},
+		{name: "mixed case javascript", href: "JaVaScRiPt:alert(1)", want: ``},
+		{name: "javascript with whitespace", href: " javascript:alert(1) ", want: ``},
+		{name: "data scheme", href: "data:text/html,<script>alert(1)</script>", want: ``},
+		{name: "invalid url", href: ":not-a-url", want: ``},
+		{name: "protocol relative is treated as relative", href: "//example.test/docs", want: `//example.test/docs`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := Search(Config{
+				ID: "docs-search",
+				Items: []Item{{
+					ID:    "result",
+					Title: "Result",
+					Href:  tc.href,
+				}},
+			}).Render(context.Background(), &buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			html := buf.String()
+			if tc.want == "" {
+				if strings.Contains(html, "data-search-href") {
+					t.Fatalf("unsafe href %q should not be emitted:\n%s", tc.href, html)
+				}
+				return
+			}
+			wantAttr := `data-search-href="` + tc.want + `"`
+			if !strings.Contains(html, wantAttr) {
+				t.Fatalf("safe href %q did not render as %q:\n%s", tc.href, wantAttr, html)
+			}
+		})
+	}
+}
+
 func TestSearchDefaults(t *testing.T) {
 	cfg := Config{}
 	if cfg.GetID() != "search" {

--- a/components/select/select.templ
+++ b/components/select/select.templ
@@ -182,6 +182,10 @@ func jsEscapeSingle(s string) string {
 			result += `\r`
 		case '\t':
 			result += `\t`
+		case '\u2028':
+			result += `\u2028`
+		case '\u2029':
+			result += `\u2029`
 		default:
 			result += string(c)
 		}

--- a/components/select/select_hardening_test.go
+++ b/components/select/select_hardening_test.go
@@ -52,3 +52,24 @@ func TestSelectOptionsEscapeNewlinesInAlpineStrings(t *testing.T) {
 	assert.Contains(t, browserHTML, `label:'first line\nalert(1)'`)
 	assert.NotContains(t, browserHTML, "label:'first line\nalert(1)'")
 }
+
+func TestSelectData_EscapesControlCharactersInAllAlpineStrings(t *testing.T) {
+	cfg := Config{
+		Placeholder: "pick\nregion\r\t\u2028\u2029",
+		Options: []Option{{
+			Value:    "value'\n\r\t\\\u2028\u2029</script>",
+			Label:    "label'\n\r\t\\\u2028\u2029</script>",
+			Selected: true,
+		}},
+	}
+
+	data := selectData(cfg)
+
+	assert.Contains(t, data, `placeholder: 'pick\nregion\r\t\u2028\u2029'`)
+	assert.Contains(t, data, `{value:'value\'\n\r\t\\\u2028\u2029</script>',label:'label\'\n\r\t\\\u2028\u2029</script>'}`)
+	assert.Contains(t, data, `selectedValues: ['value\'\n\r\t\\\u2028\u2029</script>']`)
+	assert.NotContains(t, data, "value'\n")
+	assert.NotContains(t, data, "\r")
+	assert.NotContains(t, data, "\u2028")
+	assert.NotContains(t, data, "\u2029")
+}

--- a/components/select/select_templ.go
+++ b/components/select/select_templ.go
@@ -498,6 +498,10 @@ func jsEscapeSingle(s string) string {
 			result += `\r`
 		case '\t':
 			result += `\t`
+		case '\u2028':
+			result += `\u2028`
+		case '\u2029':
+			result += `\u2029`
 		default:
 			result += string(c)
 		}

--- a/components/table/filter_config_test.go
+++ b/components/table/filter_config_test.go
@@ -88,6 +88,28 @@ func TestFilterScriptDataEscapesFilterKeys(t *testing.T) {
 	}
 }
 
+func TestFilterScriptDataEscapesFilterDefaultValues(t *testing.T) {
+	cfg := Config{
+		ID:   "addons",
+		HTMX: &HTMXConfig{Endpoint: "/console/addons"},
+		Filters: &FilterConfig{
+			Filters: []Filter{{
+				Key:          "q",
+				Type:         FilterSearch,
+				DefaultValue: "O'Reilly\\docs\nline two\r</script>",
+			}},
+		},
+	}
+
+	out := filterScriptData(cfg)
+	if strings.Contains(out, "O'Reilly\\docs\nline two\r</script>") {
+		t.Fatalf("filter default value escaped into executable Alpine data:\n%s", out)
+	}
+	if !strings.Contains(out, `filters: {'q': 'O\'Reilly\\docs\nline two\r</script>'}`) {
+		t.Fatalf("filter default value was not emitted as an escaped inert string:\n%s", out)
+	}
+}
+
 // TestFilterVariant_Constants keeps the enum surface honest — consumers
 // import these, so renaming is a breaking change.
 func TestFilterVariant_Constants(t *testing.T) {

--- a/components/tabs/tabs.templ
+++ b/components/tabs/tabs.templ
@@ -136,6 +136,16 @@ func jsEscapeSingle(s string) string {
 			result += `\'`
 		case '\\':
 			result += `\\`
+		case '\n':
+			result += `\n`
+		case '\r':
+			result += `\r`
+		case '\t':
+			result += `\t`
+		case '\u2028':
+			result += `\u2028`
+		case '\u2029':
+			result += `\u2029`
 		default:
 			result += string(c)
 		}

--- a/components/tabs/tabs_hardening_test.go
+++ b/components/tabs/tabs_hardening_test.go
@@ -19,18 +19,22 @@ func renderTabs(t *testing.T, cfg Config) string {
 
 func TestTabsData_EscapesDefaultAndSyncHashTabIDs(t *testing.T) {
 	cfg := Config{
-		DefaultTab: `billing'\x`,
+		DefaultTab: "billing'\\x\n\r\t\u2028\u2029",
 		SyncHash:   true,
 		Tabs: []Tab{
-			{ID: `billing'\x`, Label: "Billing"},
-			{ID: `usage'\x`, Label: "Usage"},
+			{ID: "billing'\\x\n\r\t\u2028\u2029", Label: "Billing"},
+			{ID: "usage'\\x\n\r\t\u2028\u2029", Label: "Usage"},
 		},
 	}
 
 	data := tabsData(cfg)
 
-	assert.Contains(t, data, `selectedTab:'billing\'\\x'`)
-	assert.Contains(t, data, `var v=['billing\'\\x','usage\'\\x'];`)
+	assert.Contains(t, data, `selectedTab:'billing\'\\x\n\r\t\u2028\u2029'`)
+	assert.Contains(t, data, `var v=['billing\'\\x\n\r\t\u2028\u2029','usage\'\\x\n\r\t\u2028\u2029'];`)
+	assert.NotContains(t, data, "billing'\\x\n")
+	assert.NotContains(t, data, "\r")
+	assert.NotContains(t, data, "\u2028")
+	assert.NotContains(t, data, "\u2029")
 }
 
 func TestTabs_RenderedAlpineExpressionsEscapeTabID(t *testing.T) {

--- a/components/tabs/tabs_templ.go
+++ b/components/tabs/tabs_templ.go
@@ -530,6 +530,16 @@ func jsEscapeSingle(s string) string {
 			result += `\'`
 		case '\\':
 			result += `\\`
+		case '\n':
+			result += `\n`
+		case '\r':
+			result += `\r`
+		case '\t':
+			result += `\t`
+		case '\u2028':
+			result += `\u2028`
+		case '\u2029':
+			result += `\u2029`
 		default:
 			result += string(c)
 		}

--- a/components/tagslist/tagslist_test.go
+++ b/components/tagslist/tagslist_test.go
@@ -39,11 +39,11 @@ func TestTagsListUsesActiveControlVocabulary(t *testing.T) {
 }
 
 func TestTagsListInitialValuesStayInsideAlpineStrings(t *testing.T) {
-	payload := `'); alert(1); ('`
+	payload := "'); alert(1); ('\n\r\t\u2028\u2029"
 	var buf bytes.Buffer
 	err := TagsList(Config{
 		ID:     "tags",
-		Name:   `tags'); alert(2); ('`,
+		Name:   "tags'); alert(2); ('\n\r\t\u2028\u2029",
 		Values: []string{payload},
 	}).Render(context.Background(), &buf)
 	if err != nil {
@@ -54,9 +54,12 @@ func TestTagsListInitialValuesStayInsideAlpineStrings(t *testing.T) {
 	if strings.Contains(html, `'); alert(1); ('`) || strings.Contains(html, `'); alert(2); ('`) {
 		t.Fatalf("rendered unescaped Alpine string payload:\n%s", html)
 	}
-	for _, want := range []string{`items: [&#39;\&#39;); alert(1); (\&#39;&#39;]`, `name: &#39;tags\&#39;); alert(2); (\&#39;&#39;`} {
+	for _, want := range []string{`items: [&#39;\&#39;); alert(1); (\&#39;\n\r\t\u2028\u2029&#39;]`, `name: &#39;tags\&#39;); alert(2); (\&#39;\n\r\t\u2028\u2029&#39;`} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("TagsList render missing escaped Alpine payload %q in %s", want, html)
 		}
+	}
+	if strings.Contains(html, "\u2028") || strings.Contains(html, "\u2029") {
+		t.Fatalf("rendered raw JavaScript line separator in Alpine string:\n%s", html)
 	}
 }

--- a/components/tagslist/types.go
+++ b/components/tagslist/types.go
@@ -83,6 +83,10 @@ func jsEscapeSingle(s string) string {
 			sb.WriteString(`\r`)
 		case '\t':
 			sb.WriteString(`\t`)
+		case '\u2028':
+			sb.WriteString(`\u2028`)
+		case '\u2029':
+			sb.WriteString(`\u2029`)
 		default:
 			sb.WriteRune(r)
 		}


### PR DESCRIPTION
## Summary
- Add focused regression coverage for Search navigation scheme filtering, Select Alpine string literal escaping, and Table filter default-value JS escaping.
- Extend variant coverage to Tabs, TagsList, Avatar, and Carousel caller-controlled JavaScript string sinks.
- Escape raw control characters and Unicode line/paragraph separators in affected component JS string helpers.

## Variant analysis notes
- Confirmed sinks: Search `data-search-href` consumed by `window.location.href`, Select option/placeholder/selected values in Alpine data, Table filter defaults in generated Alpine data, Tabs IDs in Alpine expressions/data, TagsList initial values/name in `x-data`, Avatar `Src` in `x-on:error`, Carousel slide fields in Alpine data.
- Already-covered/triaged: Table row link JS escaping was present; Toast helper receives generated server toast IDs only, so it was not changed in this pass.

## Test Plan
- [x] go test ./components/search ./components/select ./components/table ./components/structuredinput ./components/tagslist ./components/textarea ./components/textinput ./components/tabs ./components/avatar ./components/carousel -count=1
- [x] go test ./... -count=1
