### PR TITLE
test(spinner): add unit and E2E coverage

### DIFF
--- a/components/spinner/spinner_coverage_test.go
+++ b/components/spinner/spinner_coverage_test.go
@@ -1,0 +1,118 @@
+package spinner
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func renderSpinner(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := Spinner(cfg).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("render spinner %+v: %v", cfg, err)
+	}
+	return buf.String()
+}
+
+func TestCoverageRenderDefaultSpinner(t *testing.T) {
+	html := renderSpinner(t, Config{})
+
+	for _, want := range []string{
+		`class=`,
+		`aria-hidden="true"`,
+		`viewBox="0 0 24 24"`,
+		`motion-safe:animate-spin`,
+		"size-5",          // default size
+		"fill-on-surface", // default variant fill
+		"dark:fill-on-surface-dark",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("default render missing %q in %s", want, html)
+		}
+	}
+}
+
+func TestCoverageSizeClasses(t *testing.T) {
+	cases := []struct {
+		size Size
+		want string
+	}{
+		{SizeSM, "size-4"},
+		{SizeMD, "size-5"},
+		{SizeLG, "size-8"},
+		{SizeXL, "size-12"},
+		{Size("bogus"), "size-5"}, // unknown falls back to default
+		{"", "size-5"},            // zero value falls back to default
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.size), func(t *testing.T) {
+			if got := (Config{Size: tc.size}).SizeClasses(); got != tc.want {
+				t.Fatalf("SizeClasses(%q) = %q, want %q", tc.size, got, tc.want)
+			}
+			if html := renderSpinner(t, Config{Size: tc.size}); !strings.Contains(html, tc.want) {
+				t.Fatalf("render size %q missing class %q in %s", tc.size, tc.want, html)
+			}
+		})
+	}
+}
+
+func TestCoverageFillClasses(t *testing.T) {
+	cases := []struct {
+		variant Variant
+		want    string
+	}{
+		{Default, "fill-on-surface dark:fill-on-surface-dark"},
+		{Primary, "fill-primary dark:fill-primary-dark"},
+		{Secondary, "fill-secondary dark:fill-secondary-dark"},
+		{Info, "fill-info dark:fill-info"},
+		{Success, "fill-success dark:fill-success"},
+		{Warning, "fill-warning dark:fill-warning"},
+		{Danger, "fill-danger dark:fill-danger"},
+		{Variant("bogus"), "fill-on-surface dark:fill-on-surface-dark"}, // unknown falls back
+		{"", "fill-on-surface dark:fill-on-surface-dark"},               // zero value falls back
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.variant), func(t *testing.T) {
+			if got := (Config{Variant: tc.variant}).FillClasses(); got != tc.want {
+				t.Fatalf("FillClasses(%q) = %q, want %q", tc.variant, got, tc.want)
+			}
+			if html := renderSpinner(t, Config{Variant: tc.variant}); !strings.Contains(html, tc.want) {
+				t.Fatalf("render variant %q missing fill %q in %s", tc.variant, tc.want, html)
+			}
+		})
+	}
+}
+
+func TestCoverageRootClassAppended(t *testing.T) {
+	html := renderSpinner(t, Config{RootClass: "custom-extra-class"})
+	if !strings.Contains(html, "custom-extra-class") {
+		t.Fatalf("expected RootClass appended, got %s", html)
+	}
+	// RootClass should sit alongside size, fill, and animation classes.
+	for _, want := range []string{"size-5", "fill-on-surface", "motion-safe:animate-spin", "custom-extra-class"} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("render with RootClass missing %q in %s", want, html)
+		}
+	}
+}
+
+func TestCoverageRootClassEmptyNotAppended(t *testing.T) {
+	html := renderSpinner(t, Config{})
+	// An empty RootClass must not introduce a trailing space artifact in the class list.
+	if strings.Contains(html, "animate-spin  ") || strings.Contains(html, `class=" `) {
+		t.Fatalf("empty RootClass should not add stray spaces: %s", html)
+	}
+}
+
+func TestCoverageVariantAndSizeCombined(t *testing.T) {
+	html := renderSpinner(t, Config{Variant: Danger, Size: SizeXL, RootClass: "mx-auto"})
+	for _, want := range []string{"size-12", "fill-danger", "dark:fill-danger", "motion-safe:animate-spin", "mx-auto"} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("combined render missing %q in %s", want, html)
+		}
+	}
+}

--- a/site/tests/e2e/spinner_coverage_test.go
+++ b/site/tests/e2e/spinner_coverage_test.go
@@ -1,0 +1,58 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSpinnerCoverageDemo loads the spinner demo and asserts the page renders
+// every documented variant/size without any silent Alpine or console failure.
+// It complements TestSpinnerComponentDemoVariants by adding the console-error
+// guard that exercises the demo render path end to end.
+func TestSpinnerCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	var jsErrors []string
+	page.On("pageerror", func(err error) { jsErrors = append(jsErrors, err.Error()) })
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			jsErrors = append(jsErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/spinner", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("#spinner-fragment").WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateVisible,
+		Timeout: playwright.Float(3000),
+	}))
+
+	mainText, err := page.Locator("main").TextContent()
+	require.NoError(t, err)
+	require.Contains(t, mainText, "Spinner")
+
+	t.Run("animated svg root is present", func(t *testing.T) {
+		count, err := page.Locator("svg.motion-safe\\:animate-spin").Count()
+		require.NoError(t, err)
+		assert.Greater(t, count, 0, "expected at least one animated spinner svg")
+	})
+
+	t.Run("default spinner uses fallback size and fill classes", func(t *testing.T) {
+		def := page.Locator("#spinner-default svg.size-5.fill-on-surface").First()
+		require.NoError(t, def.WaitFor())
+		assert.Equal(t, "true", mustAttribute(t, def, "aria-hidden"))
+	})
+
+	require.Empty(t, jsErrors, "no JS console/page errors on spinner demo: %v", jsErrors)
+}


### PR DESCRIPTION
Raises component-only coverage for `components/spinner` from **0.0%** by adding behavior-focused tests.

## Changes
- `components/spinner/spinner_coverage_test.go` — renders every `Size` and `Variant` branch (including unknown/zero-value fallbacks), `RootClass` append + empty paths, and a combined config. Takes `SizeClasses` and `FillClasses` to **100%** and the `Spinner` templ to **~81%**.
- `site/tests/e2e/spinner_coverage_test.go` — loads `/components/spinner` with a console/page-error guard (silent-Alpine-failure catch) complementing the existing `TestSpinnerComponentDemoVariants`.
- `badges/coverage.svg` — regenerated by `just coverage`.

No production code changed; no bugs were exposed by the new tests.

---
Harness: Claude Code (Opus 4.8 1M)
Taken: 006-spinner.md
Coverage focus: components/spinner
Verification: go test ./components/spinner -count=1 (85.7%); go test ./site/tests/e2e -run TestSpinnerCoverageDemo; just coverage (spinner SizeClasses/FillClasses 100%, Spinner 80.6%)
Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)