### PR TITLE
test(badge): add unit + E2E coverage

### DIFF
--- a/components/badge/badge_coverage_test.go
+++ b/components/badge/badge_coverage_test.go
@@ -1,0 +1,244 @@
+package badge
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// renderComponent renders any templ component into a string for assertions.
+func renderComponent(t *testing.T, c templ.Component) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, c.Render(context.Background(), &buf))
+	return buf.String()
+}
+
+// allVariants is every Variant the component understands, used to exercise the
+// switch arms of the class helpers and templ entry points.
+var allVariants = []Variant{
+	Default, Inverse, Primary, Secondary, Info, Success, Warning, Danger,
+}
+
+func TestSizeClasses(t *testing.T) {
+	cases := map[Size]string{
+		SizeSM:     "text-[10px] px-1.5 py-0.5",
+		SizeLG:     "text-sm px-3 py-1.5",
+		SizeMD:     "text-xs px-2 py-1",
+		Size("xx"): "text-xs px-2 py-1", // unknown size falls back to default
+	}
+	for size, want := range cases {
+		got := Config{Size: size}.SizeClasses()
+		assert.Equalf(t, want, got, "SizeClasses for %q", size)
+	}
+}
+
+func TestSizeTextClass(t *testing.T) {
+	cases := map[Size]string{
+		SizeSM:     "text-[10px]",
+		SizeLG:     "text-sm",
+		SizeMD:     "text-xs",
+		Size("xx"): "text-xs", // unknown size falls back to default
+	}
+	for size, want := range cases {
+		got := Config{Size: size}.SizeTextClass()
+		assert.Equalf(t, want, got, "SizeTextClass for %q", size)
+	}
+}
+
+func TestVariantClasses_AllArms(t *testing.T) {
+	// Each variant maps to a distinct background token; assert the token is present
+	// so every switch arm is both executed and verified.
+	wantBG := map[Variant]string{
+		Default:   "bg-surface-alt",
+		Inverse:   "bg-surface-dark-alt",
+		Primary:   "bg-primary",
+		Secondary: "bg-secondary",
+		Info:      "bg-info",
+		Success:   "bg-success",
+		Warning:   "bg-warning",
+		Danger:    "bg-danger",
+	}
+	for _, v := range allVariants {
+		got := Config{Variant: v}.VariantClasses()
+		assert.Containsf(t, got, "border", "VariantClasses %q should set a border", v)
+		assert.Containsf(t, got, wantBG[v], "VariantClasses %q background", v)
+	}
+	// Unknown variant falls back to the default arm.
+	assert.Equal(t,
+		Config{Variant: Default}.VariantClasses(),
+		Config{Variant: Variant("nope")}.VariantClasses(),
+	)
+}
+
+func TestSoftVariantClasses_AllArms(t *testing.T) {
+	wantText := map[Variant]string{
+		Default:   "text-on-surface",
+		Inverse:   "text-on-surface",
+		Primary:   "text-primary",
+		Secondary: "text-secondary",
+		Info:      "text-info",
+		Success:   "text-success",
+		Warning:   "text-warning",
+		Danger:    "text-danger",
+	}
+	for _, v := range allVariants {
+		got := Config{Variant: v}.SoftVariantClasses()
+		assert.Containsf(t, got, "bg-surface", "SoftVariantClasses %q uses surface bg", v)
+		assert.Containsf(t, got, wantText[v], "SoftVariantClasses %q text", v)
+	}
+	assert.Equal(t,
+		Config{Variant: Default}.SoftVariantClasses(),
+		Config{Variant: Variant("nope")}.SoftVariantClasses(),
+	)
+}
+
+func TestSoftInnerClasses_AllArms(t *testing.T) {
+	wantBG := map[Variant]string{
+		Default:   "bg-surface-alt/10",
+		Inverse:   "bg-surface-dark-alt/10",
+		Primary:   "bg-primary/10",
+		Secondary: "bg-secondary/10",
+		Info:      "bg-info/10",
+		Success:   "bg-success/10",
+		Warning:   "bg-warning/10",
+		Danger:    "bg-danger/10",
+	}
+	for _, v := range allVariants {
+		got := Config{Variant: v}.SoftInnerClasses()
+		assert.Containsf(t, got, wantBG[v], "SoftInnerClasses %q", v)
+	}
+	assert.Equal(t,
+		Config{Variant: Default}.SoftInnerClasses(),
+		Config{Variant: Variant("nope")}.SoftInnerClasses(),
+	)
+}
+
+func TestIndicatorClasses_AllArms(t *testing.T) {
+	wantBG := map[Variant]string{
+		Default:   "bg-on-surface",
+		Inverse:   "bg-on-surface",
+		Primary:   "bg-primary",
+		Secondary: "bg-secondary",
+		Info:      "bg-info",
+		Success:   "bg-success",
+		Warning:   "bg-warning",
+		Danger:    "bg-danger",
+	}
+	for _, v := range allVariants {
+		got := Config{Variant: v}.IndicatorClasses()
+		assert.Containsf(t, got, "size-1.5 rounded-full", "IndicatorClasses %q base", v)
+		assert.Containsf(t, got, wantBG[v], "IndicatorClasses %q bg", v)
+	}
+	// IndicatorColor override short-circuits the variant switch.
+	got := Config{Variant: Danger, IndicatorColor: "bg-pink-500"}.IndicatorClasses()
+	assert.Equal(t, "size-1.5 rounded-full bg-pink-500", got)
+	assert.NotContains(t, got, "bg-danger")
+}
+
+func TestIsSoft(t *testing.T) {
+	assert.True(t, Config{Style: StyleSoft}.IsSoft())
+	assert.False(t, Config{Style: StyleSolid}.IsSoft())
+	assert.False(t, Config{}.IsSoft())
+}
+
+func TestBadge_SimplePath(t *testing.T) {
+	// No soft/icon/indicator => simpleBadge path.
+	html := renderComponent(t, Badge(Config{Label: "New", Variant: Primary, RootClass: "ml-2"}))
+	assert.Contains(t, html, "New")
+	assert.Contains(t, html, "bg-primary")
+	assert.Contains(t, html, "ml-2")           // RootClass threaded through
+	assert.Contains(t, html, "rounded-radius") // simpleBadge container marker
+	assert.NotContains(t, html, "inline-flex") // not the inner-span path
+}
+
+func TestBadge_SoftPath(t *testing.T) {
+	html := renderComponent(t, Badge(Config{Label: "Active", Variant: Success, Style: StyleSoft, RootClass: "mr-1"}))
+	assert.Contains(t, html, "Active")
+	assert.Contains(t, html, "inline-flex")   // badgeWithInner container
+	assert.Contains(t, html, "text-success")  // soft variant text color
+	assert.Contains(t, html, "bg-success/10") // soft inner bg
+	assert.Contains(t, html, "mr-1")
+}
+
+func TestBadge_IndicatorPath(t *testing.T) {
+	html := renderComponent(t, Badge(Config{Label: "Live", Variant: Danger, Indicator: true}))
+	assert.Contains(t, html, "inline-flex")
+	assert.Contains(t, html, `aria-hidden="true"`)
+	assert.Contains(t, html, "size-1.5 rounded-full")
+	assert.Contains(t, html, "bg-danger")
+}
+
+func TestBadge_IconPath(t *testing.T) {
+	icon := templ.Raw(`<svg data-testid="star"></svg>`)
+	html := renderComponent(t, Badge(Config{Label: "Starred", Variant: Warning, Icon: icon}))
+	assert.Contains(t, html, "inline-flex")
+	assert.Contains(t, html, `data-testid="star"`)
+	assert.Contains(t, html, "shrink-0") // icon wrapper
+	assert.Contains(t, html, "Starred")
+}
+
+func TestBadge_AllVariantsRender(t *testing.T) {
+	for _, v := range allVariants {
+		for _, style := range []Style{StyleSolid, StyleSoft} {
+			html := renderComponent(t, Badge(Config{Label: "x", Variant: v, Style: style}))
+			assert.NotEmptyf(t, html, "variant %q style %q rendered empty", v, style)
+			assert.Containsf(t, html, "class=", "variant %q style %q missing class", v, style)
+		}
+	}
+}
+
+func TestBadge_LabelEscaped(t *testing.T) {
+	// templ must escape HTML in user-provided labels.
+	html := renderComponent(t, Badge(Config{Label: `<script>alert(1)</script>`}))
+	assert.NotContains(t, html, "<script>alert(1)</script>")
+	assert.Contains(t, html, "&lt;script&gt;")
+}
+
+func TestNotificationBadge(t *testing.T) {
+	// count <= 0 renders nothing.
+	assert.Empty(t, strings.TrimSpace(renderComponent(t, NotificationBadge(0))))
+	assert.Empty(t, strings.TrimSpace(renderComponent(t, NotificationBadge(-5))))
+
+	// 1..99 shows the number.
+	html := renderComponent(t, NotificationBadge(7))
+	assert.Contains(t, html, "7")
+	assert.Contains(t, html, "bg-danger")
+
+	// >99 caps at "99+".
+	html = renderComponent(t, NotificationBadge(150))
+	assert.Contains(t, html, "99+")
+	assert.NotContains(t, html, "150")
+}
+
+func TestNotificationDot(t *testing.T) {
+	html := renderComponent(t, NotificationDot())
+	assert.Contains(t, html, "rounded-full")
+	assert.Contains(t, html, "bg-danger")
+	assert.Contains(t, html, "size-3")
+}
+
+func TestAnimatingDot_AllVariants(t *testing.T) {
+	wantColor := map[Variant]string{
+		Default:   "bg-primary", // unmatched arms fall through to the primary default
+		Inverse:   "bg-primary", // no case for Inverse => default color
+		Primary:   "bg-primary",
+		Secondary: "bg-secondary",
+		Info:      "bg-info",
+		Success:   "bg-success",
+		Warning:   "bg-warning",
+		Danger:    "bg-danger",
+	}
+	for _, v := range allVariants {
+		html := renderComponent(t, AnimatingDot(v))
+		assert.Containsf(t, html, `aria-label="notification"`, "AnimatingDot %q aria-label", v)
+		assert.Containsf(t, html, "animate-ping", "AnimatingDot %q ping", v)
+		assert.Containsf(t, html, "motion-reduce:animate-none", "AnimatingDot %q reduced motion", v)
+		assert.Containsf(t, html, wantColor[v], "AnimatingDot %q color", v)
+	}
+}

--- a/site/tests/e2e/badge_coverage_test.go
+++ b/site/tests/e2e/badge_coverage_test.go
@@ -1,0 +1,98 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBadgeCoverageDemo complements TestBadgeComponentDemo with checks that the
+// badge demo loads cleanly (no JS exceptions / console errors), that the
+// notification and animating-dot helpers render their expected hooks, and that
+// the badges survive a dark-mode toggle. filterIgnorable is defined in
+// alert_coverage_test.go.
+func TestBadgeCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newIsolatedPage(t)
+
+	var pageErrors []string
+	page.On("pageerror", func(err error) { pageErrors = append(pageErrors, err.Error()) })
+
+	var consoleErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			consoleErrors = append(consoleErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/badge", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	t.Run("page heading renders", func(t *testing.T) {
+		require.NoError(t, page.Locator("main").Filter(playwright.LocatorFilterOptions{
+			HasText: "Badge",
+		}).First().WaitFor())
+	})
+
+	t.Run("notification badge caps at 99 and exposes button labels", func(t *testing.T) {
+		require.NoError(t, page.Locator("#badge-notification button[aria-label='notifications']").WaitFor())
+
+		// NotificationBadge(count) caps display at "99" for count > 99.
+		require.NoError(t, page.Locator("#badge-notification").GetByText("99", playwright.LocatorGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).WaitFor())
+
+		// NotificationDot() renders a size-3 dot with no text.
+		dots, err := page.Locator("#badge-notification span.size-3").Count()
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, dots, 1)
+	})
+
+	t.Run("animating dots render aria-label and ping hook", func(t *testing.T) {
+		dots := page.Locator("#badge-animating span[aria-label='notification']")
+		count, err := dots.Count()
+		require.NoError(t, err)
+		assert.Equal(t, 6, count)
+
+		// Each AnimatingDot emits an inner animate-ping span.
+		ping, err := page.Locator("#badge-animating span.animate-ping").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 6, ping)
+	})
+
+	t.Run("indicator dots are aria-hidden decorations", func(t *testing.T) {
+		count, err := page.Locator("#badge-indicators span[aria-hidden='true']").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 6, count)
+	})
+
+	t.Run("badges survive a dark-mode toggle", func(t *testing.T) {
+		before, err := page.Evaluate("() => document.documentElement.classList.contains('dark')", nil)
+		require.NoError(t, err)
+		beforeBool, _ := before.(bool)
+
+		_, err = page.Evaluate(`() => { document.documentElement.classList.toggle('dark'); }`, nil)
+		require.NoError(t, err)
+
+		after, err := page.Evaluate("() => document.documentElement.classList.contains('dark')", nil)
+		require.NoError(t, err)
+		afterBool, _ := after.(bool)
+		assert.NotEqual(t, beforeBool, afterBool, "dark class should toggle")
+
+		// Solid badges stay rendered after the theme switch.
+		require.NoError(t, page.Locator("#badge-solid").GetByText("Primary", playwright.LocatorGetByTextOptions{
+			Exact: playwright.Bool(true),
+		}).First().WaitFor())
+	})
+
+	require.Empty(t, pageErrors, "uncaught JS exceptions on badge demo")
+	require.Empty(t, filterIgnorable(consoleErrors), "console errors on badge demo")
+}


### PR DESCRIPTION
Raises `components/badge` component-only coverage from 36.0% by adding behavior-focused unit and E2E tests. No production code changed.

## What
- **Unit** `components/badge/badge_coverage_test.go`: every class helper switch arm (incl. unknown-value fallbacks and the `IndicatorColor` override), all `Badge()` render branches (simple/soft/icon/indicator), `RootClass` threading, label HTML-escaping, full variant×style matrix, and `NotificationBadge`/`NotificationDot`/`AnimatingDot` across counts and variants.
- **E2E** `site/tests/e2e/badge_coverage_test.go`: complements `TestBadgeComponentDemo` with pageerror/console-error capture, notification + animating-dot hooks, and dark-mode toggle survival. Reuses `newIsolatedPage`/`waitForAlpine`/`filterIgnorable`.

## Result
- `types.go` helpers → 100%; templ entry points 68–84% (remaining gaps are generated `return err` boilerplate).

---
Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 020-badge.md
Coverage focus: components/badge
Verification: go test ./components/badge -count=1; go test ./site/tests/e2e -run Badge; just coverage (full gate, exit 0, E2E suite green)
Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)