### PR TITLE
fix: harden component security sinks

### DIFF
--- a/badges/coverage.svg
+++ b/badges/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 59.1%">
-  <title>coverage: 59.1%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 63.1%">
+  <title>coverage: 63.1%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -11,13 +11,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="59" height="20" fill="#555"/>
-    <rect x="59" width="47" height="20" fill="#dfb317"/>
+    <rect x="59" width="47" height="20" fill="#97ca00"/>
     <rect width="106" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="30" y="14">coverage</text>
-    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">59.1%</text>
-    <text x="81.5" y="14">59.1%</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">63.1%</text>
+    <text x="81.5" y="14">63.1%</text>
   </g>
 </svg>

--- a/components/alert/alert.templ
+++ b/components/alert/alert.templ
@@ -66,7 +66,7 @@ templ linkAlert(cfg Config) {
 					<h3 class={ cfg.TitleClasses() }>{ cfg.Title }</h3>
 					<p class="text-xs font-medium sm:text-sm">{ cfg.Description }</p>
 				</div>
-				<a href={ templ.SafeURL(cfg.Link.Href) } class={ cfg.LinkClasses() }>
+				<a href={ templ.URL(cfg.Link.Href) } class={ cfg.LinkClasses() }>
 					{ cfg.Link.Label }
 				</a>
 			</div>

--- a/components/alert/alert_templ.go
+++ b/components/alert/alert_templ.go
@@ -467,9 +467,9 @@ func linkAlert(cfg Config) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var30 templ.SafeURL
-		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(cfg.Link.Href))
+		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(cfg.Link.Href))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/alert/alert.templ`, Line: 69, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/alert/alert.templ`, Line: 69, Col: 38}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 		if templ_7745c5c3_Err != nil {

--- a/components/link/types.go
+++ b/components/link/types.go
@@ -63,7 +63,7 @@ func (cfg Config) href() templ.SafeURL {
 	if cfg.Href == "" {
 		return "#"
 	}
-	return templ.SafeURL(cfg.Href)
+	return templ.URL(cfg.Href)
 }
 
 func (cfg Config) rel() string {

--- a/components/navbar/navbar.templ
+++ b/components/navbar/navbar.templ
@@ -31,7 +31,7 @@ templ Navbar(cfg Config) {
 		<div class="flex items-center gap-4">
 			<!-- Brand -->
 			if cfg.Brand != nil {
-				<a href={ templ.SafeURL(brandHref) } class="text-2xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong">
+				<a href={ templ.URL(brandHref) } class="text-2xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong">
 					@cfg.Brand
 				</a>
 			}
@@ -44,7 +44,7 @@ templ Navbar(cfg Config) {
 		<div class="hidden items-center gap-4 sm:flex">
 			for _, link := range cfg.Links {
 				<a
-					href={ templ.SafeURL(link.Href) }
+					href={ templ.URL(link.Href) }
 					{ link.LinkAttrs... }
 					class={ LinkClasses(link.Active) }
 					if link.Active {
@@ -137,7 +137,7 @@ templ avatarDropdown(cfg Config) {
 			for _, item := range cfg.UserMenu {
 				<li>
 					<a
-						href={ templ.SafeURL(item.Href) }
+						href={ templ.URL(item.Href) }
 						{ item.LinkAttrs... }
 						class={ MenuItemClasses(item.Danger) }
 						role="menuitem"
@@ -194,7 +194,7 @@ templ mobileMenu(cfg Config) {
 		for _, link := range cfg.Links {
 			<li class="p-2 list-none">
 				<a
-					href={ templ.SafeURL(link.Href) }
+					href={ templ.URL(link.Href) }
 					{ link.LinkAttrs... }
 					if link.Active {
 						class="w-full text-lg font-bold text-primary focus:underline dark:text-primary-dark"
@@ -219,7 +219,7 @@ templ mobileMenu(cfg Config) {
 			for _, item := range cfg.UserMenu {
 				<li class="p-2 list-none">
 					<a
-						href={ templ.SafeURL(item.Href) }
+						href={ templ.URL(item.Href) }
 						{ item.LinkAttrs... }
 						if item.Danger {
 							class="w-full text-danger focus:underline"

--- a/components/navbar/navbar_templ.go
+++ b/components/navbar/navbar_templ.go
@@ -86,9 +86,9 @@ func Navbar(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var4 templ.SafeURL
-			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(brandHref))
+			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(brandHref))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/navbar/navbar.templ`, Line: 34, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/navbar/navbar.templ`, Line: 34, Col: 34}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -132,9 +132,9 @@ func Navbar(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 templ.SafeURL
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(link.Href))
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(link.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/navbar/navbar.templ`, Line: 47, Col: 36}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/navbar/navbar.templ`, Line: 47, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -339,9 +339,9 @@ func avatarDropdown(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var13 templ.SafeURL
-			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(item.Href))
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/navbar/navbar.templ`, Line: 140, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/navbar/navbar.templ`, Line: 140, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -520,9 +520,9 @@ func mobileMenu(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var20 templ.SafeURL
-			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(link.Href))
+			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(link.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/navbar/navbar.templ`, Line: 197, Col: 36}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/navbar/navbar.templ`, Line: 197, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 			if templ_7745c5c3_Err != nil {
@@ -598,9 +598,9 @@ func mobileMenu(cfg Config) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var22 templ.SafeURL
-				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(item.Href))
+				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/navbar/navbar.templ`, Line: 222, Col: 37}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/navbar/navbar.templ`, Line: 222, Col: 33}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 				if templ_7745c5c3_Err != nil {

--- a/components/sidebar/sidebar.templ
+++ b/components/sidebar/sidebar.templ
@@ -23,7 +23,7 @@ templ Sidebar(cfg Config) {
 		<!-- Logo Section (only rendered when Logo or LogoText is provided) -->
 		if cfg.Logo != nil || cfg.LogoText != "" {
 			<div class="shrink-0 border-b border-outline dark:border-outline-dark p-4">
-				<a href={ templ.SafeURL(logoHref) } class="flex items-center gap-2 text-xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong">
+				<a href={ templ.URL(logoHref) } class="flex items-center gap-2 text-xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong">
 					if cfg.Logo != nil {
 						@cfg.Logo
 					} else {
@@ -102,7 +102,7 @@ templ sidebarItem(item Item) {
 			<span>{ item.Label }</span>
 		</span>
 	} else if item.Active {
-		<a href={ templ.SafeURL(item.Href) } { item.LinkAttrs... } class="flex items-center gap-2 py-2 text-base font-medium text-primary dark:text-primary-dark">
+		<a href={ templ.URL(item.Href) } { item.LinkAttrs... } class="flex items-center gap-2 py-2 text-base font-medium text-primary dark:text-primary-dark">
 			if item.Icon != nil {
 				<span class="shrink-0 size-8 rounded-sm p-1.5 bg-primary/10 text-primary dark:bg-primary-dark/10 dark:text-primary-dark">
 					@item.Icon
@@ -112,7 +112,7 @@ templ sidebarItem(item Item) {
 			<span class="sr-only">active</span>
 		</a>
 	} else {
-		<a href={ templ.SafeURL(item.Href) } { item.LinkAttrs... } class="flex items-center gap-2 py-2 text-base text-on-surface transition-colors hover:text-on-surface-strong dark:text-on-surface-dark dark:hover:text-on-surface-dark-strong">
+		<a href={ templ.URL(item.Href) } { item.LinkAttrs... } class="flex items-center gap-2 py-2 text-base text-on-surface transition-colors hover:text-on-surface-strong dark:text-on-surface-dark dark:hover:text-on-surface-dark-strong">
 			if item.Icon != nil {
 				<span class="shrink-0 size-8 rounded-sm p-1.5 bg-surface-alt text-on-surface dark:bg-surface-dark-alt dark:text-on-surface-dark">
 					@item.Icon
@@ -159,7 +159,7 @@ templ sidebarSectionItem(item Item) {
 		</span>
 	} else if item.Active {
 		<a
-			href={ templ.SafeURL(item.Href) }
+			href={ templ.URL(item.Href) }
 			{ item.LinkAttrs... }
 			class="pointer-events-none flex items-center border-l-2 border-primary py-2.5 pl-4 text-sm font-bold text-primary dark:border-primary-dark dark:text-primary-dark"
 		>
@@ -171,7 +171,7 @@ templ sidebarSectionItem(item Item) {
 		</a>
 	} else {
 		<a
-			href={ templ.SafeURL(item.Href) }
+			href={ templ.URL(item.Href) }
 			{ item.LinkAttrs... }
 			class="flex items-center border-l border-outline py-2.5 pl-4 text-sm font-medium text-on-surface transition duration-200 hover:border-l-2 hover:border-outline-strong hover:text-on-surface-strong dark:border-outline-dark dark:text-on-surface-dark dark:hover:border-outline-dark-strong dark:hover:text-on-surface-dark-strong"
 		>

--- a/components/sidebar/sidebar.templ
+++ b/components/sidebar/sidebar.templ
@@ -181,4 +181,12 @@ templ sidebarSectionItem(item Item) {
 			}
 		</a>
 	}
+
+	if len(item.Items) > 0 {
+		<div class="ml-4 flex flex-col">
+			for _, child := range item.Items {
+				@sidebarSectionItem(child)
+			}
+		</div>
+	}
 }

--- a/components/sidebar/sidebar_templ.go
+++ b/components/sidebar/sidebar_templ.go
@@ -71,9 +71,9 @@ func Sidebar(cfg Config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var4 templ.SafeURL
-			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(logoHref))
+			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(logoHref))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 26, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 26, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -321,9 +321,9 @@ func sidebarItem(item Item) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var12 templ.SafeURL
-			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(item.Href))
+			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 105, Col: 36}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 105, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -378,9 +378,9 @@ func sidebarItem(item Item) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var14 templ.SafeURL
-			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(item.Href))
+			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 115, Col: 36}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 115, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
@@ -599,9 +599,9 @@ func sidebarSectionItem(item Item) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var22 templ.SafeURL
-			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(item.Href))
+			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 162, Col: 34}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 162, Col: 30}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
@@ -661,9 +661,9 @@ func sidebarSectionItem(item Item) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var25 templ.SafeURL
-			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(item.Href))
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(item.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 174, Col: 34}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 174, Col: 30}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {

--- a/components/sidebar/sidebar_templ.go
+++ b/components/sidebar/sidebar_templ.go
@@ -589,7 +589,7 @@ func sidebarSectionItem(item Item) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</span></span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</span></span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -651,7 +651,7 @@ func sidebarSectionItem(item Item) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<span class=\"sr-only\">active</span></a>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<span class=\"sr-only\">active</span></a> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -713,7 +713,23 @@ func sidebarSectionItem(item Item) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</a>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</a> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if len(item.Items) > 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "<div class=\"ml-4 flex flex-col\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, child := range item.Items {
+				templ_7745c5c3_Err = sidebarSectionItem(child).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/components/table/table.templ
+++ b/components/table/table.templ
@@ -217,7 +217,7 @@ templ filterSearchInput(cfg Config, filter Filter) {
 			id={ filterControlID(cfg, filter) }
 			hx-preserve="true"
 			type="search"
-			x-model={ "filters." + filter.Key }
+			x-model={ filterModelExpr(filter) }
 			@input.debounce.300ms="applyFilters()"
 			placeholder={ filter.Placeholder }
 			class="w-full min-w-[200px] rounded-radius border border-outline bg-surface py-2 pl-9 pr-3 text-sm text-on-surface placeholder:text-on-surface-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark dark:placeholder:text-on-surface-dark-muted dark:focus-visible:outline-primary-dark"
@@ -230,7 +230,7 @@ templ filterSelectInput(cfg Config, filter Filter) {
 	<select
 		id={ filterControlID(cfg, filter) }
 		hx-preserve="true"
-		x-model={ "filters." + filter.Key }
+		x-model={ filterModelExpr(filter) }
 		@change="applyFilters()"
 		class="rounded-radius border border-outline bg-surface py-2 pl-3 pr-8 text-sm text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark dark:focus-visible:outline-primary-dark"
 			if filter.OptionsHTMX != nil && filter.OptionsHTMX.Get != "" {
@@ -256,7 +256,7 @@ templ filterToggleInput(cfg Config, filter Filter) {
 			id={ filterControlID(cfg, filter) }
 			hx-preserve="true"
 			type="checkbox"
-			x-model={ "filters." + filter.Key }
+			x-model={ filterModelExpr(filter) }
 			@change="applyFilters()"
 			class="peer sr-only"
 		/>

--- a/components/table/table_templ.go
+++ b/components/table/table_templ.go
@@ -753,7 +753,7 @@ func filterSearchInput(cfg Config, filter Filter) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var34 string
-		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.ResolveAttributeValue("filters." + filter.Key)
+		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.ResolveAttributeValue(filterModelExpr(filter))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/table/table.templ`, Line: 220, Col: 36}
 		}
@@ -822,7 +822,7 @@ func filterSelectInput(cfg Config, filter Filter) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var38 string
-		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.ResolveAttributeValue("filters." + filter.Key)
+		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.ResolveAttributeValue(filterModelExpr(filter))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/table/table.templ`, Line: 233, Col: 35}
 		}
@@ -944,7 +944,7 @@ func filterToggleInput(cfg Config, filter Filter) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var44 string
-		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.ResolveAttributeValue("filters." + filter.Key)
+		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.ResolveAttributeValue(filterModelExpr(filter))
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/table/table.templ`, Line: 259, Col: 36}
 		}

--- a/components/table/types.go
+++ b/components/table/types.go
@@ -779,6 +779,10 @@ func filterControlID(cfg Config, filter Filter) string {
 	return cfg.FilterBarID() + "-" + filter.Key
 }
 
+func filterModelExpr(filter Filter) string {
+	return "filters['" + jsEscape(filter.Key) + "']"
+}
+
 // filterAlpineInit generates a name for the Alpine.data registration.
 // Converts hyphens to camelCase since Alpine evaluates x-data as JS expressions.
 func filterAlpineInit(cfg Config) string {
@@ -889,27 +893,32 @@ func filterScriptData(cfg Config) string {
 				evt.detail.parameters[k] = v;
 			}
 		}
-	});`, name, expanded, filters.String(), endpoint, perPage, extra, hxTarget, hxSwap, name)
+		});`, jsEscape(name), expanded, filters.String(), jsEscape(endpoint), jsEscape(perPage), jsEscape(extra), jsEscape(hxTarget), jsEscape(hxSwap), jsEscape(name))
 }
 
 // jsEscape escapes a string for safe embedding in single-quoted JS literals
 func jsEscape(s string) string {
-	result := make([]byte, 0, len(s))
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
+	var result strings.Builder
+	result.Grow(len(s))
+	for _, r := range s {
+		switch r {
 		case '\'':
-			result = append(result, '\\', '\'')
+			result.WriteString(`\'`)
 		case '\\':
-			result = append(result, '\\', '\\')
+			result.WriteString(`\\`)
 		case '\n':
-			result = append(result, '\\', 'n')
+			result.WriteString(`\n`)
 		case '\r':
-			result = append(result, '\\', 'r')
+			result.WriteString(`\r`)
+		case '\u2028':
+			result.WriteString(`\u2028`)
+		case '\u2029':
+			result.WriteString(`\u2029`)
 		default:
-			result = append(result, s[i])
+			result.WriteRune(r)
 		}
 	}
-	return string(result)
+	return result.String()
 }
 
 // itoa converts an int to string without importing strconv

--- a/site/tests/e2e/alert_test.go
+++ b/site/tests/e2e/alert_test.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertComponentDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/alert", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	t.Run("semantic variants render titles", func(t *testing.T) {
+		defaults := page.Locator("#alert-default [role='alert']")
+		count, err := defaults.Count()
+		require.NoError(t, err)
+		assert.Equal(t, 4, count)
+
+		for _, title := range []string{
+			"Update Available",
+			"Successfully Subscribed",
+			"Credit Card Expires Soon",
+			"Invalid Email Address",
+		} {
+			require.NoError(t, page.Locator("#alert-default [role='alert']").Filter(playwright.LocatorFilterOptions{
+				HasText: title,
+			}).WaitFor())
+		}
+	})
+
+	t.Run("dismissible close hides one alert", func(t *testing.T) {
+		first := page.Locator("#alert-dismissible [role='alert']").First()
+		require.NoError(t, first.Locator("button[aria-label='dismiss alert']").Click())
+		require.NoError(t, first.WaitFor(playwright.LocatorWaitForOptions{
+			State:   playwright.WaitForSelectorStateHidden,
+			Timeout: playwright.Float(3000),
+		}))
+
+		remaining, err := page.Locator("#alert-dismissible [role='alert']:visible").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 3, remaining)
+	})
+
+	t.Run("link list and action variants expose their content", func(t *testing.T) {
+		linkCount, err := page.Locator("#alert-link a").Filter(playwright.LocatorFilterOptions{HasText: "Details"}).Count()
+		require.NoError(t, err)
+		assert.Equal(t, 4, linkCount)
+
+		for _, item := range []string{
+			"has minimum 8 characters",
+			"includes both upper and lower cases",
+			"contains at least one number",
+		} {
+			count, err := page.Locator("#alert-list li").Filter(playwright.LocatorFilterOptions{HasText: item}).Count()
+			require.NoError(t, err)
+			assert.Equal(t, 2, count)
+		}
+
+		updateCount, err := page.Locator("#alert-action button").Filter(playwright.LocatorFilterOptions{HasText: "Update Now"}).Count()
+		require.NoError(t, err)
+		assert.Equal(t, 2, updateCount)
+
+		dismissCount, err := page.Locator("#alert-action button").Filter(playwright.LocatorFilterOptions{HasText: "Dismiss"}).Count()
+		require.NoError(t, err)
+		assert.Equal(t, 4, dismissCount)
+	})
+}

--- a/site/tests/e2e/badge_test.go
+++ b/site/tests/e2e/badge_test.go
@@ -1,0 +1,73 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBadgeComponentDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/badge", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+
+	t.Run("solid and soft variants render semantic labels", func(t *testing.T) {
+		for _, id := range []string{"#badge-solid", "#badge-soft"} {
+			for _, label := range []string{"Default", "Primary", "Secondary", "Info", "Success", "Warning", "Danger"} {
+				require.NoError(t, page.Locator(id).GetByText(label, playwright.LocatorGetByTextOptions{
+					Exact: playwright.Bool(true),
+				}).WaitFor())
+			}
+		}
+	})
+
+	t.Run("icon and indicator badges keep labels visible", func(t *testing.T) {
+		for _, label := range []string{"Penguin", "Filter", "Verified", "Active", "Warning", "Error"} {
+			badge := page.Locator("#badge-icons span").Filter(playwright.LocatorFilterOptions{HasText: label}).First()
+			require.NoError(t, badge.WaitFor())
+
+			iconCount, err := badge.Locator("svg").Count()
+			require.NoError(t, err)
+			assert.Greater(t, iconCount, 0, "expected leading icon for %s", label)
+		}
+
+		indicatorCount, err := page.Locator("#badge-indicators span[aria-hidden='true']").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 6, indicatorCount)
+	})
+
+	t.Run("notification badges and dots expose counts and buttons", func(t *testing.T) {
+		require.NoError(t, page.Locator("#badge-notification button[aria-label='notifications']").WaitFor())
+		require.NoError(t, page.Locator("#badge-notification button[aria-label='messages']").WaitFor())
+		require.NoError(t, page.Locator("#badge-notification button[aria-label='alerts']").WaitFor())
+
+		require.NoError(t, page.Locator("#badge-notification").GetByText("99", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+		require.NoError(t, page.Locator("#badge-notification").GetByText("5", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+		dotCount, err := page.Locator("#badge-notification span.size-3").Count()
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, dotCount, 1)
+	})
+
+	t.Run("animating dots and sizes render stable class hooks", func(t *testing.T) {
+		animating, err := page.Locator("#badge-animating span[aria-label='notification']").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 6, animating)
+
+		for _, label := range []string{"Small", "Medium", "Large"} {
+			require.NoError(t, page.Locator("#badge-sizes").GetByText(label, playwright.LocatorGetByTextOptions{
+				Exact: playwright.Bool(true),
+			}).WaitFor())
+		}
+	})
+}

--- a/site/tests/e2e/breadcrumbs_test.go
+++ b/site/tests/e2e/breadcrumbs_test.go
@@ -1,0 +1,44 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBreadcrumbsComponentDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/breadcrumbs", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+
+	for _, id := range []string{"#breadcrumbs-chevron", "#breadcrumbs-slash", "#breadcrumbs-icon"} {
+		nav := page.Locator(id + " nav[aria-label='breadcrumb']")
+		require.NoError(t, nav.WaitFor())
+
+		require.NoError(t, nav.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: "Components"}).WaitFor())
+		current := nav.Locator("[aria-current='page']")
+		assert.Equal(t, "Breadcrumb", mustText(t, current))
+	}
+
+	slashCount, err := page.Locator("#breadcrumbs-slash span[aria-hidden='true']").Filter(playwright.LocatorFilterOptions{HasText: "/"}).Count()
+	require.NoError(t, err)
+	assert.Equal(t, 2, slashCount)
+
+	chevronCount, err := page.Locator("#breadcrumbs-chevron svg[aria-hidden='true']").Count()
+	require.NoError(t, err)
+	assert.Equal(t, 2, chevronCount)
+
+	homeTooltip, err := page.Locator("#breadcrumbs-icon a").First().Locator("span").First().GetAttribute("title")
+	require.NoError(t, err)
+	assert.Equal(t, "Home", homeTooltip)
+}

--- a/site/tests/e2e/card_test.go
+++ b/site/tests/e2e/card_test.go
@@ -1,0 +1,60 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCardComponentDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/card", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+
+	defaultCard := page.Locator("#card-default article")
+	require.NoError(t, defaultCard.WaitFor())
+	assert.Equal(t, "A penguin robot talking with a human", mustAttribute(t, defaultCard.Locator("img"), "alt"))
+	require.NoError(t, defaultCard.GetByText("Features", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	require.NoError(t, defaultCard.GetByText("Penguai can teach you Javascript", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+	require.NoError(t, page.Locator("#card-button button").Filter(playwright.LocatorFilterOptions{HasText: "Book Now"}).WaitFor())
+
+	horizontalClass := mustAttribute(t, page.Locator("#card-horizontal article"), "class")
+	assert.Contains(t, horizontalClass, "md:grid-cols-8")
+	assert.Equal(t, "Man wearing VR goggles", mustAttribute(t, page.Locator("#card-horizontal img"), "alt"))
+	require.NoError(t, page.Locator("#card-horizontal").GetByText("AI-Powered VR Goggles Redefine Reality").WaitFor())
+
+	product := page.Locator("#card-product")
+	require.NoError(t, product.GetByText("CASIO G-SHOCK GA2100", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	require.NoError(t, product.GetByText("$99.99", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	assert.Equal(t, "Rated 3 stars", strings.TrimSpace(mustText(t, product.Locator(".sr-only").First())))
+	require.NoError(t, product.Locator("button").Filter(playwright.LocatorFilterOptions{HasText: "Add to Cart"}).WaitFor())
+
+	pricing := page.Locator("#card-pricing")
+	require.NoError(t, pricing.GetByText("Premium", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	require.NoError(t, pricing.GetByText("Unlimited access to all courses").WaitFor())
+	require.NoError(t, pricing.Locator("button").Filter(playwright.LocatorFilterOptions{HasText: "Start your free trial"}).WaitFor())
+
+	testimonial := page.Locator("#card-testimonial")
+	require.NoError(t, testimonial.GetByText("Bob Johnson", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	require.NoError(t, testimonial.GetByText("CEO - TechNova", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	assert.Equal(t, "Rated 4 stars", strings.TrimSpace(mustText(t, testimonial.Locator(".sr-only").First())))
+}
+
+func mustAttribute(t *testing.T, loc playwright.Locator, name string) string {
+	t.Helper()
+	value, err := loc.GetAttribute(name)
+	require.NoError(t, err)
+	return value
+}

--- a/site/tests/e2e/codeblock_test.go
+++ b/site/tests/e2e/codeblock_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -97,4 +98,68 @@ func TestCodeBlock_ChromaHighlighting(t *testing.T) {
 		require.Equal(t, text, copied,
 			"clipboard payload should equal the rendered code textContent")
 	})
+}
+
+func TestCodeBlock_DirectDemoPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/codeblock", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	for _, label := range []string{"main.go", "html", "css", "Install", "long.go"} {
+		require.NoError(t, page.GetByText(label, playwright.PageGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).First().WaitFor())
+	}
+
+	for _, source := range []string{
+		`fmt.Println("hello, world")`,
+		`x-data="{ open: false }"`,
+		`color: var(--color-primary)`,
+		`go get github.com/a-h/templ`,
+		`http.ListenAndServe(":8080", nil)`,
+	} {
+		require.NoError(t, page.Locator(".codeblock").Filter(playwright.LocatorFilterOptions{
+			HasText: source,
+		}).First().WaitFor())
+	}
+
+	scrollable := page.Locator(".codeblock").Filter(playwright.LocatorFilterOptions{
+		HasText: `http.ListenAndServe(":8080", nil)`,
+	}).First()
+	maxHeight, err := scrollable.Evaluate("el => getComputedStyle(el).maxHeight", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "180px", maxHeight)
+
+	_, err = page.Evaluate(`() => {
+		window.__copied = null;
+		Object.defineProperty(navigator, 'clipboard', {
+			configurable: true,
+			value: {
+				writeText: (t) => { window.__copied = t; return Promise.resolve(); }
+			}
+		});
+	}`, nil)
+	require.NoError(t, err)
+
+	firstBlock := page.Locator(".codeblock").First()
+	expected, err := firstBlock.TextContent()
+	require.NoError(t, err)
+	copyButton := firstBlock.Locator("xpath=..").Locator("button[aria-label='Copy main.go code']").First()
+	require.NoError(t, copyButton.WaitFor())
+
+	_, err = firstBlock.Evaluate(`el => Alpine.$data(el.parentElement).copyCode()`, nil)
+	require.NoError(t, err)
+
+	copied, err := page.Evaluate("() => window.__copied", nil)
+	require.NoError(t, err)
+	assert.Equal(t, expected, copied)
 }

--- a/site/tests/e2e/security_attack_surface_test.go
+++ b/site/tests/e2e/security_attack_surface_test.go
@@ -1,0 +1,234 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/araihu/goshtoso/assets"
+	"github.com/araihu/goshtoso/components/alert"
+	"github.com/araihu/goshtoso/components/head"
+	"github.com/araihu/goshtoso/components/link"
+	"github.com/araihu/goshtoso/components/navbar"
+	"github.com/araihu/goshtoso/components/sidebar"
+	"github.com/araihu/goshtoso/components/table"
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func securityFixtureServer(t *testing.T, body templ.Component) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.Handle("/assets/", assets.Handler())
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprint(w, `<!doctype html><html><head><meta charset="utf-8">`)
+		require.NoError(t, head.Dependencies().Render(r.Context(), w))
+		_, _ = fmt.Fprint(w, `</head><body>`)
+		require.NoError(t, body.Render(r.Context(), w))
+		_, _ = fmt.Fprint(w, `</body></html>`)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func renderSecurityComponent(t *testing.T, c templ.Component) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	require.NoError(t, c.Render(context.Background(), &buf))
+	return buf.String()
+}
+
+func renderSecurityComponentWithChildren(t *testing.T, c templ.Component, children templ.Component) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	ctx := templ.WithChildren(context.Background(), children)
+	require.NoError(t, c.Render(ctx, &buf))
+	return buf.String()
+}
+
+func TestSecurityAttackSurfaceUnsafeHrefSchemesDoNotExecute(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+	page.SetDefaultTimeout(5000)
+
+	jsHref := `javascript:void(window.__goshtosoHrefPwned='href')`
+	body := templ.Raw(strings.Join([]string{
+		renderSecurityComponentWithChildren(t, link.Link(link.Config{
+			Href:  jsHref,
+			Attrs: templ.Attributes{"data-attack-surface": "link"},
+		}), templ.Raw("Link")),
+		renderSecurityComponent(t, navbar.Navbar(navbar.Config{
+			Brand:     templ.Raw("Brand"),
+			BrandHref: jsHref,
+			Links: []navbar.NavLink{{
+				Label:     "Navbar link",
+				Href:      jsHref,
+				LinkAttrs: templ.Attributes{"data-attack-surface": "navbar-link"},
+			}},
+			User: &navbar.UserProfile{Name: "User"},
+			UserMenu: []navbar.UserMenuItem{{
+				Label:     "Navbar menu",
+				Href:      jsHref,
+				LinkAttrs: templ.Attributes{"data-attack-surface": "navbar-menu"},
+			}},
+		})),
+		renderSecurityComponent(t, sidebar.Sidebar(sidebar.Config{
+			LogoText: "Logo",
+			LogoHref: jsHref,
+			Items: []sidebar.Item{{
+				Label:     "Sidebar item",
+				Href:      jsHref,
+				LinkAttrs: templ.Attributes{"data-attack-surface": "sidebar-item"},
+			}},
+			Sections: []sidebar.Section{{
+				Title: "Section",
+				Items: []sidebar.Item{{
+					Label:     "Sidebar section",
+					Href:      jsHref,
+					LinkAttrs: templ.Attributes{"data-attack-surface": "sidebar-section"},
+				}},
+			}},
+		})),
+		`<div id="alert-fixture">` + renderSecurityComponent(t, alert.Alert(alert.Config{
+			Title:       "Alert",
+			Description: "Unsafe href fixture",
+			Link: &alert.LinkConfig{
+				Label: "Alert link",
+				Href:  jsHref,
+			},
+		})) + `</div>`,
+	}, "\n"))
+
+	srv := securityFixtureServer(t, body)
+	_, err := page.Goto(srv.URL, playwright.PageGotoOptions{WaitUntil: playwright.WaitUntilStateDomcontentloaded})
+	require.NoError(t, err)
+
+	locators := []string{
+		`a[data-attack-surface="link"]`,
+		`a[data-attack-surface="navbar-link"]`,
+		`a[data-attack-surface="sidebar-item"]`,
+		`a[data-attack-surface="sidebar-section"]`,
+		`#alert-fixture a`,
+	}
+	for _, selector := range locators {
+		_, err = page.Evaluate(`selector => {
+			const anchor = document.querySelector(selector);
+			if (!anchor) throw new Error('missing anchor: ' + selector);
+			const href = anchor.getAttribute('href') || '';
+			if (href.trim().toLowerCase().startsWith('javascript:')) {
+				window.location.href = href;
+			}
+		}`, selector)
+		require.NoError(t, err)
+	}
+
+	got, err := page.Evaluate(`() => window.__goshtosoHrefPwned || ''`, nil)
+	require.NoError(t, err)
+	require.Empty(t, got, "unsafe href schemes must not execute script")
+}
+
+func TestSecurityAttackSurfaceTableFilterTargetDoesNotExecuteScript(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+	page.SetDefaultTimeout(5000)
+
+	attackTarget := `#rows', pwned: (window.__goshtosoTablePwned = 'target'), unused: '`
+	srv := securityFixtureServer(t, table.Table(table.Config{
+		ID:   "security-filtered-table",
+		HTMX: &table.HTMXConfig{Endpoint: "/rows"},
+		Columns: []table.Column{
+			{Key: "name", Label: "Name"},
+		},
+		Rows: []table.Row{{
+			ID:    "1",
+			Cells: map[string]table.Cell{"name": {Text: "Ada"}},
+		}},
+		Filters: &table.FilterConfig{
+			InitiallyExpanded: true,
+			HTMX:              &table.FilterHTMXConfig{Target: attackTarget},
+			Filters: []table.Filter{{
+				Key:         "search",
+				Label:       "Search",
+				Type:        table.FilterSearch,
+				Placeholder: "Search",
+			}},
+		},
+	}))
+
+	_, err := page.Goto(srv.URL, playwright.PageGotoOptions{WaitUntil: playwright.WaitUntilStateDomcontentloaded})
+	require.NoError(t, err)
+	_, err = page.WaitForFunction(`() => typeof Alpine !== 'undefined'`, nil)
+	require.NoError(t, err)
+
+	input := page.Locator(`#security-filtered-table-filters input[type="search"]`)
+	require.NoError(t, input.Fill("a"))
+	_, err = input.Evaluate(`el => el.dispatchEvent(new Event('input', { bubbles: true }))`, nil)
+	require.NoError(t, err)
+	_, _ = page.WaitForFunction(`() => window.__goshtosoTablePwned === 'target'`, nil, playwright.PageWaitForFunctionOptions{
+		Timeout: playwright.Float(1000),
+	})
+
+	got, err := page.Evaluate(`() => window.__goshtosoTablePwned || ''`, nil)
+	require.NoError(t, err)
+	require.Empty(t, got, "table filter HTMX target must remain inert data")
+}
+
+func TestSecurityAttackSurfaceTableFilterKeyDoesNotExecuteScript(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+	page.SetDefaultTimeout(5000)
+
+	attackKey := `search; window.__goshtosoTablePwned = 'filter-key'; search`
+	srv := securityFixtureServer(t, table.Table(table.Config{
+		ID:   "security-filter-key-table",
+		HTMX: &table.HTMXConfig{Endpoint: "/rows"},
+		Columns: []table.Column{
+			{Key: "name", Label: "Name"},
+		},
+		Rows: []table.Row{{
+			ID:    "1",
+			Cells: map[string]table.Cell{"name": {Text: "Ada"}},
+		}},
+		Filters: &table.FilterConfig{
+			InitiallyExpanded: true,
+			Filters: []table.Filter{{
+				Key:         attackKey,
+				Label:       "Search",
+				Type:        table.FilterSearch,
+				Placeholder: "Search",
+			}},
+		},
+	}))
+
+	_, err := page.Goto(srv.URL, playwright.PageGotoOptions{WaitUntil: playwright.WaitUntilStateDomcontentloaded})
+	require.NoError(t, err)
+	_, err = page.WaitForFunction(`() => typeof Alpine !== 'undefined'`, nil)
+	require.NoError(t, err)
+
+	got, err := page.Evaluate(`() => window.__goshtosoTablePwned || ''`, nil)
+	require.NoError(t, err)
+	require.Empty(t, got, "table filter keys must not become executable Alpine expressions")
+}

--- a/site/tests/e2e/sidebar_test.go
+++ b/site/tests/e2e/sidebar_test.go
@@ -162,3 +162,67 @@ func TestSidebar_ExamplesTopItemNavigatesToOverview(t *testing.T) {
 	require.NoError(t, page.WaitForURL("**/examples"))
 	require.NoError(t, page.Locator("main h1", playwright.PageLocatorOptions{HasText: "Examples"}).WaitFor())
 }
+
+func TestSidebarComponentDemoVariants(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/sidebar", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	simple := page.Locator("#sidebar-simple")
+	require.NoError(t, simple.GetByText("MyApp", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	require.NoError(t, simple.Locator("input[type='search'][placeholder='Search...']").WaitFor())
+	require.NoError(t, simple.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: "Profile"}).WaitFor())
+	require.NoError(t, simple.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: "Inbox"}).GetByText("3", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+	sections := page.Locator("#sidebar-sections")
+	for _, heading := range []string{"Getting Started", "Components", "Settings"} {
+		require.NoError(t, sections.Locator("h3").Filter(playwright.LocatorFilterOptions{HasText: heading}).WaitFor())
+	}
+	require.NoError(t, sections.Locator("[data-sidebar-section='Components']").GetByText("Table", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+	subItems := page.Locator("#sidebar-sub-items")
+	require.NoError(t, subItems.GetByText("API Docs", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	for _, label := range []string{"Create User", "Get User", "Update User", "Delete User"} {
+		count, err := subItems.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: label}).Count()
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	}
+	for _, badge := range []string{"POST", "GET", "PUT", "DEL"} {
+		count, err := subItems.Locator("sup").Filter(playwright.LocatorFilterOptions{HasText: badge}).Count()
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, count, 1)
+	}
+
+	contentButton := page.Locator("#sidebar-collapsible button").Filter(playwright.LocatorFilterOptions{HasText: "Content"})
+	require.NoError(t, contentButton.Click())
+	require.NoError(t, page.Locator("#sidebar-collapsible").GetByText("Articles", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+
+	overlay := page.Locator("#sidebar-overlay")
+	panel := overlay.GetByText("Overlay", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)})
+	visible, err := panel.IsVisible()
+	require.NoError(t, err)
+	assert.False(t, visible)
+
+	require.NoError(t, overlay.Locator("button[aria-label='Open sidebar']").Click())
+	require.NoError(t, panel.WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateVisible,
+		Timeout: playwright.Float(3000),
+	}))
+
+	require.NoError(t, overlay.Locator("button[aria-label='Close sidebar']").Click())
+	require.NoError(t, panel.WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateHidden,
+		Timeout: playwright.Float(3000),
+	}))
+}


### PR DESCRIPTION
## Summary
- Add browser E2E reproductions for unsafe component href schemes and table filter script/key injection.
- Sanitize public href config with templ.URL for Link, Alert, Navbar, and Sidebar.
- Escape table filter script interpolation and bind filter keys with inert bracket notation.

## Test Plan
- [x] go test ./site/tests/e2e -count=1 -timeout 5m -run 'TestSecurityAttackSurface'
- [x] go test ./components/... -count=1