### PR TITLE
test(textinput): add unit + e2e coverage (23.6% → 67.6%)

### DIFF
--- a/components/textinput/textinput_coverage_test.go
+++ b/components/textinput/textinput_coverage_test.go
@@ -1,0 +1,207 @@
+package textinput
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCoverageRenderDefault exercises the default input branch with the full
+// set of optional attributes so each conditional in defaultInput is rendered.
+func TestCoverageRenderDefault(t *testing.T) {
+	html := renderTextInput(t, Config{
+		ID:           "email",
+		Name:         "email",
+		Label:        "Email",
+		Placeholder:  "you@example.com",
+		Value:        "seed",
+		Type:         TypeEmail,
+		Disabled:     true,
+		Required:     true,
+		Readonly:     true,
+		Autocomplete: "email",
+		Pattern:      "[a-z]+",
+		MaxLength:    32,
+		HelperText:   "Helper",
+		RootClass:    "root-extra",
+		InputAttrs:   templ.Attributes{"data-test": "input"},
+	})
+
+	for _, want := range []string{
+		`type="email"`,
+		`autocomplete="email"`,
+		`pattern="[a-z]+"`,
+		`maxlength="32"`,
+		"disabled",
+		"required",
+		"readonly",
+		`data-test="input"`,
+		"root-extra",
+		"<label",
+		"<small",
+		"Helper",
+	} {
+		assert.Contains(t, html, want, "default input missing %q", want)
+	}
+}
+
+// TestCoverageMaskInput hits the masked <input> branch of defaultInput.
+func TestCoverageMaskInput(t *testing.T) {
+	html := renderTextInput(t, Config{
+		ID:    "phone",
+		Name:  "phone",
+		Type:  TypeTel,
+		Mask:  "(999) 999-9999",
+		Value: "",
+	})
+
+	assert.Contains(t, html, "x-data")
+	assert.Contains(t, html, `x-mask="(999) 999-9999"`)
+	assert.Contains(t, html, `type="tel"`)
+}
+
+// TestCoveragePasswordInput exercises the passwordInput template including the
+// Alpine toggle and the conditional attributes.
+func TestCoveragePasswordInput(t *testing.T) {
+	html := renderTextInput(t, Config{
+		ID:           "password",
+		Name:         "password",
+		Label:        "Password",
+		Type:         TypePassword,
+		Placeholder:  "secret",
+		Disabled:     true,
+		Required:     true,
+		Readonly:     true,
+		Autocomplete: "current-password",
+		Pattern:      ".{8,}",
+		MaxLength:    64,
+		HelperText:   "Min 8 chars",
+		InputAttrs:   templ.Attributes{"data-test": "pw"},
+	})
+
+	for _, want := range []string{
+		`x-data="{ showPassword: false }"`,
+		`x-bind:type="showPassword ? 'text' : 'password'"`,
+		`x-on:click="showPassword = !showPassword"`,
+		`aria-label="Show password"`,
+		`autocomplete="current-password"`,
+		`pattern=".{8,}"`,
+		`maxlength="64"`,
+		"disabled",
+		"required",
+		"readonly",
+		`data-test="pw"`,
+		"Min 8 chars",
+	} {
+		assert.Contains(t, html, want, "password input missing %q", want)
+	}
+}
+
+// TestCoverageSearchInput exercises searchInput including its optional id and
+// the search-specific class helper.
+func TestCoverageSearchInput(t *testing.T) {
+	html := renderTextInput(t, Config{
+		ID:         "q",
+		Name:       "q",
+		Type:       TypeSearch,
+		Disabled:   true,
+		Readonly:   true,
+		Pattern:    "[a-z]+",
+		MaxLength:  10,
+		InputAttrs: templ.Attributes{"hx-get": "/search"},
+	})
+
+	for _, want := range []string{
+		`type="search"`,
+		`aria-label="search"`,
+		`id="q"`,
+		"pl-10",
+		`pattern="[a-z]+"`,
+		`maxlength="10"`,
+		"disabled",
+		"readonly",
+		`hx-get="/search"`,
+	} {
+		assert.Contains(t, html, want, "search input missing %q", want)
+	}
+}
+
+// TestCoverageSearchInputNoID confirms the id attribute is omitted when ID is
+// empty (the false branch of the conditional).
+func TestCoverageSearchInputNoID(t *testing.T) {
+	html := renderTextInput(t, Config{
+		Name: "q",
+		Type: TypeSearch,
+	})
+
+	assert.NotContains(t, html, "id=")
+}
+
+// TestCoverageLabelStateIcons covers the error/success icon branches in
+// inputLabel and the state-specific class helpers.
+func TestCoverageLabelStateIcons(t *testing.T) {
+	errorHTML := renderTextInput(t, Config{
+		ID:         "e",
+		Label:      "Field",
+		State:      StateError,
+		HelperText: "bad",
+	})
+	assert.Contains(t, errorHTML, "text-danger")
+	assert.Contains(t, errorHTML, "border-danger")
+	assert.Contains(t, errorHTML, "M5.28 4.22") // error icon path
+
+	successHTML := renderTextInput(t, Config{
+		ID:         "s",
+		Label:      "Field",
+		State:      StateSuccess,
+		HelperText: "good",
+	})
+	assert.Contains(t, successHTML, "text-success")
+	assert.Contains(t, successHTML, "border-success")
+	assert.Contains(t, successHTML, "M12.416 3.376") // success icon path
+}
+
+// TestCoverageConfigHelpers exercises the pure config helpers directly so each
+// branch is covered without rendering.
+func TestCoverageConfigHelpers(t *testing.T) {
+	assert.Equal(t, TypeText, Config{}.GetType())
+	assert.Equal(t, TypeEmail, Config{Type: TypeEmail}.GetType())
+
+	assert.True(t, Config{Type: TypePassword}.IsPassword())
+	assert.False(t, Config{}.IsPassword())
+	assert.True(t, Config{Type: TypeSearch}.IsSearch())
+	assert.False(t, Config{}.IsSearch())
+
+	assert.True(t, Config{Mask: "x"}.HasMask())
+	assert.False(t, Config{}.HasMask())
+	assert.True(t, Config{Pattern: "x"}.HasPattern())
+	assert.False(t, Config{}.HasPattern())
+	assert.True(t, Config{MaxLength: 1}.HasMaxLength())
+	assert.False(t, Config{}.HasMaxLength())
+	assert.Equal(t, "0", Config{}.MaxLengthStr())
+	assert.Equal(t, "42", Config{MaxLength: 42}.MaxLengthStr())
+
+	// Class helpers: default, error, success branches.
+	for _, st := range []State{StateDefault, StateError, StateSuccess} {
+		cfg := Config{State: st}
+		assert.NotEmpty(t, cfg.InputClasses())
+		assert.NotEmpty(t, cfg.LabelClasses())
+		assert.NotEmpty(t, cfg.HelperTextClasses())
+		assert.NotEmpty(t, searchInputClasses(cfg))
+	}
+
+	// Container with and without RootClass.
+	assert.NotContains(t, Config{}.ContainerClasses(), "extra")
+	assert.Contains(t, Config{RootClass: "extra"}.ContainerClasses(), "extra")
+}
+
+// TestCoverageDefaultNoLabelNoHelper covers the false branches for label and
+// helper text in defaultInput.
+func TestCoverageDefaultNoLabelNoHelper(t *testing.T) {
+	html := renderTextInput(t, Config{Name: "bare"})
+	assert.NotContains(t, html, "<label")
+	assert.NotContains(t, html, "<small")
+	assert.True(t, strings.Contains(html, "<input"))
+}

--- a/site/tests/e2e/textinput_coverage_test.go
+++ b/site/tests/e2e/textinput_coverage_test.go
@@ -1,0 +1,111 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTextinputCoverageDemo exercises the password toggle, search, and mask
+// variants on the text-input demo page to drive the lower-coverage templ
+// branches (passwordInput, searchInput, masked defaultInput) through a real
+// browser, and asserts there are no console errors.
+func TestTextinputCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+
+	var consoleErrors []string
+	page.OnConsole(func(msg playwright.ConsoleMessage) {
+		if msg.Type() == "error" {
+			consoleErrors = append(consoleErrors, msg.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/text-input", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+
+	_, err = page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+	require.NoError(t, err)
+
+	t.Run("PasswordToggle", func(t *testing.T) {
+		container := page.Locator("#textinput-password")
+		require.NoError(t, container.ScrollIntoViewIfNeeded())
+
+		input := container.Locator("input")
+		require.NoError(t, input.WaitFor())
+
+		// Alpine binds the type via x-bind:type; it starts as "password".
+		liveType, err := input.Evaluate("el => el.getAttribute('type')", nil)
+		require.NoError(t, err)
+		require.Equal(t, "password", liveType, "password input should start hidden")
+
+		toggle := container.Locator("button[aria-label='Show password']")
+		require.NoError(t, toggle.Click())
+
+		_, err = page.WaitForFunction(
+			"() => document.querySelector('#textinput-password input').getAttribute('type') === 'text'",
+			nil,
+		)
+		require.NoError(t, err)
+
+		// Toggling back hides it again.
+		require.NoError(t, toggle.Click())
+		_, err = page.WaitForFunction(
+			"() => document.querySelector('#textinput-password input').getAttribute('type') === 'password'",
+			nil,
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("SearchVariantRenders", func(t *testing.T) {
+		container := page.Locator("#textinput-search")
+		require.NoError(t, container.ScrollIntoViewIfNeeded())
+
+		input := container.Locator("input[type='search']")
+		require.NoError(t, input.WaitFor())
+
+		ariaLabel, err := input.GetAttribute("aria-label")
+		require.NoError(t, err)
+		require.Equal(t, "search", ariaLabel)
+
+		class, err := input.GetAttribute("class")
+		require.NoError(t, err)
+		require.Contains(t, class, "pl-10", "search input reserves space for the icon")
+
+		// The leading search icon svg is present.
+		iconCount, err := container.Locator("svg").Count()
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, iconCount, 1)
+	})
+
+	t.Run("MaskVariantAcceptsInput", func(t *testing.T) {
+		container := page.Locator("#textinput-mask")
+		require.NoError(t, container.ScrollIntoViewIfNeeded())
+
+		input := container.Locator("input")
+		require.NoError(t, input.WaitFor())
+
+		hasMask, err := input.Evaluate("el => el.hasAttribute('x-mask')", nil)
+		require.NoError(t, err)
+		require.Equal(t, true, hasMask, "mask variant should expose x-mask")
+
+		require.NoError(t, input.Fill("1234567890"))
+		value, err := input.InputValue()
+		require.NoError(t, err)
+		require.NotEmpty(t, value, "mask input should accept typed characters")
+	})
+
+	require.Empty(t, consoleErrors, "no console errors expected: %v", consoleErrors)
+}


### PR DESCRIPTION
Raises `components/textinput` statement coverage from **23.6% → 67.6%** (527/780).

## What
- **Unit** (`components/textinput/textinput_coverage_test.go`): every `Config` helper now at 100% (`GetType`, `InputClasses`, `LabelClasses`, `HelperTextClasses`, `ContainerClasses`, `IsPassword`/`IsSearch`, `HasMask`/`HasPattern`/`HasMaxLength`, `MaxLengthStr`). Buffer-render tests cover the previously-0% `passwordInput` (70.2%) and `searchInput` (69.8%), the masked `defaultInput` branch (31.5% → 60.7%), and the error/success icon branches of `inputLabel`.
- **E2E** (`site/tests/e2e/textinput_coverage_test.go`): drives the Alpine password show/hide toggle, the search variant, and the `x-mask` variant on `/components/text-input`, asserting no console errors.

No production code changed — no bugs surfaced; tests pass against current rendering.

Built in an isolated worktree off `origin/main` because the shared working dir is being mutated by other concurrent coverage agents.

```
Harness: Claude Code (Opus 4.8 1M)
Taken: 014-textinput.md
Coverage focus: components/textinput
Verification: go test ./components/textinput -count=1 (67.6%); go test ./tests/e2e -run TestTextinputCoverageDemo; just coverage; golangci-lint run (both modules, 0 issues)
Auto-merge: OK once CI is green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)