### PR TITLE
test(toggle): fix false-positive checked/disabled assertions

### DIFF
--- a/components/toggle/toggle_coverage_test.go
+++ b/components/toggle/toggle_coverage_test.go
@@ -18,6 +18,22 @@ func renderToggle(t *testing.T, cfg Config) string {
 	return buf.String()
 }
 
+// inputTag returns just the opening <input> tag (the checkbox) so attribute
+// assertions are not confused by peer-checked / peer-disabled utility classes
+// that appear elsewhere in the rendered markup.
+func inputTag(t *testing.T, html string) string {
+	t.Helper()
+	start := strings.Index(html, "<input")
+	if start < 0 {
+		t.Fatalf("no <input> in render: %s", html)
+	}
+	end := strings.Index(html[start:], ">")
+	if end < 0 {
+		t.Fatalf("unterminated <input> in render: %s", html)
+	}
+	return html[start : start+end+1]
+}
+
 func TestCoverageRenderDefaultToggle(t *testing.T) {
 	html := renderToggle(t, Config{ID: "t1", Label: "Enable"})
 
@@ -45,13 +61,25 @@ func TestCoverageRenderDefaultToggle(t *testing.T) {
 }
 
 func TestCoverageCheckedAndDisabled(t *testing.T) {
-	html := renderToggle(t, Config{ID: "t2", Label: "On", Checked: true, Disabled: true})
-
-	if !strings.Contains(html, "checked") {
-		t.Fatalf("expected checked attribute: %s", html)
+	// Assert on the <input> tag only: the track div carries peer-checked /
+	// peer-disabled utility classes, so a whole-document substring search would
+	// pass even when the boolean attributes are absent.
+	on := inputTag(t, renderToggle(t, Config{ID: "t2", Label: "On", Checked: true, Disabled: true}))
+	if !strings.Contains(on, "checked") {
+		t.Fatalf("expected checked attribute on input: %s", on)
 	}
-	if !strings.Contains(html, "disabled") {
-		t.Fatalf("expected disabled attribute: %s", html)
+	if !strings.Contains(on, "disabled") {
+		t.Fatalf("expected disabled attribute on input: %s", on)
+	}
+
+	// Guard against a false positive: an unconfigured toggle must NOT render the
+	// boolean attributes on its input.
+	off := inputTag(t, renderToggle(t, Config{ID: "t2", Label: "Off"}))
+	if strings.Contains(off, "checked") {
+		t.Fatalf("unexpected checked attribute on default input: %s", off)
+	}
+	if strings.Contains(off, "disabled") {
+		t.Fatalf("unexpected disabled attribute on default input: %s", off)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #110. Codex stop-time review flagged that `TestCoverageCheckedAndDisabled` asserted `strings.Contains(html, "checked")` / `"disabled"` against the whole rendered document — those substrings are always present via the track div's `peer-checked` / `peer-disabled` utility classes, so the assertions could never fail (false positives).

Fix: scope the assertions to the `<input>` tag via a new `inputTag` helper, and add a negative case proving an unconfigured toggle renders neither boolean attribute.

Harness: Claude Code (Opus 4.8 1M)
Taken: 024-toggle.md
Coverage focus: components/toggle
Verification: go test ./components/toggle -count=1 (75.6%, pass)
Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)