### PR TITLE
test: expand sidebar coverage

### DIFF
--- a/components/sidebar/sidebar_coverage_test.go
+++ b/components/sidebar/sidebar_coverage_test.go
@@ -1,0 +1,176 @@
+package sidebar
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+)
+
+func TestCoverageRenderSidebarBranches(t *testing.T) {
+	html := renderSidebar(t, Config{
+		LogoText:          "Docs",
+		LogoHref:          "/docs",
+		ShowSearch:        true,
+		SearchPlaceholder: "Filter navigation",
+		RootClass:         "coverage-root",
+		Items: []Item{
+			{
+				ID:     "overview",
+				Label:  "Overview",
+				Href:   "/overview",
+				Icon:   testComponent(`<svg data-testid="overview-icon"></svg>`),
+				Active: true,
+				LinkAttrs: templ.Attributes{
+					"data-sidebar-item": "Overview",
+					"hx-get":            "/overview",
+					"hx-target":         "#main-content",
+				},
+			},
+			{
+				ID:    "inbox",
+				Label: "Inbox",
+				Href:  "/inbox",
+				Icon:  testComponent(`<svg data-testid="inbox-icon"></svg>`),
+				Badge: "7",
+				Items: []Item{
+					{ID: "archive", Label: "Archive", Href: "/archive", Badge: "new"},
+					{ID: "muted", Label: "Muted", Href: "/muted", Disabled: true},
+				},
+			},
+			{
+				ID:       "disabled",
+				Label:    "Disabled top item",
+				Href:     "/disabled",
+				Icon:     testComponent(`<svg data-testid="disabled-icon"></svg>`),
+				Disabled: true,
+			},
+		},
+		SectionsTitle: "Component groups",
+		Sections: []Section{
+			{
+				Title: "Primary",
+				Items: []Item{
+					{ID: "button", Label: "Button", Href: "/components/button", Active: true, Badge: "hot"},
+					{ID: "card", Label: "Card", Href: "/components/card", Badge: "soon"},
+					{
+						ID:    "nested",
+						Label: "Nested",
+						Href:  "/components/nested",
+						Items: []Item{
+							{ID: "nested-child", Label: "Nested child", Href: "/components/nested-child"},
+						},
+					},
+					{ID: "disabled-section", Label: "Disabled section item", Href: "/components/disabled", Disabled: true},
+				},
+			},
+		},
+		FooterSlot: testComponent(`<div data-testid="sidebar-footer">Footer slot</div>`),
+	})
+
+	assertContainsAll(t, html,
+		`aria-label="sidebar navigation"`,
+		`href="/docs"`,
+		`Docs`,
+		`coverage-root`,
+		`placeholder="Filter navigation"`,
+		`href="/overview"`,
+		`data-sidebar-item="Overview"`,
+		`hx-get="/overview"`,
+		`hx-target="#main-content"`,
+		`text-primary dark:text-primary-dark`,
+		`<span class="sr-only">active</span>`,
+		`data-testid="overview-icon"`,
+		`Inbox`,
+		`>7</span>`,
+		`Archive`,
+		`>new</span>`,
+		`Disabled top item`,
+		`cursor-not-allowed`,
+		`Component groups`,
+		`data-sidebar-section="Primary"`,
+		`border-l-2 border-primary`,
+		`>hot</sup>`,
+		`>soon</sup>`,
+		`Nested child`,
+		`Disabled section item`,
+		`data-testid="sidebar-footer"`,
+	)
+
+	if strings.Contains(html, `href="/disabled"`) {
+		t.Fatalf("disabled top item should not render an href: %s", html)
+	}
+	if strings.Contains(html, `href="/components/disabled"`) {
+		t.Fatalf("disabled section item should not render an href: %s", html)
+	}
+}
+
+func TestCoverageSearchSlotOverridesDefaultSearch(t *testing.T) {
+	html := renderSidebar(t, Config{
+		Logo:              testComponent(`<span data-testid="logo-slot">Logo slot</span>`),
+		LogoText:          "Fallback text",
+		ShowSearch:        true,
+		SearchPlaceholder: "Should not render",
+		SearchSlot:        testComponent(`<div data-testid="search-slot">Custom search</div>`),
+	})
+
+	assertContainsAll(t, html,
+		`data-testid="logo-slot"`,
+		`data-testid="search-slot"`,
+		`Custom search`,
+	)
+
+	for _, absent := range []string{`Fallback text`, `name="search"`, `Should not render`} {
+		if strings.Contains(html, absent) {
+			t.Fatalf("custom slot render should not contain %q: %s", absent, html)
+		}
+	}
+}
+
+func TestCoverageSidebarClassHelpers(t *testing.T) {
+	cfg := Config{}
+
+	assertContainsAll(t, cfg.ContainerClasses(),
+		`h-full`,
+		`border-r`,
+		`bg-surface`,
+		`dark:bg-surface-dark`,
+		`flex flex-col`,
+	)
+	assertContainsAll(t, cfg.NavClasses(),
+		`flex-1`,
+		`overflow-y-auto`,
+		`sidebar-scroll`,
+		`p-4`,
+	)
+}
+
+func renderSidebar(t *testing.T, cfg Config) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := Sidebar(cfg).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("render sidebar: %v", err)
+	}
+	return buf.String()
+}
+
+func testComponent(markup string) templ.Component {
+	return templ.ComponentFunc(func(ctx context.Context, w io.Writer) error {
+		_, err := io.WriteString(w, markup)
+		return err
+	})
+}
+
+func assertContainsAll(t *testing.T, got string, wants ...string) {
+	t.Helper()
+
+	for _, want := range wants {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in %s", want, got)
+		}
+	}
+}

--- a/site/tests/e2e/sidebar_coverage_test.go
+++ b/site/tests/e2e/sidebar_coverage_test.go
@@ -1,0 +1,113 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSidebarCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newPage(t, sharedBrowser)
+
+	var jsErrors []string
+	page.On("pageerror", func(err error) { jsErrors = append(jsErrors, err.Error()) })
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			jsErrors = append(jsErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/sidebar", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	require.NoError(t, page.Locator("#sidebar-fragment").WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+	mainText, err := page.Locator("main").TextContent()
+	require.NoError(t, err)
+	require.Contains(t, mainText, "Sidebar")
+
+	t.Run("simple and section variants expose active states and badges", func(t *testing.T) {
+		simple := page.Locator("#sidebar-simple")
+		require.NoError(t, simple.ScrollIntoViewIfNeeded())
+		require.NoError(t, simple.Locator("input[type='search'][placeholder='Search...']").WaitFor())
+		require.NoError(t, simple.Locator("a.text-primary").Filter(playwright.LocatorFilterOptions{HasText: "Profile"}).WaitFor())
+		require.NoError(t, simple.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: "Inbox"}).GetByText("3", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+
+		sections := page.Locator("#sidebar-sections")
+		require.NoError(t, sections.ScrollIntoViewIfNeeded())
+		require.NoError(t, sections.Locator("[data-sidebar-section='Components']").GetByText("Table", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)}).WaitFor())
+		require.NoError(t, sections.Locator("a.pointer-events-none").Filter(playwright.LocatorFilterOptions{HasText: "Overview"}).WaitFor())
+	})
+
+	t.Run("nested section children and badges render", func(t *testing.T) {
+		subItems := page.Locator("#sidebar-sub-items")
+		require.NoError(t, subItems.ScrollIntoViewIfNeeded())
+
+		for _, label := range []string{"Create User", "Get User", "Update User", "Delete User", "List Products", "Create Product"} {
+			require.NoError(t, subItems.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: label}).WaitFor())
+		}
+		for _, badge := range []string{"POST", "GET", "PUT", "DEL"} {
+			require.NoError(t, subItems.Locator("sup").Filter(playwright.LocatorFilterOptions{HasText: badge}).First().WaitFor())
+		}
+	})
+
+	t.Run("collapsible demo updates live Alpine visibility", func(t *testing.T) {
+		collapsible := page.Locator("#sidebar-collapsible")
+		require.NoError(t, collapsible.ScrollIntoViewIfNeeded())
+
+		require.True(t, sidebarVisible(t, page, "#sidebar-collapsible", "Dashboard"))
+		require.False(t, sidebarVisible(t, page, "#sidebar-collapsible", "Articles"))
+
+		contentButton := collapsible.Locator("button").Filter(playwright.LocatorFilterOptions{HasText: "Content"})
+		require.NoError(t, contentButton.Click())
+		_, err := page.WaitForFunction(
+			`() => Array.from(document.querySelectorAll("#sidebar-collapsible a")).some((el) => el.textContent.trim() === "Articles" && el.offsetParent !== null)`,
+			nil,
+			playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("overlay opens and closes with Alpine state", func(t *testing.T) {
+		overlay := page.Locator("#sidebar-overlay")
+		require.NoError(t, overlay.ScrollIntoViewIfNeeded())
+
+		panel := overlay.GetByText("Overlay", playwright.LocatorGetByTextOptions{Exact: playwright.Bool(true)})
+		visible, err := panel.IsVisible()
+		require.NoError(t, err)
+		require.False(t, visible)
+
+		require.NoError(t, overlay.Locator("button[aria-label='Open sidebar']").Click())
+		require.NoError(t, panel.WaitFor(playwright.LocatorWaitForOptions{
+			State:   playwright.WaitForSelectorStateVisible,
+			Timeout: playwright.Float(3000),
+		}))
+		require.NoError(t, overlay.Locator("input[type='search'][placeholder='Search...']").WaitFor())
+
+		require.NoError(t, overlay.Locator("button[aria-label='Close sidebar']").Click())
+		require.NoError(t, panel.WaitFor(playwright.LocatorWaitForOptions{
+			State:   playwright.WaitForSelectorStateHidden,
+			Timeout: playwright.Float(3000),
+		}))
+	})
+
+	require.Empty(t, jsErrors, "no JS console/page errors on sidebar demo: %v", jsErrors)
+}
+
+func sidebarVisible(t *testing.T, page playwright.Page, scope string, text string) bool {
+	t.Helper()
+
+	result, err := page.Evaluate(`([scope, text]) => Array.from(document.querySelectorAll(scope + " a")).some((el) => el.textContent.trim() === text && el.offsetParent !== null)`, []string{scope, text})
+	require.NoError(t, err)
+
+	return result.(bool)
+}


### PR DESCRIPTION
Harness: Codex
Taken: 021-sidebar.md
Coverage focus: components/sidebar
Verification: go test ./components/sidebar -count=1; go test ./site/tests/e2e/... -count=1 -timeout 5m -run 'Sidebar'; just coverage
Auto-merge: OK once CI is green

## Summary
- Add render-focused unit coverage for sidebar item, section, search, logo, footer, and class-helper branches.
- Add demo E2E coverage for sidebar variants, nested items, Alpine collapsible state, overlay open/close, and console/page errors.
