### PR TITLE
test: add tooltip coverage

### DIFF
--- a/badges/coverage.svg
+++ b/badges/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 33.1%">
-  <title>coverage: 33.1%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 43.8%">
+  <title>coverage: 43.8%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -11,13 +11,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="59" height="20" fill="#555"/>
-    <rect x="59" width="47" height="20" fill="#e05d44"/>
+    <rect x="59" width="47" height="20" fill="#dfb317"/>
     <rect width="106" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="30" y="14">coverage</text>
-    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">33.1%</text>
-    <text x="81.5" y="14">33.1%</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">43.8%</text>
+    <text x="81.5" y="14">43.8%</text>
   </g>
 </svg>

--- a/badges/coverage.svg
+++ b/badges/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 43.8%">
-  <title>coverage: 43.8%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 33.1%">
+  <title>coverage: 33.1%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -11,13 +11,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="59" height="20" fill="#555"/>
-    <rect x="59" width="47" height="20" fill="#dfb317"/>
+    <rect x="59" width="47" height="20" fill="#e05d44"/>
     <rect width="106" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="30" y="14">coverage</text>
-    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">43.8%</text>
-    <text x="81.5" y="14">43.8%</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">33.1%</text>
+    <text x="81.5" y="14">33.1%</text>
   </g>
 </svg>

--- a/components/tooltip/tooltip_coverage_test.go
+++ b/components/tooltip/tooltip_coverage_test.go
@@ -1,0 +1,184 @@
+package tooltip
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+)
+
+func TestTooltipCoverageConfigHelpers(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      Config
+		position string
+		rich     bool
+		id       string
+		label    string
+	}{
+		{
+			name:     "defaults",
+			cfg:      Config{},
+			position: "absolute bottom-full mb-2 left-1/2 -translate-x-1/2",
+			id:       "tooltipExample",
+			label:    "Hover Me",
+		},
+		{
+			name: "bottom rich custom labels",
+			cfg: Config{
+				ID:           "help",
+				Description:  "More details",
+				Position:     Bottom,
+				TriggerLabel: "Details",
+			},
+			position: "absolute top-full mt-2 left-1/2 -translate-x-1/2",
+			rich:     true,
+			id:       "help",
+			label:    "Details",
+		},
+		{
+			name:     "left",
+			cfg:      Config{Position: Left},
+			position: "absolute right-full mr-2 top-1/2 -translate-y-1/2",
+			id:       "tooltipExample",
+			label:    "Hover Me",
+		},
+		{
+			name:     "right",
+			cfg:      Config{Position: Right},
+			position: "absolute left-full ml-2 top-1/2 -translate-y-1/2",
+			id:       "tooltipExample",
+			label:    "Hover Me",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.positionClasses(); got != tt.position {
+				t.Fatalf("positionClasses() = %q, want %q", got, tt.position)
+			}
+			if got := tt.cfg.isRich(); got != tt.rich {
+				t.Fatalf("isRich() = %v, want %v", got, tt.rich)
+			}
+			if got := tt.cfg.tooltipID(); got != tt.id {
+				t.Fatalf("tooltipID() = %q, want %q", got, tt.id)
+			}
+			if got := tt.cfg.triggerLabel(); got != tt.label {
+				t.Fatalf("triggerLabel() = %q, want %q", got, tt.label)
+			}
+		})
+	}
+}
+
+func TestTooltipCoverageRenderDefaultRichClickAndCustomTrigger(t *testing.T) {
+	customTrigger := templ.ComponentFunc(func(ctx context.Context, w io.Writer) error {
+		_, err := w.Write([]byte(`<span data-testid="custom-trigger">?</span>`))
+		return err
+	})
+
+	tests := []struct {
+		name string
+		cfg  Config
+		want []string
+	}{
+		{
+			name: "default hover tooltip",
+			cfg: Config{
+				ID:           "plainTip",
+				Label:        "Helpful context",
+				Position:     Top,
+				TriggerLabel: "Hover help",
+			},
+			want: []string{
+				`type="button"`,
+				`aria-describedby="plainTip"`,
+				`id="plainTip"`,
+				`role="tooltip"`,
+				"Hover help",
+				"Helpful context",
+				"peer-hover:opacity-100",
+				"bottom-full mb-2",
+			},
+		},
+		{
+			name: "rich tooltip",
+			cfg: Config{
+				ID:           "richTip",
+				Label:        "Storage",
+				Description:  "Backed up every hour",
+				Position:     Bottom,
+				TriggerLabel: "Show storage help",
+			},
+			want: []string{
+				`aria-describedby="richTip"`,
+				`id="richTip"`,
+				`role="tooltip"`,
+				"Storage",
+				"Backed up every hour",
+				"flex w-64 flex-col",
+				"text-balance",
+				"top-full mt-2",
+			},
+		},
+		{
+			name: "click tooltip",
+			cfg: Config{
+				ID:           "clickTip",
+				Label:        "Click details",
+				Position:     Right,
+				TriggerMode:  Click,
+				TriggerLabel: "Toggle help",
+			},
+			want: []string{
+				`x-data="{ showTooltip: false }"`,
+				`x-on:click="showTooltip = !showTooltip"`,
+				`x-show="showTooltip"`,
+				`x-on:click.outside="showTooltip = false"`,
+				`aria-describedby="clickTip"`,
+				`id="clickTip"`,
+				"left-full ml-2",
+				"Click details",
+			},
+		},
+		{
+			name: "custom trigger",
+			cfg: Config{
+				ID:       "customTip",
+				Label:    "Custom trigger context",
+				Position: Left,
+				Trigger:  customTrigger,
+			},
+			want: []string{
+				`class="peer"`,
+				`aria-describedby="customTip"`,
+				`data-testid="custom-trigger"`,
+				"Custom trigger context",
+				"right-full mr-2",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			html := renderTooltip(t, tt.cfg)
+			for _, want := range tt.want {
+				if !strings.Contains(html, want) {
+					t.Fatalf("Tooltip render missing %q in %s", want, html)
+				}
+			}
+		})
+	}
+}
+
+func renderTooltip(t *testing.T, cfg Config) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := Tooltip(cfg).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("render tooltip: %v", err)
+	}
+	return buf.String()
+}

--- a/site/tests/e2e/tooltip_coverage_test.go
+++ b/site/tests/e2e/tooltip_coverage_test.go
@@ -1,0 +1,113 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTooltipCoverageDemo complements the legacy tooltip E2E tests with a
+// deterministic pass over the documented demo variants, Alpine click state, and
+// console/page-error checks.
+func TestTooltipCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newPage(t, sharedBrowser)
+
+	var jsErrors []string
+	page.On("pageerror", func(err error) { jsErrors = append(jsErrors, err.Error()) })
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			jsErrors = append(jsErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/tooltip", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForTooltipAlpine(page))
+
+	require.NoError(t, page.Locator("#tooltip-fragment").WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+	mainText, err := page.Locator("main").TextContent()
+	require.NoError(t, err)
+	require.Contains(t, mainText, "Tooltip")
+
+	t.Run("hover positions render with ARIA wiring", func(t *testing.T) {
+		positions := map[string]string{
+			"demoTop":    "bottom-full",
+			"demoBottom": "top-full",
+			"demoLeft":   "right-full",
+			"demoRight":  "left-full",
+		}
+		for id, wantClass := range positions {
+			trigger := page.Locator("[aria-describedby='" + id + "']").First()
+			require.NoError(t, trigger.ScrollIntoViewIfNeeded())
+			require.Equal(t, id, tooltipAttribute(t, trigger, "aria-describedby"))
+
+			tip := page.Locator("#" + id)
+			require.Equal(t, "tooltip", tooltipAttribute(t, tip, "role"))
+			require.Contains(t, tooltipAttribute(t, tip, "class"), wantClass)
+		}
+	})
+
+	t.Run("rich tooltip exposes heading and description text", func(t *testing.T) {
+		rich := page.Locator("#richTop")
+		require.NoError(t, rich.ScrollIntoViewIfNeeded())
+		require.Contains(t, tooltipAttribute(t, rich, "class"), "flex w-64 flex-col")
+		require.NoError(t, rich.Locator("span.text-sm.font-medium").WaitFor())
+		require.NoError(t, rich.Locator("p.text-balance").WaitFor())
+
+		text, err := rich.TextContent()
+		require.NoError(t, err)
+		require.Contains(t, text, "Tooltip top")
+		require.Contains(t, text, "A rich tooltip that contains longer text")
+	})
+
+	t.Run("click trigger toggles live Alpine visibility", func(t *testing.T) {
+		trigger := page.Locator("[aria-describedby='clickTop']").First()
+		require.NoError(t, trigger.ScrollIntoViewIfNeeded())
+
+		visible, err := page.Evaluate("() => getComputedStyle(document.querySelector('#clickTop')).display !== 'none'", nil)
+		require.NoError(t, err)
+		require.False(t, visible.(bool), "click tooltip should start hidden")
+
+		require.NoError(t, trigger.Click())
+		_, err = page.WaitForFunction(
+			"() => getComputedStyle(document.querySelector('#clickTop')).display !== 'none'",
+			nil,
+			playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)},
+		)
+		require.NoError(t, err)
+
+		require.NoError(t, page.Locator("main").Click(playwright.LocatorClickOptions{
+			Position: &playwright.Position{X: 10, Y: 10},
+		}))
+		_, err = page.WaitForFunction(
+			"() => getComputedStyle(document.querySelector('#clickTop')).display === 'none'",
+			nil,
+			playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)},
+		)
+		require.NoError(t, err)
+	})
+
+	require.Empty(t, jsErrors, "no JS console/page errors on tooltip demo: %v", jsErrors)
+}
+
+func waitForTooltipAlpine(page playwright.Page) error {
+	_, err := page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+	return err
+}
+
+func tooltipAttribute(t *testing.T, loc playwright.Locator, name string) string {
+	t.Helper()
+
+	value, err := loc.GetAttribute(name)
+	require.NoError(t, err)
+	return value
+}


### PR DESCRIPTION
## Summary
- Add root package coverage for tooltip config helpers and default/rich/click/custom-trigger render paths.
- Add deterministic tooltip demo E2E coverage for ARIA wiring, rich content, Alpine click visibility, and console/page errors.
- Update the generated coverage badge from the required `just coverage` run.

Harness: Codex
Taken: 008-tooltip.md
Coverage focus: components/tooltip
Verification: go test ./components/tooltip -count=1; cd site && go test ./tests/e2e/... -count=1 -timeout 5m -run 'Tooltip'; just coverage
Auto-merge: OK once CI is green
