### PR TITLE
test(modal): add unit + E2E coverage (27.2% → 71.5%)

### DIFF
--- a/components/modal/modal_coverage_test.go
+++ b/components/modal/modal_coverage_test.go
@@ -1,0 +1,285 @@
+package modal
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func render(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := Modal(cfg).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("render Modal: %v", err)
+	}
+	return buf.String()
+}
+
+func mustContain(t *testing.T, html string, wants ...string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(html, want) {
+			t.Fatalf("rendered HTML missing %q:\n%s", want, html)
+		}
+	}
+}
+
+func mustNotContain(t *testing.T, html string, unwanted ...string) {
+	t.Helper()
+	for _, bad := range unwanted {
+		if strings.Contains(html, bad) {
+			t.Fatalf("rendered HTML unexpectedly contains %q:\n%s", bad, html)
+		}
+	}
+}
+
+// TestCoverageDefaultModalStructure covers the default modal render path:
+// trigger, dialog roles, header/body/footer, primary button.
+func TestCoverageDefaultModalStructure(t *testing.T) {
+	html := render(t, Config{
+		ID:           "confirm",
+		Title:        "Confirm action",
+		Body:         "Are you sure?",
+		TriggerLabel: "Open dialog",
+		PrimaryLabel: "Confirm",
+	})
+
+	mustContain(t,
+		html,
+		`role="dialog"`,
+		`aria-modal="true"`,
+		`aria-labelledby="confirmTitle"`,
+		`id="confirmTitle"`,
+		`aria-label="close modal"`,
+		"Confirm action",
+		"Are you sure?",
+		"Open dialog",
+		"Confirm",
+		"confirmIsOpen",
+	)
+	// No alert-only icon badge when not in alert mode.
+	mustNotContain(t, html, "rounded-full")
+}
+
+// TestCoverageSecondaryButtonRendered covers secondaryButton, which is only
+// emitted when SecondaryLabel is set in default mode.
+func TestCoverageSecondaryButtonRendered(t *testing.T) {
+	html := render(t, Config{
+		ID:             "delete",
+		Title:          "Delete item",
+		TriggerLabel:   "Delete",
+		PrimaryLabel:   "Yes",
+		SecondaryLabel: "Cancel",
+	})
+
+	mustContain(t, html, "Cancel", "Yes", "deleteIsOpen = false")
+}
+
+// TestCoveragePrimaryButtonHTMXAndOnClick covers every HTMX branch and the
+// OnClick branch of buttonClickExpr/primaryButton.
+func TestCoveragePrimaryButtonHTMXAndOnClick(t *testing.T) {
+	html := render(t, Config{
+		ID:           "save",
+		Title:        "Save",
+		TriggerLabel: "Open",
+		PrimaryLabel: "Save now",
+		PrimaryAction: &ButtonAction{
+			OnClick: "doSave()",
+			HTMX: &HTMXConfig{
+				Get:    "/api/save",
+				Post:   "/api/save-post",
+				Target: "#result",
+				Swap:   "innerHTML",
+			},
+		},
+	})
+
+	mustContain(t,
+		html,
+		`hx-get="/api/save"`,
+		`hx-post="/api/save-post"`,
+		`hx-target="#result"`,
+		`hx-swap="innerHTML"`,
+		"saveIsOpen = false; doSave()",
+	)
+}
+
+// TestCoverageSecondaryButtonHTMX covers the HTMX branches on secondaryButton.
+func TestCoverageSecondaryButtonHTMX(t *testing.T) {
+	html := render(t, Config{
+		ID:             "form",
+		TriggerLabel:   "Open",
+		PrimaryLabel:   "Submit",
+		SecondaryLabel: "Reset",
+		SecondaryAction: &ButtonAction{
+			OnClick: "resetForm()",
+			HTMX: &HTMXConfig{
+				Get:    "/api/reset",
+				Post:   "/api/reset-post",
+				Target: "#form",
+				Swap:   "outerHTML",
+			},
+		},
+	})
+
+	mustContain(t,
+		html,
+		`hx-get="/api/reset"`,
+		`hx-post="/api/reset-post"`,
+		`hx-target="#form"`,
+		`hx-swap="outerHTML"`,
+		"formIsOpen = false; resetForm()",
+	)
+}
+
+// TestCoverageAlertModalVariants covers alertModal, alertIcon (every case),
+// IconBadgeClasses, AlertCTAClasses, alertTriggerClasses, and alertCTAButton.
+func TestCoverageAlertModalVariants(t *testing.T) {
+	cases := []struct {
+		variant   Variant
+		iconColor string
+		ctaColor  string
+		hasIcon   bool
+	}{
+		{Success, "text-success", "bg-success", true},
+		{Info, "text-info", "bg-info", true},
+		{Warning, "text-warning", "bg-warning", true},
+		{Danger, "text-danger", "bg-danger", true},
+		{Default, "", "bg-primary", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(string(tc.variant), func(t *testing.T) {
+			html := render(t, Config{
+				ID:           "alert",
+				Title:        "Heads up",
+				Body:         "Something happened",
+				TriggerLabel: "Show alert",
+				PrimaryLabel: "Got it",
+				Variant:      tc.variant,
+				AlertMode:    true,
+			})
+
+			// Alert header has an icon badge wrapper.
+			mustContain(t, html, "rounded-full", "Got it", "Heads up")
+			// CTA button carries the variant CTA classes.
+			mustContain(t, html, tc.ctaColor)
+
+			if tc.hasIcon {
+				// Variant-specific SVG icon present (fill-rule path icons).
+				mustContain(t, html, tc.iconColor, "fill-rule")
+			} else {
+				// Default alert variant: no colored icon, no SVG icon path.
+				mustNotContain(t, html, "fill-rule")
+			}
+		})
+	}
+}
+
+// TestCoverageAlertCTAButtonHTMX covers HTMX branches on alertCTAButton.
+func TestCoverageAlertCTAButtonHTMX(t *testing.T) {
+	html := render(t, Config{
+		ID:           "confirm",
+		Title:        "Confirm",
+		TriggerLabel: "Open",
+		PrimaryLabel: "Proceed",
+		AlertMode:    true,
+		Variant:      Danger,
+		PrimaryAction: &ButtonAction{
+			OnClick: "proceed()",
+			HTMX: &HTMXConfig{
+				Get:    "/api/go",
+				Post:   "/api/go-post",
+				Target: "#out",
+				Swap:   "beforeend",
+			},
+		},
+	})
+
+	mustContain(t,
+		html,
+		`hx-get="/api/go"`,
+		`hx-post="/api/go-post"`,
+		`hx-target="#out"`,
+		`hx-swap="beforeend"`,
+		"confirmIsOpen = false; proceed()",
+	)
+}
+
+// TestCoveragePanelClassAppended covers the PanelClass branch of DialogClasses.
+func TestCoveragePanelClassAppended(t *testing.T) {
+	html := render(t, Config{
+		ID:           "wide",
+		TriggerLabel: "Open",
+		PrimaryLabel: "OK",
+		PanelClass:   "max-w-3xl custom-panel",
+	})
+
+	mustContain(t, html, "custom-panel")
+}
+
+// TestCoverageTriggerClassesByMode exercises both branches of TriggerClasses
+// and the variant switch in alertTriggerClasses.
+func TestCoverageTriggerClassesByMode(t *testing.T) {
+	def := Config{}
+	if got := def.TriggerClasses(); !strings.Contains(got, "bg-primary") {
+		t.Fatalf("default TriggerClasses missing bg-primary: %q", got)
+	}
+
+	variants := map[Variant]string{
+		Success: "bg-success",
+		Info:    "bg-info",
+		Warning: "bg-warning",
+		Danger:  "bg-danger",
+		Default: "bg-primary",
+	}
+	for v, want := range variants {
+		cfg := Config{AlertMode: true, Variant: v}
+		if got := cfg.TriggerClasses(); !strings.Contains(got, want) {
+			t.Fatalf("alert TriggerClasses(%s) missing %q: %q", v, want, got)
+		}
+	}
+}
+
+// TestCoverageHeaderClassesByMode exercises both branches of HeaderClasses.
+func TestCoverageHeaderClassesByMode(t *testing.T) {
+	alert := Config{AlertMode: true}.HeaderClasses()
+	def := Config{}.HeaderClasses()
+	if alert == def {
+		t.Fatalf("alert and default header classes should differ")
+	}
+	// Default uses p-4; alert uses px-4 py-2.
+	if !strings.Contains(def, "p-4") {
+		t.Fatalf("default header classes missing p-4: %q", def)
+	}
+	if !strings.Contains(alert, "py-2") {
+		t.Fatalf("alert header classes missing py-2: %q", alert)
+	}
+}
+
+// TestCoverageIconBadgeAndCTAClassesDirect exercises the helper methods across
+// all variants directly, including the default (uncolored) badge branch.
+func TestCoverageIconBadgeAndCTAClassesDirect(t *testing.T) {
+	if got := (Config{Variant: Default}).IconBadgeClasses(); strings.Contains(got, "bg-success") {
+		t.Fatalf("default IconBadgeClasses should not be colored: %q", got)
+	}
+	for v, want := range map[Variant]string{
+		Success: "text-success",
+		Info:    "text-info",
+		Warning: "text-warning",
+		Danger:  "text-danger",
+	} {
+		if got := (Config{Variant: v}).IconBadgeClasses(); !strings.Contains(got, want) {
+			t.Fatalf("IconBadgeClasses(%s) missing %q: %q", v, want, got)
+		}
+		// CTA buttons use the solid bg-<variant> fill, not the text- token.
+		ctaWant := strings.Replace(want, "text-", "bg-", 1)
+		if got := (Config{Variant: v}).AlertCTAClasses(); !strings.Contains(got, ctaWant) {
+			t.Fatalf("AlertCTAClasses(%s) missing %q: %q", v, ctaWant, got)
+		}
+	}
+	if got := (Config{Variant: Default}).AlertCTAClasses(); !strings.Contains(got, "bg-primary") {
+		t.Fatalf("default AlertCTAClasses missing bg-primary: %q", got)
+	}
+}

--- a/site/tests/e2e/modal_coverage_test.go
+++ b/site/tests/e2e/modal_coverage_test.go
@@ -1,0 +1,172 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestModalCoverageDemo exercises the /components/modal demo: default open/close
+// (button, ESC), the four alert variants, the HTMX confirm action, and the
+// JavaScript OnClick action. It mirrors the low-coverage branches in
+// components/modal so the browser path is exercised end to end.
+func TestModalCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+
+	// Collect console errors to assert the demo stays clean across interactions.
+	var consoleErrors []string
+	page.On("console", func(msg playwright.ConsoleMessage) {
+		if msg.Type() == "error" {
+			consoleErrors = append(consoleErrors, msg.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/modal", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("#modal-fragment").WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateAttached,
+	}))
+
+	t.Run("Page_Loads", func(t *testing.T) {
+		title, err := page.Title()
+		require.NoError(t, err)
+		assert.Contains(t, title, "Modal")
+	})
+
+	t.Run("Default_Open_Close_Button", func(t *testing.T) {
+		container := page.Locator("#modal-default")
+		dialog := container.Locator("[role='dialog']")
+
+		// Dialog hidden before opening (x-cloak/x-show false).
+		require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateHidden,
+		}))
+
+		require.NoError(t, container.GetByText("Open Modal").Click())
+		require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateVisible,
+		}))
+
+		ariaModal, err := dialog.GetAttribute("aria-modal")
+		require.NoError(t, err)
+		assert.Equal(t, "true", ariaModal)
+
+		// Close via the header close button.
+		require.NoError(t, dialog.Locator("button[aria-label='close modal']").Click())
+		require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateHidden,
+		}))
+	})
+
+	t.Run("Default_Close_With_Escape", func(t *testing.T) {
+		container := page.Locator("#modal-default")
+		dialog := container.Locator("[role='dialog']")
+
+		require.NoError(t, container.GetByText("Open Modal").Click())
+		require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateVisible,
+		}))
+
+		require.NoError(t, page.Keyboard().Press("Escape"))
+		require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateHidden,
+		}))
+	})
+
+	t.Run("Alert_Variants_Open", func(t *testing.T) {
+		container := page.Locator("#modal-alert")
+		for _, label := range []string{"Success Modal", "Info Modal", "Warning Modal", "Danger Modal"} {
+			// Each alert trigger lives in its own x-data root; open then close it.
+			root := container.Locator("div[x-data]").Filter(playwright.LocatorFilterOptions{
+				HasText: label,
+			}).First()
+			dialog := root.Locator("[role='dialog']")
+
+			require.NoError(t, root.GetByText(label).Click())
+			require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+				State: playwright.WaitForSelectorStateVisible,
+			}), "alert dialog %q should open", label)
+
+			// Alert dialog renders a single full-width CTA button.
+			cta := dialog.Locator("button.w-full")
+			require.NoError(t, cta.WaitFor(playwright.LocatorWaitForOptions{
+				State: playwright.WaitForSelectorStateVisible,
+			}), "alert %q should render full-width CTA", label)
+
+			require.NoError(t, dialog.Locator("button[aria-label='close modal']").Click())
+			require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+				State: playwright.WaitForSelectorStateHidden,
+			}))
+		}
+	})
+
+	t.Run("HTMX_Action_Swaps_Result", func(t *testing.T) {
+		container := page.Locator("#modal-htmx")
+		dialog := container.Locator("[role='dialog']")
+
+		require.NoError(t, container.GetByText("Open HTMX Modal").Click())
+		require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateVisible,
+		}))
+
+		// Confirm fires the POST and closes the modal.
+		require.NoError(t, dialog.GetByRole("button", playwright.LocatorGetByRoleOptions{
+			Name: "Confirm", Exact: playwright.Bool(true),
+		}).Click())
+
+		result := page.Locator("#modal-htmx-result")
+		require.NoError(t, result.GetByText("Hello from HTMX!").WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateVisible,
+		}))
+		text, err := result.TextContent()
+		require.NoError(t, err)
+		assert.Contains(t, text, "POST")
+	})
+
+	t.Run("JS_Action_Fires_Dialog", func(t *testing.T) {
+		container := page.Locator("#modal-js")
+		dialog := container.Locator("[role='dialog']")
+
+		// Auto-accept the alert() raised by the OnClick handler.
+		var dialogMessage string
+		page.Once("dialog", func(d playwright.Dialog) {
+			dialogMessage = d.Message()
+			_ = d.Accept()
+		})
+
+		require.NoError(t, container.GetByRole("button", playwright.LocatorGetByRoleOptions{
+			Name: "Open JS Modal", Exact: playwright.Bool(true),
+		}).Click())
+		require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateVisible,
+		}))
+
+		require.NoError(t, dialog.GetByRole("button", playwright.LocatorGetByRoleOptions{
+			Name: "Delete", Exact: playwright.Bool(true),
+		}).Click())
+		require.NoError(t, dialog.WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateHidden,
+		}))
+		assert.Contains(t, dialogMessage, "deleted")
+	})
+
+	t.Run("No_Console_Errors", func(t *testing.T) {
+		assert.Empty(t, consoleErrors, "demo should not log console errors: %s", strings.Join(consoleErrors, "; "))
+	})
+}


### PR DESCRIPTION
Raises `components/modal` component-only coverage from 27.2% to 71.5% by
covering the alert path and HTMX/JS button branches with focused unit tests,
plus browser behavior via E2E.

Unit (`components/modal/modal_coverage_test.go`): alert modal for every
variant (Success/Info/Warning/Danger/Default), alertIcon, alertCTAButton,
secondaryButton, primaryButton HTMX + OnClick branches, PanelClass, and the
TriggerClasses/HeaderClasses/IconBadgeClasses/AlertCTAClasses helpers.

E2E (`site/tests/e2e/modal_coverage_test.go`): default open/close via button
and ESC, all four alert triggers, HTMX confirm swap into `#modal-htmx-result`,
the JS `OnClick` alert, and an inline console-error assertion.

No production bugs found; tests pass against existing source. badges/coverage.svg
intentionally excluded (regenerated by every parallel PR).

Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 016-modal.md
Coverage focus: components/modal
Verification: go test ./components/modal -count=1; go test ./site/tests/e2e/... -run TestModalCoverageDemo; just coverage (exit 0, total 44.6%)
Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)