### PR TITLE
test: expand component e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           if-no-files-found: ignore
 
   coverage:
-    name: Combined coverage
+    name: Component coverage
     runs-on: araihu
     steps:
       - uses: actions/checkout@v6
@@ -234,32 +234,33 @@ jobs:
           tailwindcss -i css/main.css -o assets/styles.css
 
       # The merged coverage profile uses Go's native 1.20+ coverage data format
-      # so package tests and the coverage-instrumented demo server can be
-      # combined into one statement-coverage number.
-      - name: Combined unit + E2E coverage
+      # so package tests and the coverage-instrumented demo server can drive
+      # the publishable library without counting demo-site package coverage.
+      - name: Component unit + E2E coverage
         id: coverage
         run: |
           set -euo pipefail
           root="$PWD"
-          root_coverpkg="github.com/araihu/goshtoso/..."
-          all_coverpkg="${root_coverpkg},github.com/araihu/goshtoso/site/..."
+          component_coverpkg="$(go list ./components/... | paste -sd, -)"
 
           go work init . ./site
 
           rm -rf .coverage
           mkdir -p .coverage/unit-root .coverage/unit-site .coverage/e2e .coverage/merged
 
-          go test -cover -coverpkg="$root_coverpkg" ./... -count=1 \
+          root_pkgs="$(go list ./... | grep -v '^github.com/araihu/goshtoso/site/')"
+          go test -cover -coverpkg="$component_coverpkg" $root_pkgs -count=1 \
             -args -test.gocoverdir="$root/.coverage/unit-root"
 
           (
             cd site
             site_pkgs="$(go list ./... | grep -v '/tests/e2e')"
-            go test -cover -coverpkg="$all_coverpkg" $site_pkgs -count=1 \
+            site_component_coverpkg="$(go list -deps $site_pkgs | grep '^github.com/araihu/goshtoso/components/' | sort -u | paste -sd, -)"
+            go test -cover -coverpkg="$site_component_coverpkg" $site_pkgs -count=1 \
               -args -test.gocoverdir="$root/.coverage/unit-site"
 
             GOSHTOSO_E2E_COVERDIR="$root/.coverage/e2e" \
-            GOSHTOSO_E2E_COVERPKG="$all_coverpkg" \
+            GOSHTOSO_E2E_COVERPKG="$component_coverpkg" \
               go test ./tests/e2e/... -count=1 -timeout 15m
           )
 
@@ -277,7 +278,7 @@ jobs:
 
           echo "$total_line"
           {
-            echo "### Combined Go coverage"
+            echo "### Component Go coverage"
             echo
             echo '```text'
             echo "$total_line"

--- a/badges/coverage.svg
+++ b/badges/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 63.1%">
-  <title>coverage: 63.1%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 32.3%">
+  <title>coverage: 32.3%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -11,13 +11,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="59" height="20" fill="#555"/>
-    <rect x="59" width="47" height="20" fill="#97ca00"/>
+    <rect x="59" width="47" height="20" fill="#e05d44"/>
     <rect width="106" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="30" y="14">coverage</text>
-    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">63.1%</text>
-    <text x="81.5" y="14">63.1%</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">32.3%</text>
+    <text x="81.5" y="14">32.3%</text>
   </g>
 </svg>

--- a/justfile
+++ b/justfile
@@ -37,14 +37,13 @@ css:
 vendor-js:
     go run ./cmd/vendorgen -download
 
-# Run root unit tests, site unit tests, and E2E tests, then merge all Go
+# Run root unit tests, site unit tests, and E2E tests, then merge component
 # coverage data into .coverage/coverage.out and .coverage/coverage.html.
 coverage:
     #!/usr/bin/env bash
     set -euo pipefail
     root="$PWD"
-    root_coverpkg="github.com/araihu/goshtoso/..."
-    all_coverpkg="${root_coverpkg},github.com/araihu/goshtoso/site/..."
+    component_coverpkg="$(go list ./components/... | paste -sd, -)"
 
     if [ ! -f go.work ]; then
       go work init . ./site
@@ -53,17 +52,19 @@ coverage:
     rm -rf .coverage
     mkdir -p .coverage/unit-root .coverage/unit-site .coverage/e2e .coverage/merged
 
-    go test -cover -coverpkg="$root_coverpkg" ./... -count=1 \
+    root_pkgs="$(go list ./... | grep -v '^github.com/araihu/goshtoso/site/')"
+    go test -cover -coverpkg="$component_coverpkg" $root_pkgs -count=1 \
       -args -test.gocoverdir="$root/.coverage/unit-root"
 
     (
       cd site
       site_pkgs="$(go list ./... | grep -v '/tests/e2e')"
-      go test -cover -coverpkg="$all_coverpkg" $site_pkgs -count=1 \
+      site_component_coverpkg="$(go list -deps $site_pkgs | grep '^github.com/araihu/goshtoso/components/' | sort -u | paste -sd, -)"
+      go test -cover -coverpkg="$site_component_coverpkg" $site_pkgs -count=1 \
         -args -test.gocoverdir="$root/.coverage/unit-site"
 
       GOSHTOSO_E2E_COVERDIR="$root/.coverage/e2e" \
-      GOSHTOSO_E2E_COVERPKG="$all_coverpkg" \
+      GOSHTOSO_E2E_COVERPKG="$component_coverpkg" \
         go test ./tests/e2e/... -count=1 -timeout 15m
     )
 

--- a/site/tests/e2e/banner_test.go
+++ b/site/tests/e2e/banner_test.go
@@ -5,43 +5,103 @@ import (
 	"testing"
 
 	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBannerCookiePreviewStaysInsideDemoBox(t *testing.T) {
+func TestBannerComponentDemoVariants(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping E2E test in short mode")
 	}
 
-	cleanupServer := setupServer(t)
-	defer cleanupServer()
-
-	_, browser, cleanupPW := setupPlaywright(t)
-	defer cleanupPW()
-
+	_, browser, _ := setupPlaywright(t)
 	page := newPage(t, browser)
 	_, err := page.Goto(baseURL+"/components/banner", playwright.PageGotoOptions{
 		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
 	})
 	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
 
-	stage := page.Locator("#banner-cookie > div").First()
-	dialog := page.Locator("#banner-cookie [role='dialog']").First()
-	require.NoError(t, stage.WaitFor())
-	require.NoError(t, dialog.WaitFor())
+	t.Run("simple banner dismisses only itself", func(t *testing.T) {
+		simple := page.Locator("#banner-simple")
+		bannerEl := simple.Locator("[role='banner']")
+		require.NoError(t, bannerEl.GetByText("Limited Time Offer! Explore exclusive deals & savings", playwright.LocatorGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).WaitFor())
 
-	classAttr, err := dialog.GetAttribute("class")
-	require.NoError(t, err)
-	require.Contains(t, classAttr, "absolute bottom-4")
-	require.False(t, strings.Contains(classAttr, "fixed bottom-4"), "demo cookie banner should not be viewport fixed")
+		require.NoError(t, simple.Locator("button[aria-label='dismiss banner']").Click())
+		require.NoError(t, bannerEl.WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateHidden,
+		}))
 
-	stageBox, err := stage.BoundingBox()
-	require.NoError(t, err)
-	dialogBox, err := dialog.BoundingBox()
-	require.NoError(t, err)
+		require.NoError(t, page.Locator("#banner-persistent [role='banner']").WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateVisible,
+		}))
+	})
 
-	require.GreaterOrEqual(t, dialogBox.X, stageBox.X)
-	require.GreaterOrEqual(t, dialogBox.Y, stageBox.Y)
-	require.LessOrEqual(t, dialogBox.X+dialogBox.Width, stageBox.X+stageBox.Width)
-	require.LessOrEqual(t, dialogBox.Y+dialogBox.Height, stageBox.Y+stageBox.Height)
+	t.Run("persistent and CTA banners expose expected controls", func(t *testing.T) {
+		persistent := page.Locator("#banner-persistent")
+		require.NoError(t, persistent.GetByText("This banner cannot be dismissed by users", playwright.LocatorGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).WaitFor())
+
+		dismissCount, err := persistent.Locator("button[aria-label='dismiss banner']").Count()
+		require.NoError(t, err)
+		assert.Zero(t, dismissCount)
+
+		cta := page.Locator("#banner-cta")
+		require.NoError(t, cta.GetByText("Get Fit Anywhere, Anytime 💪", playwright.LocatorGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).WaitFor())
+		require.NoError(t, cta.Locator("button").Filter(playwright.LocatorFilterOptions{HasText: "Start free trial"}).WaitFor())
+	})
+
+	t.Run("semantic variants render user-facing copy", func(t *testing.T) {
+		variants := page.Locator("#banner-variants")
+		for _, text := range []string{
+			"Default variant banner",
+			"Primary variant for promotions",
+			"Info variant for general information",
+			"Success! Operation completed successfully",
+			"Warning: Please review your settings",
+			"Error: Something went wrong",
+		} {
+			require.NoError(t, variants.GetByText(text, playwright.LocatorGetByTextOptions{
+				Exact: playwright.Bool(true),
+			}).WaitFor())
+		}
+	})
+
+	t.Run("cookie banner actions remain scoped to the preview", func(t *testing.T) {
+		stage := page.Locator("#banner-cookie > div").First()
+		dialog := page.Locator("#banner-cookie [role='dialog']").First()
+		require.NoError(t, stage.WaitFor())
+		require.NoError(t, dialog.WaitFor())
+		require.NoError(t, dialog.Locator("h3").Filter(playwright.LocatorFilterOptions{HasText: "Cookie Time!"}).WaitFor())
+		require.NoError(t, dialog.GetByText("We use cookies to make your experience sweet and crispy. For more information, please read our Privacy Policy.", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+		classAttr, err := dialog.GetAttribute("class")
+		require.NoError(t, err)
+		require.Contains(t, classAttr, "absolute bottom-4")
+		require.False(t, strings.Contains(classAttr, "fixed bottom-4"), "demo cookie banner should not be viewport fixed")
+
+		stageBox, err := stage.BoundingBox()
+		require.NoError(t, err)
+		dialogBox, err := dialog.BoundingBox()
+		require.NoError(t, err)
+
+		require.GreaterOrEqual(t, dialogBox.X, stageBox.X)
+		require.GreaterOrEqual(t, dialogBox.Y, stageBox.Y)
+		require.LessOrEqual(t, dialogBox.X+dialogBox.Width, stageBox.X+stageBox.Width)
+		require.LessOrEqual(t, dialogBox.Y+dialogBox.Height, stageBox.Y+stageBox.Height)
+
+		require.NoError(t, dialog.Locator("button").Filter(playwright.LocatorFilterOptions{HasText: "No, thank you"}).Click())
+		require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateHidden,
+		}))
+
+		visibleBanners, err := page.Locator("#banner-variants [role='banner']:visible").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 6, visibleBanners)
+	})
 }

--- a/site/tests/e2e/chatbubble_test.go
+++ b/site/tests/e2e/chatbubble_test.go
@@ -4,33 +4,88 @@ import (
 	"testing"
 
 	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestChatBubble_DemoPage loads /components/chatbubble and asserts the docs
-// fragment renders, both a Sent (data-mine='true') and a received
-// (data-mine='false') bubble exist, and the sidebar link is present.
-func TestChatBubble_DemoPage(t *testing.T) {
+func TestChatBubbleComponentDemoVariants(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
 	page := newIsolatedPage(t)
 
-	_, err := page.Goto(baseURL + "/components/chatbubble")
+	_, err := page.Goto(baseURL+"/components/chatbubble", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
 	require.NoError(t, err)
 
-	// The docs fragment anchor proves a 200-equivalent demo page (not a 404 shell).
 	require.NoError(t, page.Locator("#chatbubble-fragment").First().WaitFor(
 		playwright.LocatorWaitForOptions{Timeout: playwright.Float(5000)}))
 
-	// At least one Sent demo bubble (static data-mine='true').
-	mineCount, err := page.Locator("#chatbubble-fragment [data-mine='true']").Count()
-	require.NoError(t, err)
-	require.Positive(t, mineCount, "demo page should have at least one Sent (data-mine='true') bubble")
+	t.Run("default preview renders sent and received alignment hooks", func(t *testing.T) {
+		defaultPreview := page.Locator("#chatbubble-default")
+		require.NoError(t, defaultPreview.GetByText("Hi there! How can I assist you today?", playwright.LocatorGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).WaitFor())
+		require.NoError(t, defaultPreview.GetByText("I accidentally deleted some important files. Can they be recovered?", playwright.LocatorGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).WaitFor())
 
-	// At least one received bubble (data-mine='false').
-	recvCount, err := page.Locator("#chatbubble-fragment [data-mine='false']").Count()
-	require.NoError(t, err)
-	require.Positive(t, recvCount, "demo page should have at least one received (data-mine='false') bubble")
+		receivedCount, err := defaultPreview.Locator("[data-mine='false']").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 2, receivedCount)
 
-	// Sidebar link is present.
-	require.NoError(t, page.Locator("a[href='/components/chatbubble']").First().WaitFor(
-		playwright.LocatorWaitForOptions{Timeout: playwright.Float(5000)}))
+		sentCount, err := defaultPreview.Locator("[data-mine='true']").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 1, sentCount)
+	})
+
+	t.Run("timestamp and status previews expose message metadata", func(t *testing.T) {
+		timestamp := page.Locator("#chatbubble-timestamp")
+		require.NoError(t, timestamp.GetByText("Ada", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+		require.NoError(t, timestamp.GetByText("11:32 AM", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+		sentHeaderVisible, err := timestamp.GetByText("11:33 AM", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).IsVisible()
+		require.NoError(t, err)
+		assert.False(t, sentHeaderVisible, "sent bubble headers are intentionally suppressed")
+
+		status := page.Locator("#chatbubble-status")
+		require.NoError(t, status.GetByText("Grace", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+		require.NoError(t, status.GetByText("Delivered", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+		require.NoError(t, status.GetByText("Seen", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+	})
+
+	t.Run("avatar and grouped previews keep avatars scoped to visible senders", func(t *testing.T) {
+		avatar := page.Locator("#chatbubble-avatar")
+		require.NoError(t, avatar.GetByText("AL", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+		require.NoError(t, avatar.GetByText("ME", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+		grouped := page.Locator("#chatbubble-grouped")
+		for _, message := range []string{
+			"I split the work into three slices.",
+			"Taking the first one myself.",
+			"Can you grab the second?",
+		} {
+			require.NoError(t, grouped.GetByText(message, playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+		}
+
+		adaCount, err := grouped.GetByText("Ada", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).Count()
+		require.NoError(t, err)
+		assert.Equal(t, 1, adaCount)
+
+		initialsCount, err := grouped.GetByText("AL", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).Count()
+		require.NoError(t, err)
+		assert.Equal(t, 1, initialsCount)
+	})
+
+	t.Run("typing indicator exposes live region and animated dots", func(t *testing.T) {
+		typing := page.Locator("#chatbubble-typing [aria-label='typing']")
+		require.NoError(t, typing.WaitFor())
+		assert.Equal(t, "polite", mustAttribute(t, typing, "aria-live"))
+
+		dotCount, err := typing.Locator("span.animate-bounce").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 3, dotCount)
+	})
 }

--- a/site/tests/e2e/kbd_test.go
+++ b/site/tests/e2e/kbd_test.go
@@ -8,44 +8,72 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestKbd_PageLoads(t *testing.T) {
+func TestKbdComponentDemoVariants(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping E2E test in short mode")
 	}
 
-	cleanupServer := setupServer(t)
-	defer cleanupServer()
-
-	_, browser, cleanupPW := setupPlaywright(t)
-	defer cleanupPW()
-
+	_, browser, _ := setupPlaywright(t)
 	page := newPage(t, browser)
-
 	_, err := page.Goto(baseURL+"/components/kbd", playwright.PageGotoOptions{
 		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
 	})
 	require.NoError(t, err)
-
-	title, err := page.Title()
-	require.NoError(t, err)
-	assert.Contains(t, title, "KBD")
 
 	require.NoError(t, page.Locator("#kbd-fragment").WaitFor(playwright.LocatorWaitForOptions{
 		State:   playwright.WaitForSelectorStateVisible,
 		Timeout: playwright.Float(3000),
 	}))
 
-	keys, err := page.Locator("#kbd-frequently-used kbd").Count()
-	require.NoError(t, err)
-	assert.GreaterOrEqual(t, keys, 16)
+	t.Run("frequently used and inline keys render semantic kbd elements", func(t *testing.T) {
+		frequentlyUsed := page.Locator("#kbd-frequently-used")
+		for _, key := range []string{"Tab", "Shift", "Space", "Ctrl", "Command", "Alt", "Enter", "Esc", "Caps Lock"} {
+			require.NoError(t, frequentlyUsed.GetByText(key, playwright.LocatorGetByTextOptions{
+				Exact: playwright.Bool(true),
+			}).WaitFor())
+		}
 
-	icons, err := page.Locator("#kbd-icons kbd[aria-label]").Count()
-	require.NoError(t, err)
-	assert.GreaterOrEqual(t, icons, 9)
+		inline := page.Locator("#kbd-inline")
+		require.NoError(t, inline.Locator("kbd").Filter(playwright.LocatorFilterOptions{HasText: "Tab"}).WaitFor())
+		require.NoError(t, inline.Locator("kbd").Filter(playwright.LocatorFilterOptions{HasText: "Space"}).WaitFor())
+	})
 
-	for _, id := range []string{"#kbd-inline", "#kbd-alphabet", "#kbd-numbers", "#kbd-functions", "#kbd-sizes"} {
-		count, err := page.Locator(id).Count()
+	t.Run("icon keys expose accessible labels and hide glyphs", func(t *testing.T) {
+		for _, label := range []string{"Command", "Shift", "Option", "Control", "Tab", "Up", "Down", "Left", "Right"} {
+			key := page.Locator("#kbd-icons kbd[aria-label='" + label + "']")
+			require.NoError(t, key.WaitFor())
+			require.NoError(t, key.Locator("span[aria-hidden='true'] svg").WaitFor())
+			require.NoError(t, key.Locator(".sr-only").Filter(playwright.LocatorFilterOptions{HasText: label}).WaitFor())
+		}
+	})
+
+	t.Run("alphabet number and function sections render complete key sets", func(t *testing.T) {
+		alphabetCount, err := page.Locator("#kbd-alphabet kbd").Count()
 		require.NoError(t, err)
-		assert.Equal(t, 1, count, "%s should exist once", id)
-	}
+		assert.Equal(t, 26, alphabetCount)
+		alphabet := page.Locator("#kbd-alphabet")
+		require.NoError(t, alphabet.GetByText("A", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+		require.NoError(t, alphabet.GetByText("Z", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+		numberCount, err := page.Locator("#kbd-numbers kbd").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 10, numberCount)
+		require.NoError(t, page.Locator("#kbd-numbers").GetByText("0", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+		functions := page.Locator("#kbd-functions")
+		for _, key := range []string{"F1", "F8", "F12"} {
+			require.NoError(t, functions.GetByText(key, playwright.LocatorGetByTextOptions{
+				Exact: playwright.Bool(true),
+			}).WaitFor())
+		}
+	})
+
+	t.Run("size variants keep distinct sizing hooks", func(t *testing.T) {
+		sizes := []string{"min-h-5", "min-h-6", "min-h-7", "min-h-9"}
+		for _, size := range sizes {
+			count, err := page.Locator("#kbd-sizes kbd." + size).Count()
+			require.NoError(t, err)
+			assert.Equal(t, 1, count, "expected one %s key", size)
+		}
+	})
 }

--- a/site/tests/e2e/link_test.go
+++ b/site/tests/e2e/link_test.go
@@ -13,14 +13,8 @@ func TestLinkComponentDemo(t *testing.T) {
 		t.Skip("skipping E2E test in short mode")
 	}
 
-	cleanupServer := setupServer(t)
-	defer cleanupServer()
-
-	_, browser, cleanupPW := setupPlaywright(t)
-	defer cleanupPW()
-
+	_, browser, _ := setupPlaywright(t)
 	page := newPage(t, browser)
-
 	_, err := page.Goto(baseURL+"/components/link", playwright.PageGotoOptions{
 		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
 	})
@@ -28,25 +22,46 @@ func TestLinkComponentDemo(t *testing.T) {
 
 	require.NoError(t, page.Locator("#link-fragment").WaitFor())
 
-	defaultLink := page.Locator("#link-default a").First()
-	href, err := defaultLink.GetAttribute("href")
-	require.NoError(t, err)
-	assert.Equal(t, "#", href)
+	t.Run("default and inline links expose hrefs and visible text", func(t *testing.T) {
+		defaultLink := page.Locator("#link-default a").First()
+		require.NoError(t, defaultLink.GetByText("Read if bored", playwright.LocatorGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).WaitFor())
+		assert.Equal(t, "#", mustAttribute(t, defaultLink, "href"))
 
-	className, err := defaultLink.GetAttribute("class")
-	require.NoError(t, err)
-	assert.Contains(t, className, "text-primary")
+		className := mustAttribute(t, defaultLink, "class")
+		assert.Contains(t, className, "text-primary")
 
-	iconCount, err := page.Locator("#link-icon a svg[aria-hidden='true']").Count()
-	require.NoError(t, err)
-	assert.Equal(t, 1, iconCount)
+		inline := page.Locator("#link-inline")
+		require.NoError(t, inline.GetByText("Follow us on", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(false)}).WaitFor())
+		require.NoError(t, inline.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: "social media"}).WaitFor())
+		assert.Equal(t, "#", mustAttribute(t, inline.Locator("a").First(), "href"))
+	})
 
-	buttonLink := page.Locator("#link-button a").First()
-	role, err := buttonLink.GetAttribute("role")
-	require.NoError(t, err)
-	assert.Equal(t, "button", role)
+	t.Run("icon link keeps text and decorative icon together", func(t *testing.T) {
+		iconLink := page.Locator("#link-icon a").First()
+		require.NoError(t, iconLink.GetByText("about our company", playwright.LocatorGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).WaitFor())
 
-	buttonClass, err := buttonLink.GetAttribute("class")
-	require.NoError(t, err)
-	assert.Contains(t, buttonClass, "bg-primary")
+		iconCount, err := iconLink.Locator("svg[aria-hidden='true']").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 1, iconCount)
+
+		className := mustAttribute(t, iconLink, "class")
+		assert.Contains(t, className, "inline-flex")
+		assert.Contains(t, className, "gap-1.5")
+	})
+
+	t.Run("button link exposes button role and primary action styling", func(t *testing.T) {
+		buttonLink := page.Locator("#link-button a").First()
+		require.NoError(t, buttonLink.GetByText("I'm a link", playwright.LocatorGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).WaitFor())
+		assert.Equal(t, "button", mustAttribute(t, buttonLink, "role"))
+
+		buttonClass := mustAttribute(t, buttonLink, "class")
+		assert.Contains(t, buttonClass, "bg-primary")
+		assert.Contains(t, buttonClass, "rounded-2xl")
+	})
 }

--- a/site/tests/e2e/spinner_test.go
+++ b/site/tests/e2e/spinner_test.go
@@ -2,100 +2,64 @@ package e2e
 
 import (
 	"testing"
-	"time"
 
 	"github.com/playwright-community/playwright-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestSpinner_PageLoads tests that the spinner demo page loads correctly
-func TestSpinner_PageLoads(t *testing.T) {
+func TestSpinnerComponentDemoVariants(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping E2E test in short mode")
 	}
 
-	cleanupServer := setupServer(t)
-	defer cleanupServer()
-
-	_, browser, cleanupPW := setupPlaywright(t)
-	defer cleanupPW()
-
+	_, browser, _ := setupPlaywright(t)
 	page := newPage(t, browser)
-
 	_, err := page.Goto(baseURL+"/components/spinner", playwright.PageGotoOptions{
 		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
 	})
 	require.NoError(t, err)
 
-	t.Run("Page_Title_Contains_Spinner", func(t *testing.T) {
-		title, err := page.Title()
-		require.NoError(t, err)
-		assert.Contains(t, title, "Spinner", "page title should contain Spinner")
-		t.Log("✓ Page title contains Spinner")
+	require.NoError(t, page.Locator("#spinner-fragment").WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateVisible,
+		Timeout: playwright.Float(3000),
+	}))
+
+	t.Run("default spinner is decorative with stable SVG attributes", func(t *testing.T) {
+		defaultSpinner := page.Locator("#spinner-default svg.motion-safe\\:animate-spin").First()
+		require.NoError(t, defaultSpinner.WaitFor())
+		assert.Equal(t, "true", mustAttribute(t, defaultSpinner, "aria-hidden"))
+		assert.Equal(t, "0 0 24 24", mustAttribute(t, defaultSpinner, "viewBox"))
 	})
 
-	t.Run("Spinner_SVGs_Are_Rendered", func(t *testing.T) {
-		// Wait for Alpine.js
-		time.Sleep(150 * time.Millisecond)
-
-		// Check that spinner SVGs exist on the page
-		spinners := page.Locator("svg.motion-safe\\:animate-spin")
-		count, err := spinners.Count()
-		require.NoError(t, err)
-		assert.Greater(t, count, 0, "should have at least one spinner SVG on the page")
-		t.Logf("✓ Found %d spinner SVGs on the page", count)
-	})
-
-	t.Run("Spinner_Has_Correct_Attributes", func(t *testing.T) {
-		time.Sleep(150 * time.Millisecond)
-
-		// Check first spinner has correct attributes
-		firstSpinner := page.Locator("svg.motion-safe\\:animate-spin").First()
-		ariaHidden, err := firstSpinner.GetAttribute("aria-hidden")
-		require.NoError(t, err)
-		assert.Equal(t, "true", ariaHidden, "spinner should have aria-hidden=true")
-
-		viewBox, err := firstSpinner.GetAttribute("viewBox")
-		require.NoError(t, err)
-		assert.Equal(t, "0 0 24 24", viewBox, "spinner should have correct viewBox")
-
-		t.Log("✓ Spinner has correct SVG attributes")
-	})
-
-	t.Run("Spinner_Color_Variants_Exist", func(t *testing.T) {
-		time.Sleep(150 * time.Millisecond)
-
-		// Check for color variant classes
-		variants := []string{
-			"fill-primary",
-			"fill-secondary",
-			"fill-info",
-			"fill-success",
-			"fill-warning",
-			"fill-danger",
+	t.Run("color variants render one spinner per semantic color", func(t *testing.T) {
+		variants := []struct {
+			name  string
+			class string
+		}{
+			{"primary", "fill-primary"},
+			{"secondary", "fill-secondary"},
+			{"info", "fill-info"},
+			{"success", "fill-success"},
+			{"warning", "fill-warning"},
+			{"danger", "fill-danger"},
 		}
 
 		for _, variant := range variants {
-			locator := page.Locator("svg." + variant)
+			locator := page.Locator("#spinner-variants svg." + variant.class)
 			count, err := locator.Count()
 			require.NoError(t, err)
-			assert.Greater(t, count, 0, "should have spinner with class %s", variant)
+			assert.Equal(t, 1, count, "expected one %s spinner", variant.name)
 		}
-		t.Log("✓ All color variant spinners are present")
 	})
 
-	t.Run("Spinner_Size_Variants_Exist", func(t *testing.T) {
-		time.Sleep(150 * time.Millisecond)
-
-		// Check for size variant classes
+	t.Run("size variants render each documented size", func(t *testing.T) {
 		sizes := []string{"size-4", "size-5", "size-8", "size-12"}
 		for _, size := range sizes {
-			locator := page.Locator("svg." + size + ".motion-safe\\:animate-spin")
+			locator := page.Locator("#spinner-sizes svg." + size + ".motion-safe\\:animate-spin")
 			count, err := locator.Count()
 			require.NoError(t, err)
-			assert.Greater(t, count, 0, "should have spinner with size class %s", size)
+			assert.Equal(t, 1, count, "expected one spinner with %s", size)
 		}
-		t.Log("✓ All size variant spinners are present")
 	})
 }


### PR DESCRIPTION
## Summary
- expands direct component demo E2E coverage for Banner, Chat Bubble, KBD, Link, and Spinner
- keeps the coverage badge focused on component packages rather than demo-site package paths
- updates CI and `just coverage` so site tests can drive component rendering without counting `site/...` coverage

## Test Plan
- [x] `just coverage`
- [x] `git diff --check`
- [x] confirmed `.coverage/coverage.out` and `.coverage/coverage-func.txt` contain no `site/`, `assets/`, `cmd/`, or `internal/` package paths
