### PR TITLE
test(fileinput): add unit and E2E coverage

### DIFF
--- a/components/fileinput/fileinput_coverage_test.go
+++ b/components/fileinput/fileinput_coverage_test.go
@@ -1,0 +1,212 @@
+package fileinput
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+)
+
+// renderConfig renders FileInput(cfg) to a string for assertions.
+func renderConfig(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := FileInput(cfg).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("render fileinput: %v", err)
+	}
+	return buf.String()
+}
+
+func TestCoverageRenderDefaultFileinput(t *testing.T) {
+	html := renderConfig(t, Config{})
+	for _, want := range []string{
+		"class=",
+		`data-fileinput-variant="dropzone"`,
+		`type="file"`,
+		"border-dashed",
+		"Browse",
+		"or drag and drop here",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("default render missing %q in %s", want, html)
+		}
+	}
+	// A bare default config should not emit accept/required/disabled/aria-describedby.
+	for _, notWant := range []string{"accept=", "required", "disabled", "aria-describedby"} {
+		if strings.Contains(html, notWant) {
+			t.Fatalf("default render unexpectedly contains %q in %s", notWant, html)
+		}
+	}
+}
+
+func TestCoverageDropZoneAllBranches(t *testing.T) {
+	html := renderConfig(t, Config{
+		ID:         "cover",
+		Name:       "cover",
+		Label:      "Cover Picture",
+		Accept:     "image/*",
+		HelperText: "PNG, JPG - Max 5MB",
+		Required:   true,
+		InputAttrs: templ.Attributes{"hx-post": "/upload"},
+	})
+
+	for _, want := range []string{
+		"<span", "Cover Picture", // Label branch
+		`accept="image/*"`,       // Accept branch
+		"required",               // Required branch
+		`aria-describedby="cover-helper"`, // HelperText -> describedby branch
+		`id="cover-helper"`,               // helper small branch
+		"PNG, JPG - Max 5MB",
+		`hx-post="/upload"`, // InputAttrs spread
+		`for="cover"`,
+		`id="cover"`,
+		`name="cover"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("dropzone render missing %q in %s", want, html)
+		}
+	}
+	if strings.Contains(html, "disabled") {
+		t.Fatalf("non-disabled dropzone should not contain disabled attr: %s", html)
+	}
+}
+
+func TestCoverageDropZoneDisabled(t *testing.T) {
+	html := renderConfig(t, Config{ID: "x", Disabled: true})
+	for _, want := range []string{"disabled", "opacity-50", "cursor-not-allowed"} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("disabled dropzone missing %q in %s", want, html)
+		}
+	}
+}
+
+func TestCoverageUploadVariantAllBranches(t *testing.T) {
+	html := renderConfig(t, Config{
+		Variant:    VariantUpload,
+		ID:         "resume",
+		Name:       "resume",
+		Label:      "Resume",
+		Accept:     ".pdf,.docx",
+		HelperText: "PDF or DOCX",
+		Required:   true,
+		InputAttrs: templ.Attributes{"data-test": "upload"},
+	})
+
+	for _, want := range []string{
+		`data-fileinput-variant="upload"`,
+		"No file selected",
+		"rounded-radius",
+		"bg-surface-alt",
+		"Resume",
+		`accept=".pdf,.docx"`,
+		"required",
+		`aria-describedby="resume-helper"`,
+		`id="resume-helper"`,
+		"PDF or DOCX",
+		`data-test="upload"`,
+		`for="resume"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("upload render missing %q in %s", want, html)
+		}
+	}
+	// Upload variant must not render the drop zone.
+	if strings.Contains(html, "border-dashed") {
+		t.Fatalf("upload variant should not render drop zone: %s", html)
+	}
+}
+
+func TestCoverageUploadDisabled(t *testing.T) {
+	html := renderConfig(t, Config{Variant: VariantUpload, ID: "u", Disabled: true})
+	for _, want := range []string{"disabled", "cursor-not-allowed", "opacity-75"} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("disabled upload missing %q in %s", want, html)
+		}
+	}
+}
+
+func TestCoverageNoLabelNoHelper(t *testing.T) {
+	// Drop zone without label/helper exercises the false branches.
+	html := renderConfig(t, Config{ID: "bare"})
+	if strings.Contains(html, "<span class=") && strings.Contains(html, "pl-0.5 text-sm") {
+		t.Fatalf("bare dropzone should not render label span: %s", html)
+	}
+	if strings.Contains(html, "aria-describedby") {
+		t.Fatalf("bare dropzone should not set aria-describedby: %s", html)
+	}
+
+	// Upload variant without label/helper.
+	up := renderConfig(t, Config{Variant: VariantUpload, ID: "bareup"})
+	if strings.Contains(up, "aria-describedby") {
+		t.Fatalf("bare upload should not set aria-describedby: %s", up)
+	}
+}
+
+func TestCoverageIsUpload(t *testing.T) {
+	if (Config{}).IsUpload() {
+		t.Fatal("default config should not be upload")
+	}
+	if !(Config{Variant: VariantUpload}).IsUpload() {
+		t.Fatal("upload variant should report IsUpload")
+	}
+}
+
+func TestCoverageContainerClasses(t *testing.T) {
+	base := Config{}.ContainerClasses()
+	if !strings.Contains(base, "flex w-full") {
+		t.Fatalf("unexpected container base: %q", base)
+	}
+	withRoot := Config{RootClass: "mt-4"}.ContainerClasses()
+	if !strings.HasSuffix(withRoot, " mt-4") {
+		t.Fatalf("RootClass not appended to container: %q", withRoot)
+	}
+}
+
+func TestCoverageUploadContainerClasses(t *testing.T) {
+	base := Config{}.UploadContainerClasses()
+	if !strings.Contains(base, "text-left") {
+		t.Fatalf("unexpected upload container base: %q", base)
+	}
+	withRoot := Config{RootClass: "gap-3"}.UploadContainerClasses()
+	if !strings.HasSuffix(withRoot, " gap-3") {
+		t.Fatalf("RootClass not appended to upload container: %q", withRoot)
+	}
+}
+
+func TestCoverageClassHelpers(t *testing.T) {
+	cfg := Config{}
+	checks := map[string]string{
+		"LabelClasses":          cfg.LabelClasses(),
+		"BrowseLabelClasses":    cfg.BrowseLabelClasses(),
+		"UploadFileNameClasses": cfg.UploadFileNameClasses(),
+		"HelperTextClasses":     cfg.HelperTextClasses(),
+	}
+	for name, got := range checks {
+		if strings.TrimSpace(got) == "" {
+			t.Fatalf("%s returned empty", name)
+		}
+	}
+
+	if !strings.Contains(cfg.DropZoneClasses(), "border-dashed") {
+		t.Fatal("enabled DropZoneClasses missing border-dashed")
+	}
+	if !strings.Contains((Config{Disabled: true}).DropZoneClasses(), "opacity-50") {
+		t.Fatal("disabled DropZoneClasses missing opacity-50")
+	}
+
+	if !strings.Contains(cfg.UploadControlClasses(), "cursor-pointer") {
+		t.Fatal("enabled UploadControlClasses missing cursor-pointer")
+	}
+	if !strings.Contains((Config{Disabled: true}).UploadControlClasses(), "cursor-not-allowed") {
+		t.Fatal("disabled UploadControlClasses missing cursor-not-allowed")
+	}
+
+	if strings.Contains(cfg.UploadButtonClasses(), "cursor-not-allowed") {
+		t.Fatal("enabled UploadButtonClasses should not be cursor-not-allowed")
+	}
+	if !strings.Contains((Config{Disabled: true}).UploadButtonClasses(), "cursor-not-allowed") {
+		t.Fatal("disabled UploadButtonClasses missing cursor-not-allowed")
+	}
+}

--- a/site/tests/e2e/fileinput_coverage_test.go
+++ b/site/tests/e2e/fileinput_coverage_test.go
@@ -1,0 +1,89 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFileinputCoverageDemo exercises the file-input demo page beyond the
+// variant snapshots in fileinput_test.go: it drives the drop zone's Alpine
+// drag state machine (dragenter/dragleave toggling the highlight border) and
+// asserts the page renders without JS console or page errors.
+func TestFileinputCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newPage(t, sharedBrowser)
+
+	var jsErrors []string
+	page.On("pageerror", func(err error) { jsErrors = append(jsErrors, err.Error()) })
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			jsErrors = append(jsErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/fileinput", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("main").First().WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+
+	mainText, err := page.Locator("main").First().TextContent()
+	require.NoError(t, err)
+	require.Contains(t, mainText, "File Input")
+
+	_, err = page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+	require.NoError(t, err)
+
+	// All five demo variants should render their drop zone / upload markers.
+	dropZones := page.Locator("[data-fileinput-variant='dropzone']")
+	dzCount, err := dropZones.Count()
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, dzCount, 4, "default, required, disabled, nolabel drop zones")
+
+	uploads := page.Locator("[data-fileinput-variant='upload']")
+	upCount, err := uploads.Count()
+	require.NoError(t, err)
+	require.Equal(t, 1, upCount)
+
+	// Drive the drop zone's Alpine drag state: dragenter highlights the border,
+	// dragleave clears it. This exercises the @dragenter/@dragleave handlers.
+	zone := page.Locator("#fileinput-default [data-fileinput-variant='dropzone']")
+	require.NoError(t, zone.ScrollIntoViewIfNeeded())
+
+	require.NoError(t, zone.DispatchEvent("dragenter", nil))
+	_, err = page.WaitForFunction(
+		"() => document.querySelector('#fileinput-default [data-fileinput-variant=\"dropzone\"]').className.includes('border-primary')",
+		nil,
+		playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)},
+	)
+	require.NoError(t, err, "dragenter should toggle the primary highlight border")
+
+	require.NoError(t, zone.DispatchEvent("dragleave", nil))
+	_, err = page.WaitForFunction(
+		"() => document.querySelector('#fileinput-default [data-fileinput-variant=\"dropzone\"]').className.includes('border-outline')",
+		nil,
+		playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)},
+	)
+	require.NoError(t, err, "dragleave should restore the default border")
+
+	// Selecting a file on the drop zone input keeps the page error-free and the
+	// hidden input retains the file (drop zone has no x-text display).
+	require.NoError(t, page.Locator("#demoCoverPicture").SetInputFiles(playwright.InputFile{
+		Name:     "cover.png",
+		MimeType: "image/png",
+		Buffer:   []byte("\x89PNG\r\n"),
+	}))
+	fileCount, err := page.Locator("#demoCoverPicture").Evaluate("el => el.files.length", nil)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, fileCount)
+
+	require.Empty(t, jsErrors, "no JS console/page errors on file input demo: %v", jsErrors)
+}


### PR DESCRIPTION
Raises `components/fileinput` Go coverage from **0.0% → ~72%** by adding behavior-focused unit and E2E tests. No production code changed — no bugs surfaced.

## What's covered
- **Unit** (`components/fileinput/fileinput_coverage_test.go`): renders both drop-zone and upload variants across every config branch (label / accept / required / disabled / helper text / `InputAttrs` spread) and asserts all class helpers. All hand-written `types.go` helpers reach **100%**; the residual ~28% is templ's generated, unreachable `if err != nil` boilerplate in the render functions.
- **E2E** (`site/tests/e2e/fileinput_coverage_test.go`): drives the drop zone's Alpine drag state machine (`dragenter`/`dragleave` toggling the highlight border) — untested by the existing `fileinput_test.go` — and asserts no JS console/page errors.

## Notes
- `badges/coverage.svg` was regenerated locally by `just coverage` but **intentionally excluded** from this commit: this is one of several parallel coverage PRs and committing the badge guarantees cross-PR merge conflicts that would block auto-merge. It regenerates on the next full coverage run.

---

Harness: Claude Code (Opus 4.8)
Taken: 004-fileinput.md
Coverage focus: components/fileinput
Verification: go test ./components/fileinput -count=1; go test ./site/tests/e2e/... -run TestFileinputCoverageDemo; just coverage (full suite green, total 34.7%)
Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)