### PR TITLE
test: expand component demo e2e coverage

### DIFF
--- a/badges/coverage.svg
+++ b/badges/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 59.1%">
-  <title>coverage: 59.1%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 63.1%">
+  <title>coverage: 63.1%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -11,13 +11,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="59" height="20" fill="#555"/>
-    <rect x="59" width="47" height="20" fill="#dfb317"/>
+    <rect x="59" width="47" height="20" fill="#97ca00"/>
     <rect width="106" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="30" y="14">coverage</text>
-    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">59.1%</text>
-    <text x="81.5" y="14">59.1%</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">63.1%</text>
+    <text x="81.5" y="14">63.1%</text>
   </g>
 </svg>

--- a/components/sidebar/sidebar.templ
+++ b/components/sidebar/sidebar.templ
@@ -181,4 +181,12 @@ templ sidebarSectionItem(item Item) {
 			}
 		</a>
 	}
+
+	if len(item.Items) > 0 {
+		<div class="ml-4 flex flex-col">
+			for _, child := range item.Items {
+				@sidebarSectionItem(child)
+			}
+		</div>
+	}
 }

--- a/components/sidebar/sidebar_templ.go
+++ b/components/sidebar/sidebar_templ.go
@@ -589,7 +589,7 @@ func sidebarSectionItem(item Item) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</span></span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</span></span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -651,7 +651,7 @@ func sidebarSectionItem(item Item) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<span class=\"sr-only\">active</span></a>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<span class=\"sr-only\">active</span></a> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -713,7 +713,23 @@ func sidebarSectionItem(item Item) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</a>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</a> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if len(item.Items) > 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "<div class=\"ml-4 flex flex-col\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, child := range item.Items {
+				templ_7745c5c3_Err = sidebarSectionItem(child).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/site/tests/e2e/alert_test.go
+++ b/site/tests/e2e/alert_test.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertComponentDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/alert", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	t.Run("semantic variants render titles", func(t *testing.T) {
+		defaults := page.Locator("#alert-default [role='alert']")
+		count, err := defaults.Count()
+		require.NoError(t, err)
+		assert.Equal(t, 4, count)
+
+		for _, title := range []string{
+			"Update Available",
+			"Successfully Subscribed",
+			"Credit Card Expires Soon",
+			"Invalid Email Address",
+		} {
+			require.NoError(t, page.Locator("#alert-default [role='alert']").Filter(playwright.LocatorFilterOptions{
+				HasText: title,
+			}).WaitFor())
+		}
+	})
+
+	t.Run("dismissible close hides one alert", func(t *testing.T) {
+		first := page.Locator("#alert-dismissible [role='alert']").First()
+		require.NoError(t, first.Locator("button[aria-label='dismiss alert']").Click())
+		require.NoError(t, first.WaitFor(playwright.LocatorWaitForOptions{
+			State:   playwright.WaitForSelectorStateHidden,
+			Timeout: playwright.Float(3000),
+		}))
+
+		remaining, err := page.Locator("#alert-dismissible [role='alert']:visible").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 3, remaining)
+	})
+
+	t.Run("link list and action variants expose their content", func(t *testing.T) {
+		linkCount, err := page.Locator("#alert-link a").Filter(playwright.LocatorFilterOptions{HasText: "Details"}).Count()
+		require.NoError(t, err)
+		assert.Equal(t, 4, linkCount)
+
+		for _, item := range []string{
+			"has minimum 8 characters",
+			"includes both upper and lower cases",
+			"contains at least one number",
+		} {
+			count, err := page.Locator("#alert-list li").Filter(playwright.LocatorFilterOptions{HasText: item}).Count()
+			require.NoError(t, err)
+			assert.Equal(t, 2, count)
+		}
+
+		updateCount, err := page.Locator("#alert-action button").Filter(playwright.LocatorFilterOptions{HasText: "Update Now"}).Count()
+		require.NoError(t, err)
+		assert.Equal(t, 2, updateCount)
+
+		dismissCount, err := page.Locator("#alert-action button").Filter(playwright.LocatorFilterOptions{HasText: "Dismiss"}).Count()
+		require.NoError(t, err)
+		assert.Equal(t, 4, dismissCount)
+	})
+}

--- a/site/tests/e2e/badge_test.go
+++ b/site/tests/e2e/badge_test.go
@@ -1,0 +1,73 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBadgeComponentDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/badge", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+
+	t.Run("solid and soft variants render semantic labels", func(t *testing.T) {
+		for _, id := range []string{"#badge-solid", "#badge-soft"} {
+			for _, label := range []string{"Default", "Primary", "Secondary", "Info", "Success", "Warning", "Danger"} {
+				require.NoError(t, page.Locator(id).GetByText(label, playwright.LocatorGetByTextOptions{
+					Exact: playwright.Bool(true),
+				}).WaitFor())
+			}
+		}
+	})
+
+	t.Run("icon and indicator badges keep labels visible", func(t *testing.T) {
+		for _, label := range []string{"Penguin", "Filter", "Verified", "Active", "Warning", "Error"} {
+			badge := page.Locator("#badge-icons span").Filter(playwright.LocatorFilterOptions{HasText: label}).First()
+			require.NoError(t, badge.WaitFor())
+
+			iconCount, err := badge.Locator("svg").Count()
+			require.NoError(t, err)
+			assert.Greater(t, iconCount, 0, "expected leading icon for %s", label)
+		}
+
+		indicatorCount, err := page.Locator("#badge-indicators span[aria-hidden='true']").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 6, indicatorCount)
+	})
+
+	t.Run("notification badges and dots expose counts and buttons", func(t *testing.T) {
+		require.NoError(t, page.Locator("#badge-notification button[aria-label='notifications']").WaitFor())
+		require.NoError(t, page.Locator("#badge-notification button[aria-label='messages']").WaitFor())
+		require.NoError(t, page.Locator("#badge-notification button[aria-label='alerts']").WaitFor())
+
+		require.NoError(t, page.Locator("#badge-notification").GetByText("99", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+		require.NoError(t, page.Locator("#badge-notification").GetByText("5", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+		dotCount, err := page.Locator("#badge-notification span.size-3").Count()
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, dotCount, 1)
+	})
+
+	t.Run("animating dots and sizes render stable class hooks", func(t *testing.T) {
+		animating, err := page.Locator("#badge-animating span[aria-label='notification']").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 6, animating)
+
+		for _, label := range []string{"Small", "Medium", "Large"} {
+			require.NoError(t, page.Locator("#badge-sizes").GetByText(label, playwright.LocatorGetByTextOptions{
+				Exact: playwright.Bool(true),
+			}).WaitFor())
+		}
+	})
+}

--- a/site/tests/e2e/breadcrumbs_test.go
+++ b/site/tests/e2e/breadcrumbs_test.go
@@ -1,0 +1,44 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBreadcrumbsComponentDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/breadcrumbs", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+
+	for _, id := range []string{"#breadcrumbs-chevron", "#breadcrumbs-slash", "#breadcrumbs-icon"} {
+		nav := page.Locator(id + " nav[aria-label='breadcrumb']")
+		require.NoError(t, nav.WaitFor())
+
+		require.NoError(t, nav.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: "Components"}).WaitFor())
+		current := nav.Locator("[aria-current='page']")
+		assert.Equal(t, "Breadcrumb", mustText(t, current))
+	}
+
+	slashCount, err := page.Locator("#breadcrumbs-slash span[aria-hidden='true']").Filter(playwright.LocatorFilterOptions{HasText: "/"}).Count()
+	require.NoError(t, err)
+	assert.Equal(t, 2, slashCount)
+
+	chevronCount, err := page.Locator("#breadcrumbs-chevron svg[aria-hidden='true']").Count()
+	require.NoError(t, err)
+	assert.Equal(t, 2, chevronCount)
+
+	homeTooltip, err := page.Locator("#breadcrumbs-icon a").First().Locator("span").First().GetAttribute("title")
+	require.NoError(t, err)
+	assert.Equal(t, "Home", homeTooltip)
+}

--- a/site/tests/e2e/card_test.go
+++ b/site/tests/e2e/card_test.go
@@ -1,0 +1,60 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCardComponentDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/card", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+
+	defaultCard := page.Locator("#card-default article")
+	require.NoError(t, defaultCard.WaitFor())
+	assert.Equal(t, "A penguin robot talking with a human", mustAttribute(t, defaultCard.Locator("img"), "alt"))
+	require.NoError(t, defaultCard.GetByText("Features", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	require.NoError(t, defaultCard.GetByText("Penguai can teach you Javascript", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+	require.NoError(t, page.Locator("#card-button button").Filter(playwright.LocatorFilterOptions{HasText: "Book Now"}).WaitFor())
+
+	horizontalClass := mustAttribute(t, page.Locator("#card-horizontal article"), "class")
+	assert.Contains(t, horizontalClass, "md:grid-cols-8")
+	assert.Equal(t, "Man wearing VR goggles", mustAttribute(t, page.Locator("#card-horizontal img"), "alt"))
+	require.NoError(t, page.Locator("#card-horizontal").GetByText("AI-Powered VR Goggles Redefine Reality").WaitFor())
+
+	product := page.Locator("#card-product")
+	require.NoError(t, product.GetByText("CASIO G-SHOCK GA2100", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	require.NoError(t, product.GetByText("$99.99", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	assert.Equal(t, "Rated 3 stars", strings.TrimSpace(mustText(t, product.Locator(".sr-only").First())))
+	require.NoError(t, product.Locator("button").Filter(playwright.LocatorFilterOptions{HasText: "Add to Cart"}).WaitFor())
+
+	pricing := page.Locator("#card-pricing")
+	require.NoError(t, pricing.GetByText("Premium", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	require.NoError(t, pricing.GetByText("Unlimited access to all courses").WaitFor())
+	require.NoError(t, pricing.Locator("button").Filter(playwright.LocatorFilterOptions{HasText: "Start your free trial"}).WaitFor())
+
+	testimonial := page.Locator("#card-testimonial")
+	require.NoError(t, testimonial.GetByText("Bob Johnson", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	require.NoError(t, testimonial.GetByText("CEO - TechNova", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	assert.Equal(t, "Rated 4 stars", strings.TrimSpace(mustText(t, testimonial.Locator(".sr-only").First())))
+}
+
+func mustAttribute(t *testing.T, loc playwright.Locator, name string) string {
+	t.Helper()
+	value, err := loc.GetAttribute(name)
+	require.NoError(t, err)
+	return value
+}

--- a/site/tests/e2e/codeblock_test.go
+++ b/site/tests/e2e/codeblock_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -97,4 +98,68 @@ func TestCodeBlock_ChromaHighlighting(t *testing.T) {
 		require.Equal(t, text, copied,
 			"clipboard payload should equal the rendered code textContent")
 	})
+}
+
+func TestCodeBlock_DirectDemoPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/codeblock", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	for _, label := range []string{"main.go", "html", "css", "Install", "long.go"} {
+		require.NoError(t, page.GetByText(label, playwright.PageGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).First().WaitFor())
+	}
+
+	for _, source := range []string{
+		`fmt.Println("hello, world")`,
+		`x-data="{ open: false }"`,
+		`color: var(--color-primary)`,
+		`go get github.com/a-h/templ`,
+		`http.ListenAndServe(":8080", nil)`,
+	} {
+		require.NoError(t, page.Locator(".codeblock").Filter(playwright.LocatorFilterOptions{
+			HasText: source,
+		}).First().WaitFor())
+	}
+
+	scrollable := page.Locator(".codeblock").Filter(playwright.LocatorFilterOptions{
+		HasText: `http.ListenAndServe(":8080", nil)`,
+	}).First()
+	maxHeight, err := scrollable.Evaluate("el => getComputedStyle(el).maxHeight", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "180px", maxHeight)
+
+	_, err = page.Evaluate(`() => {
+		window.__copied = null;
+		Object.defineProperty(navigator, 'clipboard', {
+			configurable: true,
+			value: {
+				writeText: (t) => { window.__copied = t; return Promise.resolve(); }
+			}
+		});
+	}`, nil)
+	require.NoError(t, err)
+
+	firstBlock := page.Locator(".codeblock").First()
+	expected, err := firstBlock.TextContent()
+	require.NoError(t, err)
+	copyButton := firstBlock.Locator("xpath=..").Locator("button[aria-label='Copy main.go code']").First()
+	require.NoError(t, copyButton.WaitFor())
+
+	_, err = firstBlock.Evaluate(`el => Alpine.$data(el.parentElement).copyCode()`, nil)
+	require.NoError(t, err)
+
+	copied, err := page.Evaluate("() => window.__copied", nil)
+	require.NoError(t, err)
+	assert.Equal(t, expected, copied)
 }

--- a/site/tests/e2e/sidebar_test.go
+++ b/site/tests/e2e/sidebar_test.go
@@ -162,3 +162,67 @@ func TestSidebar_ExamplesTopItemNavigatesToOverview(t *testing.T) {
 	require.NoError(t, page.WaitForURL("**/examples"))
 	require.NoError(t, page.Locator("main h1", playwright.PageLocatorOptions{HasText: "Examples"}).WaitFor())
 }
+
+func TestSidebarComponentDemoVariants(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/sidebar", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	simple := page.Locator("#sidebar-simple")
+	require.NoError(t, simple.GetByText("MyApp", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	require.NoError(t, simple.Locator("input[type='search'][placeholder='Search...']").WaitFor())
+	require.NoError(t, simple.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: "Profile"}).WaitFor())
+	require.NoError(t, simple.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: "Inbox"}).GetByText("3", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+	sections := page.Locator("#sidebar-sections")
+	for _, heading := range []string{"Getting Started", "Components", "Settings"} {
+		require.NoError(t, sections.Locator("h3").Filter(playwright.LocatorFilterOptions{HasText: heading}).WaitFor())
+	}
+	require.NoError(t, sections.Locator("[data-sidebar-section='Components']").GetByText("Table", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+	subItems := page.Locator("#sidebar-sub-items")
+	require.NoError(t, subItems.GetByText("API Docs", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	for _, label := range []string{"Create User", "Get User", "Update User", "Delete User"} {
+		count, err := subItems.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: label}).Count()
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	}
+	for _, badge := range []string{"POST", "GET", "PUT", "DEL"} {
+		count, err := subItems.Locator("sup").Filter(playwright.LocatorFilterOptions{HasText: badge}).Count()
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, count, 1)
+	}
+
+	contentButton := page.Locator("#sidebar-collapsible button").Filter(playwright.LocatorFilterOptions{HasText: "Content"})
+	require.NoError(t, contentButton.Click())
+	require.NoError(t, page.Locator("#sidebar-collapsible").GetByText("Articles", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+
+	overlay := page.Locator("#sidebar-overlay")
+	panel := overlay.GetByText("Overlay", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)})
+	visible, err := panel.IsVisible()
+	require.NoError(t, err)
+	assert.False(t, visible)
+
+	require.NoError(t, overlay.Locator("button[aria-label='Open sidebar']").Click())
+	require.NoError(t, panel.WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateVisible,
+		Timeout: playwright.Float(3000),
+	}))
+
+	require.NoError(t, overlay.Locator("button[aria-label='Close sidebar']").Click())
+	require.NoError(t, panel.WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateHidden,
+		Timeout: playwright.Float(3000),
+	}))
+}


### PR DESCRIPTION
## Summary
- add direct component-page E2E coverage for Alert, Badge, Breadcrumbs, Card, Code Block, and Sidebar demos
- cover Code Block direct-page variants, copy behavior, and scrollable snippets
- fix Sidebar section items so nested sub-items render recursively, matching the demo

## Test Plan
- [x] `go test ./site/tests/e2e/... -count=1 -timeout 5m -run 'Test(Alert|Sidebar|CodeBlock|Breadcrumbs|Badge|Card)'`
- [x] `templ generate`
- [x] `go test ./... -count=1`
- [x] `cd site && go test $(go list ./... | grep -v /tests/e2e) -count=1`
- [x] `git diff --check`

## Follow-up
- Wrote remaining coverage handoff to `/tmp/goshtoso-e2e-coverage-remaining-components-handoff.md`.
