### PR TITLE
test: add pagination coverage

### DIFF
--- a/components/pagination/pagination_coverage_test.go
+++ b/components/pagination/pagination_coverage_test.go
@@ -1,0 +1,107 @@
+package pagination
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCoveragePageWindowShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want []PageItem
+	}{
+		{
+			name: "no pages",
+			cfg:  Config{CurrentPage: 1, TotalPages: 0},
+		},
+		{
+			name: "small count shows every page",
+			cfg:  Config{CurrentPage: 3, TotalPages: 5},
+			want: []PageItem{
+				{Page: 1}, {Page: 2}, {Page: 3, IsCurrent: true}, {Page: 4}, {Page: 5},
+			},
+		},
+		{
+			name: "near beginning has trailing ellipsis",
+			cfg:  Config{CurrentPage: 2, TotalPages: 30},
+			want: []PageItem{
+				{Page: 1}, {Page: 2, IsCurrent: true}, {Page: 3}, {Page: 4}, {IsEllipsis: true}, {Page: 30},
+			},
+		},
+		{
+			name: "middle has both ellipses",
+			cfg:  Config{CurrentPage: 15, TotalPages: 30},
+			want: []PageItem{
+				{Page: 1}, {IsEllipsis: true}, {Page: 14}, {Page: 15, IsCurrent: true}, {Page: 16}, {IsEllipsis: true}, {Page: 30},
+			},
+		},
+		{
+			name: "near end has leading ellipsis",
+			cfg:  Config{CurrentPage: 29, TotalPages: 30},
+			want: []PageItem{
+				{Page: 1}, {IsEllipsis: true}, {Page: 27}, {Page: 28}, {Page: 29, IsCurrent: true}, {Page: 30},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cfg.Pages())
+		})
+	}
+}
+
+func TestCoveragePreviousNextAndSwapDefaults(t *testing.T) {
+	first := Config{CurrentPage: 1, TotalPages: 3}
+	assert.Equal(t, 1, first.PreviousPage())
+	assert.Equal(t, 2, first.NextPage())
+
+	last := Config{CurrentPage: 3, TotalPages: 3}
+	assert.Equal(t, 2, last.PreviousPage())
+	assert.Equal(t, 3, last.NextPage())
+
+	assert.Equal(t, "innerHTML", Config{}.SwapStrategy())
+	assert.Equal(t, "outerHTML", Config{HTMX: &HTMXConfig{Swap: "outerHTML"}}.SwapStrategy())
+}
+
+func TestCoverageRenderEllipsisAndHTMXBranches(t *testing.T) {
+	rendered := renderPagination(t, Config{
+		ID:          "paged-items",
+		Variant:     WithEllipsis,
+		CurrentPage: 15,
+		TotalPages:  30,
+		BaseURL:     "/items?filter=active",
+		NavClass:    "justify-center",
+		HTMX:        &HTMXConfig{Target: "#items", Swap: "outerHTML"},
+	})
+
+	assert.Contains(t, rendered, `id="paged-items"`)
+	assert.Contains(t, rendered, `aria-label="pagination"`)
+	assert.Contains(t, rendered, `justify-center`)
+	assert.Contains(t, rendered, `href="/items?filter=active&amp;page=14"`)
+	assert.Contains(t, rendered, `hx-get="/items?filter=active&amp;page=14"`)
+	assert.Contains(t, rendered, `hx-target="#items"`)
+	assert.Contains(t, rendered, `hx-swap="outerHTML"`)
+	assert.Contains(t, rendered, `aria-current="page"`)
+	assert.Contains(t, rendered, `aria-label="more pages"`)
+	assert.Contains(t, rendered, `stroke-linecap="round"`)
+	assert.Equal(t, 2, strings.Count(rendered, `aria-label="more pages"`))
+}
+
+func TestCoverageRenderSimpleLastPageDisablesNext(t *testing.T) {
+	rendered := renderPagination(t, Config{
+		Variant:     Simple,
+		CurrentPage: 4,
+		TotalPages:  4,
+		BaseURL:     "/items",
+	})
+
+	assert.Contains(t, rendered, `href="/items?page=3"`)
+	assert.Contains(t, rendered, `aria-label="previous page"`)
+	assert.Contains(t, rendered, `aria-disabled="true"`)
+	assert.Contains(t, rendered, `cursor-not-allowed`)
+	assert.NotContains(t, rendered, `aria-label="page 1"`)
+}

--- a/site/tests/e2e/pagination_coverage_test.go
+++ b/site/tests/e2e/pagination_coverage_test.go
@@ -1,0 +1,73 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaginationCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+	var jsErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			jsErrors = append(jsErrors, m.Text())
+		}
+	})
+	page.On("pageerror", func(err error) {
+		jsErrors = append(jsErrors, err.Error())
+	})
+
+	_, err := page.Goto(baseURL+"/components/pagination", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("main").GetByText("Pagination").First().WaitFor())
+	require.NoError(t, page.Locator("#pagination-simple").ScrollIntoViewIfNeeded())
+
+	next := page.Locator("#pagination-simple a[aria-label='next page']")
+	nextHref, err := next.GetAttribute("href")
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(nextHref, "?page=4"), "simple next link should target page 4")
+	require.NoError(t, next.Click())
+	require.NoError(t, page.WaitForURL("**/components/pagination?page=4"))
+
+	_, err = page.Goto(baseURL+"/components/pagination", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+
+	beginEllipses, err := page.Locator("#pagination-ellipsis-begin span[aria-label='more pages']").Count()
+	require.NoError(t, err)
+	assert.Equal(t, 1, beginEllipses)
+	require.NoError(t, page.Locator("#pagination-ellipsis-begin a[aria-current='page'][aria-label='page 2']").WaitFor())
+
+	endEllipses, err := page.Locator("#pagination-ellipsis-end span[aria-label='more pages']").Count()
+	require.NoError(t, err)
+	assert.Equal(t, 1, endEllipses)
+	require.NoError(t, page.Locator("#pagination-ellipsis-end a[aria-current='page'][aria-label='page 29']").WaitFor())
+
+	htmxPage := page.Locator("#pagination-small a[aria-label='page 4']")
+	hxGet, err := htmxPage.GetAttribute("hx-get")
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(hxGet, "?page=4"), "HTMX page link should target page 4")
+	hxSwap, err := htmxPage.GetAttribute("hx-swap")
+	require.NoError(t, err)
+	assert.Equal(t, "innerHTML", hxSwap)
+
+	require.Empty(t, jsErrors, "no JS console/page errors on pagination demo: %v", jsErrors)
+}


### PR DESCRIPTION
Harness: Codex
Taken: 022-pagination.md
Coverage focus: components/pagination
Verification: go test ./components/pagination -count=1; go test ./tests/e2e/... -count=1 -timeout 5m -run 'TestPaginationCoverageDemo'; go test ./tests/e2e/... -count=1 -timeout 5m -run 'Pagination'; just coverage
Auto-merge: OK once CI is green