### PR TITLE
fix: harden carousel CTA href binding

### DIFF
--- a/components/carousel/carousel_hardening_test.go
+++ b/components/carousel/carousel_hardening_test.go
@@ -26,3 +26,19 @@ func TestSlidesToJSONEscapesControlCharactersInAlpineStrings(t *testing.T) {
 		t.Fatalf("slidesToJSON emitted raw JS line terminator:\n%s", out)
 	}
 }
+
+func TestSlidesToJSONSanitizesExecutableCTAHref(t *testing.T) {
+	out := slidesToJSON([]Slide{{
+		ImgSrc:   "/safe.webp",
+		ImgAlt:   "Safe",
+		CTAHref:  "javascript:alert(1)",
+		CTALabel: "Open",
+	}})
+
+	if strings.Contains(out, "javascript:alert(1)") {
+		t.Fatalf("slidesToJSON emitted executable CTA href:\n%s", out)
+	}
+	if !strings.Contains(out, "ctaUrl:'about:invalid#TemplFailedSanitizationURL'") {
+		t.Fatalf("slidesToJSON missing inert CTA fallback:\n%s", out)
+	}
+}

--- a/components/carousel/types.go
+++ b/components/carousel/types.go
@@ -210,7 +210,7 @@ func slidesToJSON(slides []Slide) string {
 			fmt.Fprintf(&b, ",description:'%s'", jsEscape(s.Description))
 		}
 		if s.CTAHref != "" {
-			fmt.Fprintf(&b, ",ctaUrl:'%s'", jsEscape(s.CTAHref))
+			fmt.Fprintf(&b, ",ctaUrl:'%s'", jsEscape(string(templ.URL(s.CTAHref))))
 		}
 		if s.CTALabel != "" {
 			fmt.Fprintf(&b, ",ctaText:'%s'", jsEscape(s.CTALabel))

--- a/site/tests/e2e/carousel_hardening_test.go
+++ b/site/tests/e2e/carousel_hardening_test.go
@@ -1,0 +1,49 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/araihu/goshtoso/components/carousel"
+	"github.com/araihu/goshtoso/components/head"
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCarouselRejectsExecutableCTAHref(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newPage(t, sharedBrowser)
+	dialogSeen := listenForDialogs(t, page)
+
+	_, err := page.Goto(baseURL, playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateLoad,
+	})
+	require.NoError(t, err)
+
+	html := renderInteractiveDocument(t, head.DependenciesMinimal(), carousel.Carousel(carousel.Config{
+		ID:      "security-carousel",
+		Variant: carousel.WithCTA,
+		Slides: []carousel.Slide{
+			{
+				ImgSrc:      "/assets/images/avatars/avatar-1.webp",
+				ImgAlt:      "Profile",
+				Title:       "Security slide",
+				Description: "CTA should never execute script URLs.",
+				CTAHref:     `javascript:alert('carousel-cta-xss')`,
+				CTALabel:    "Open",
+			},
+		},
+	}))
+	require.NoError(t, page.SetContent(html, playwright.PageSetContentOptions{
+		WaitUntil: playwright.WaitUntilStateLoad,
+	}))
+	_, err = page.WaitForFunction(`() => typeof Alpine !== 'undefined'`, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, page.GetByRole("link", playwright.PageGetByRoleOptions{
+		Name: "Open",
+	}).Click())
+	requireNoDialog(t, dialogSeen, "carousel CTA executed javascript: href")
+}

--- a/site/tests/e2e/form_hardening_test.go
+++ b/site/tests/e2e/form_hardening_test.go
@@ -1,0 +1,95 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/a-h/templ"
+	"github.com/araihu/goshtoso/components/form"
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormNavigationSinksRejectExecutableSchemes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	t.Run("submit action", func(t *testing.T) {
+		page := newPage(t, sharedBrowser)
+		dialogSeen := listenForDialogs(t, page)
+
+		html := renderComponentDocument(t, form.Form(form.Config{
+			Action: "javascript:alert('form-action-xss')",
+			Footer: &form.FooterConfig{
+				SubmitLabel: "Submit",
+			},
+		}))
+		require.NoError(t, page.SetContent(html))
+
+		require.NoError(t, page.GetByRole("button", playwright.PageGetByRoleOptions{
+			Name: "Submit",
+		}).Click())
+		requireNoDialog(t, dialogSeen, "submit executed javascript: form action")
+	})
+
+	t.Run("cancel href", func(t *testing.T) {
+		page := newPage(t, sharedBrowser)
+		dialogSeen := listenForDialogs(t, page)
+
+		html := renderComponentDocument(t, form.Form(form.Config{
+			Footer: &form.FooterConfig{
+				CancelLabel: "Cancel",
+				CancelHref:  "javascript:alert('form-cancel-xss')",
+				SubmitLabel: "Submit",
+			},
+		}))
+		require.NoError(t, page.SetContent(html))
+
+		require.NoError(t, page.GetByRole("link", playwright.PageGetByRoleOptions{
+			Name: "Cancel",
+		}).Click())
+		requireNoDialog(t, dialogSeen, "cancel link executed javascript: href")
+	})
+}
+
+func renderComponentDocument(t *testing.T, c templ.Component) string {
+	t.Helper()
+
+	return "<!doctype html><html><body>" + renderComponentFragment(t, c) + "</body></html>"
+}
+
+func renderComponentFragment(t *testing.T, c templ.Component) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	require.NoError(t, c.Render(context.Background(), &buf))
+
+	return buf.String()
+}
+
+func listenForDialogs(t *testing.T, page playwright.Page) <-chan string {
+	t.Helper()
+
+	dialogSeen := make(chan string, 1)
+	page.On("dialog", func(dialog playwright.Dialog) {
+		select {
+		case dialogSeen <- dialog.Message():
+		default:
+		}
+		require.NoError(t, dialog.Accept())
+	})
+	return dialogSeen
+}
+
+func requireNoDialog(t *testing.T, dialogSeen <-chan string, context string) {
+	t.Helper()
+
+	select {
+	case msg := <-dialogSeen:
+		t.Fatalf("%s: %s", context, msg)
+	case <-time.After(300 * time.Millisecond):
+	}
+}

--- a/site/tests/e2e/table_hardening_test.go
+++ b/site/tests/e2e/table_hardening_test.go
@@ -1,0 +1,75 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/araihu/goshtoso/components/head"
+	"github.com/araihu/goshtoso/components/table"
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableExpandableRowIDEscapesAlpineExpressions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newPage(t, sharedBrowser)
+	dialogSeen := listenForDialogs(t, page)
+
+	_, err := page.Goto(baseURL, playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateLoad,
+	})
+	require.NoError(t, err)
+
+	html := renderInteractiveDocument(t, head.Dependencies(), table.Table(table.Config{
+		ID: "security-table",
+		Columns: []table.Column{
+			{Key: "name", Label: "Name"},
+		},
+		Rows: []table.Row{
+			{
+				ID:         `row-1'];alert("table-row-id-xss");//`,
+				Expandable: true,
+				Detail:     templ.Raw(`<div>Secret details</div>`),
+				Cells: map[string]table.Cell{
+					"name": {Text: "Alice"},
+				},
+			},
+		},
+	}))
+	require.NoError(t, page.SetContent(html, playwright.PageSetContentOptions{
+		WaitUntil: playwright.WaitUntilStateLoad,
+	}))
+	_, err = page.WaitForFunction(`() => typeof Alpine !== 'undefined'`, nil)
+	require.NoError(t, err)
+
+	requireNoDialog(t, dialogSeen, "table row ID executed during Alpine init")
+
+	require.NoError(t, page.Locator("#security-table tbody tr").First().Click())
+	requireNoDialog(t, dialogSeen, "table row ID executed on expandable row click")
+}
+
+func renderInteractiveDocument(t *testing.T, components ...templ.Component) string {
+	t.Helper()
+
+	var rendered []string
+	for _, component := range components {
+		rendered = append(rendered, renderComponentFragment(t, component))
+	}
+
+	var headHTML []string
+	var bodyHTML []string
+	for _, fragment := range rendered {
+		switch {
+		case strings.Contains(fragment, "<link") || strings.Contains(fragment, "<script"):
+			headHTML = append(headHTML, fragment)
+		default:
+			bodyHTML = append(bodyHTML, fragment)
+		}
+	}
+
+	return "<!doctype html><html><head>" + strings.Join(headHTML, "") + "</head><body>" + strings.Join(bodyHTML, "") + "</body></html>"
+}


### PR DESCRIPTION
## Summary
- sanitize carousel CTA hrefs before they enter Alpine state so `x-bind:href` cannot execute script URLs
- add a component hardening test for inert fallback rendering
- add focused E2E security probes for carousel CTA, form navigation sinks, and expandable table row IDs

## Test Plan
- go test ./components/carousel -count=1
- go test ./site/tests/e2e/... -run 'Test(FormNavigationSinksRejectExecutableSchemes|TableExpandableRowIDEscapesAlpineExpressions|CarouselRejectsExecutableCTAHref)' -count=1
