### PR TITLE
test(navbar): add component coverage

### DIFF
--- a/components/navbar/navbar_coverage_test.go
+++ b/components/navbar/navbar_coverage_test.go
@@ -1,0 +1,110 @@
+package navbar
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCoverageActionPartitioning(t *testing.T) {
+	leftDefault := ActionItem{Content: templ.Raw(`<span data-action="left-default"></span>`)}
+	leftExplicit := ActionItem{Content: templ.Raw(`<span data-action="left-explicit"></span>`), Position: ActionLeft}
+	right := ActionItem{Content: templ.Raw(`<span data-action="right"></span>`), Position: ActionRight}
+
+	cfg := Config{Actions: []ActionItem{leftDefault, leftExplicit, right}}
+
+	leftActions := cfg.LeftActions()
+	assert.Len(t, leftActions, 2)
+	assert.Equal(t, ActionPosition(""), leftActions[0].Position)
+	assert.Equal(t, ActionLeft, leftActions[1].Position)
+
+	rightActions := cfg.RightActions()
+	assert.Len(t, rightActions, 1)
+	assert.Equal(t, ActionRight, rightActions[0].Position)
+}
+
+func TestCoverageNavbarClassHelpers(t *testing.T) {
+	cfg := Config{NavClass: "sticky top-0"}
+	assert.Contains(t, cfg.NavClasses(), "border-b border-outline")
+	assert.Contains(t, cfg.NavClasses(), "sticky top-0")
+
+	activeLink := LinkClasses(true)
+	assert.Contains(t, activeLink, "font-bold")
+	assert.NotContains(t, activeLink, "text-on-surface underline-offset")
+
+	inactiveLink := LinkClasses(false)
+	assert.Contains(t, inactiveLink, "font-medium")
+	assert.Contains(t, inactiveLink, "text-on-surface")
+	assert.NotContains(t, inactiveLink, "font-bold")
+
+	dangerItem := MenuItemClasses(true)
+	assert.Contains(t, dangerItem, "text-danger")
+	assert.Contains(t, dangerItem, "hover:bg-danger/5")
+
+	standardItem := MenuItemClasses(false)
+	assert.Contains(t, standardItem, "text-on-surface")
+	assert.Contains(t, standardItem, "hover:text-on-surface-strong")
+	assert.NotContains(t, standardItem, "text-danger")
+}
+
+func TestCoverageRenderFullNavbarBranches(t *testing.T) {
+	html := renderNavbar(t, Config{
+		Brand:     templ.Raw(`<span>Acme</span>`),
+		BrandHref: "/dashboard",
+		Links: []NavLink{
+			{Label: "Home", Href: "/home", Active: true, LinkAttrs: templ.Attributes{"data-nav": "home"}},
+			{Label: "Docs", Href: "/docs"},
+		},
+		Actions: []ActionItem{
+			{Content: templ.Raw(`<button data-action="left">Left</button>`)},
+			{Content: templ.Raw(`<button data-action="right">Right</button>`), Position: ActionRight},
+		},
+		User: &UserProfile{
+			Name:  "Ada Lovelace",
+			Email: "ada@example.test",
+		},
+		UserMenu: []UserMenuItem{
+			{Label: "Profile", Href: "/profile", Icon: templ.Raw(`<svg data-icon="profile"></svg>`), LinkAttrs: templ.Attributes{"data-menu": "profile"}},
+			{Label: "Sign out", Href: "/logout", Danger: true},
+		},
+		NavAttrs: templ.Attributes{"data-navbar": "coverage"},
+	})
+
+	for _, want := range []string{
+		`href="/dashboard"`,
+		`data-navbar="coverage"`,
+		`data-action="left"`,
+		`data-action="right"`,
+		`data-nav="home"`,
+		`aria-current="page"`,
+		`aria-label="user menu"`,
+		`x-bind:aria-expanded="userDropDownIsOpen"`,
+		`role="menu"`,
+		`data-menu="profile"`,
+		`data-icon="profile"`,
+		`Ada Lovelace`,
+		`ada@example.test`,
+		`Sign out`,
+		`text-danger`,
+		`aria-label="mobile menu"`,
+		`x-show="mobileMenuIsOpen"`,
+	} {
+		assert.Contains(t, html, want)
+	}
+
+	assert.Equal(t, 2, strings.Count(html, `href="/profile"`), "user menu item renders in desktop and mobile menus")
+	assert.Contains(t, html, `class="size-10 rounded-full`)
+	assert.Contains(t, html, `aria-hidden="true"`)
+}
+
+func TestCoverageRenderDefaultsAndSuppressesEmptyOptionalRegions(t *testing.T) {
+	html := renderNavbar(t, Config{
+		Brand: templ.Raw(`<span>Acme</span>`),
+	})
+
+	assert.Contains(t, html, `href="/"`)
+	assert.NotContains(t, html, `aria-label="mobile menu"`)
+	assert.NotContains(t, html, `aria-label="user menu"`)
+}

--- a/site/tests/e2e/navbar_coverage_test.go
+++ b/site/tests/e2e/navbar_coverage_test.go
@@ -1,0 +1,84 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNavbarCoverageDemo(t *testing.T) {
+	page := newPage(t, sharedBrowser, playwright.BrowserNewPageOptions{
+		Viewport: &playwright.Size{Width: 1280, Height: 900},
+	})
+
+	var consoleErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			consoleErrors = append(consoleErrors, m.Text())
+		}
+	})
+	page.On("pageerror", func(err error) {
+		consoleErrors = append(consoleErrors, err.Error())
+	})
+
+	_, err := page.Goto(baseURL+"/components/navbar", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
+		State: playwright.LoadStateNetworkidle,
+	}))
+
+	require.NoError(t, page.Locator("main").Filter(playwright.LocatorFilterOptions{HasText: "Navbar"}).WaitFor())
+	require.NoError(t, page.Locator("#navbar-simple nav[aria-label='main navigation']").WaitFor())
+	require.NoError(t, page.Locator("#navbar-user nav[aria-label='main navigation']").WaitFor())
+	rightSlotCount, err := page.Locator("#navbar-right-slot button[aria-label='Toggle dark mode']").Count()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, rightSlotCount, 1)
+
+	userNav := page.Locator("#navbar-user nav[aria-label='main navigation']")
+	avatarButton := userNav.Locator("button[aria-label='user menu']")
+	require.NoError(t, avatarButton.ScrollIntoViewIfNeeded())
+	require.NoError(t, avatarButton.WaitFor())
+
+	expanded, err := avatarButton.Evaluate("el => el.getAttribute('aria-expanded')", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "false", expanded)
+
+	require.NoError(t, avatarButton.Click())
+	require.NoError(t, userNav.Locator("ul[role='menu']").WaitFor())
+
+	expanded, err = avatarButton.Evaluate("el => el.getAttribute('aria-expanded')", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "true", expanded)
+	require.NoError(t, userNav.Locator("ul[role='menu']").Filter(playwright.LocatorFilterOptions{HasText: "Alice Brown"}).WaitFor())
+
+	signOut := userNav.Locator("a[role='menuitem']").Filter(playwright.LocatorFilterOptions{
+		HasText: "Sign Out",
+	})
+	require.NoError(t, signOut.WaitFor())
+	signOutClass, err := signOut.GetAttribute("class")
+	require.NoError(t, err)
+	assert.Contains(t, signOutClass, "text-danger")
+
+	require.NoError(t, page.SetViewportSize(390, 844))
+	mobileMenuButton := page.Locator("#navbar-simple button[aria-label='mobile menu']")
+	require.NoError(t, mobileMenuButton.ScrollIntoViewIfNeeded())
+	require.NoError(t, mobileMenuButton.WaitFor())
+
+	expanded, err = mobileMenuButton.Evaluate("el => el.getAttribute('aria-expanded')", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "false", expanded)
+
+	require.NoError(t, mobileMenuButton.Click())
+	expanded, err = mobileMenuButton.Evaluate("el => el.getAttribute('aria-expanded')", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "true", expanded)
+	mobileMenu := page.Locator("#navbar-simple ul.fixed").First()
+	require.NoError(t, mobileMenu.Filter(playwright.LocatorFilterOptions{HasText: "Products"}).WaitFor())
+	require.NoError(t, mobileMenu.Filter(playwright.LocatorFilterOptions{HasText: "Login"}).WaitFor())
+
+	assert.Empty(t, consoleErrors, "console errors on navbar demo")
+}


### PR DESCRIPTION
Harness: Codex
Taken: 010-navbar.md
Coverage focus: components/navbar
Verification: go test ./components/navbar -count=1; cd site && go test ./tests/e2e/... -count=1 -timeout 5m -run 'Navbar'; just coverage
Auto-merge: OK once CI is green

## Summary
- Adds focused navbar unit coverage for action partitioning, helper classes, default brand href, avatar dropdown, mobile menu, and user menu rendering.
- Adds E2E coverage for the navbar demo covering live Alpine aria-expanded state, desktop avatar dropdown content, danger menu styling, right-slot rendering, and mobile menu links.
- Updates the generated coverage badge from the clean updated-base `just coverage` run.

## Coverage
- components/navbar overall: 12.2% -> 72.7%.
- Total coverage from `just coverage`: 44.1%.