### PR TITLE
test: expand breadcrumbs coverage

### DIFF
--- a/components/breadcrumbs/breadcrumbs_coverage_test.go
+++ b/components/breadcrumbs/breadcrumbs_coverage_test.go
@@ -1,0 +1,79 @@
+package breadcrumbs
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBreadcrumbsCoverageRendersDefaultStructureAndCurrentPage(t *testing.T) {
+	rendered := renderBreadcrumbs(t, Config{
+		Items: []Item{
+			{Label: "Home", Href: "/"},
+			{Label: "Docs", Href: "/docs"},
+		},
+		Current: "Breadcrumbs",
+	})
+
+	assert.Contains(t, rendered, `aria-label="breadcrumb"`)
+	assert.Contains(t, rendered, `class="flex flex-wrap items-center gap-1"`)
+	assert.Contains(t, rendered, `class="flex items-center gap-1"`)
+	assert.Contains(t, rendered, `href="/"`)
+	assert.Contains(t, rendered, `href="/docs"`)
+	assert.Contains(t, rendered, `aria-current="page"`)
+	assert.Contains(t, rendered, `Breadcrumbs`)
+	assert.Equal(t, 2, strings.Count(rendered, `<svg xmlns="http://www.w3.org/2000/svg" fill="none"`))
+	assert.NotContains(t, rendered, `<span aria-hidden="true">/</span>`)
+}
+
+func TestBreadcrumbsCoverageRendersSlashSeparatorClassesAndAttributes(t *testing.T) {
+	rendered := renderBreadcrumbs(t, Config{
+		Items: []Item{
+			{
+				Label: "Components",
+				Href:  "/components?section=nav",
+				LinkAttrs: templ.Attributes{
+					"data-track": "breadcrumb-link",
+					"rel":        "nofollow",
+				},
+			},
+			{
+				Label:   "Breadcrumbs",
+				Href:    "/components/breadcrumbs",
+				Icon:    templ.Raw(`<svg data-testid="crumb-icon"></svg>`),
+				Tooltip: "Breadcrumb component",
+			},
+		},
+		Separator: Slash,
+		NavClass:  "custom-nav",
+		NavAttrs: templ.Attributes{
+			"id":        "docs-breadcrumbs",
+			"data-role": "trail",
+		},
+	})
+
+	assert.Contains(t, rendered, `text-on-surface dark:text-on-surface-dark custom-nav`)
+	assert.Contains(t, rendered, `id="docs-breadcrumbs"`)
+	assert.Contains(t, rendered, `data-role="trail"`)
+	assert.Contains(t, rendered, `class="flex flex-wrap items-center gap-2"`)
+	assert.Contains(t, rendered, `class="flex items-center gap-2"`)
+	assert.Contains(t, rendered, `href="/components?section=nav"`)
+	assert.Contains(t, rendered, `data-track="breadcrumb-link"`)
+	assert.Contains(t, rendered, `rel="nofollow"`)
+	assert.Contains(t, rendered, `title="Breadcrumb component"`)
+	assert.Contains(t, rendered, `data-testid="crumb-icon"`)
+	assert.Equal(t, 2, strings.Count(rendered, `<span aria-hidden="true">/</span>`))
+	assert.NotContains(t, rendered, `aria-current="page"`)
+	assert.NotContains(t, rendered, `fill="none" viewBox="0 0 24 24"`)
+}
+
+func TestBreadcrumbsCoverageHelperClassBranches(t *testing.T) {
+	assert.Equal(t, "", extraClass(""))
+	assert.Equal(t, " mt-2", extraClass("mt-2"))
+	assert.Equal(t, "flex flex-wrap items-center gap-1", listClasses(Chevron))
+	assert.Equal(t, "flex flex-wrap items-center gap-2", listClasses(Slash))
+	assert.Equal(t, "flex items-center gap-1", itemClasses(Chevron))
+	assert.Equal(t, "flex items-center gap-2", itemClasses(Slash))
+}

--- a/site/tests/e2e/breadcrumbs_coverage_test.go
+++ b/site/tests/e2e/breadcrumbs_coverage_test.go
@@ -1,0 +1,104 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBreadcrumbsCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newPage(t, sharedBrowser)
+
+	var pageErrors []string
+	page.On("pageerror", func(err error) { pageErrors = append(pageErrors, err.Error()) })
+
+	var consoleErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			consoleErrors = append(consoleErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/breadcrumbs", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	require.NoError(t, page.Locator("main").Filter(playwright.LocatorFilterOptions{
+		HasText: "Breadcrumbs",
+	}).First().WaitFor())
+	for _, id := range []string{"#breadcrumbs-chevron", "#breadcrumbs-slash", "#breadcrumbs-icon"} {
+		require.NoError(t, page.Locator(id+" nav[aria-label='breadcrumb']").WaitFor())
+		require.NoError(t, page.Locator(id+" [aria-current='page']").WaitFor())
+	}
+
+	chevronCount, err := page.Locator("#breadcrumbs-chevron svg[aria-hidden='true'][stroke='currentColor']").Count()
+	require.NoError(t, err)
+	assert.Equal(t, 2, chevronCount)
+
+	slashCount, err := page.Locator("#breadcrumbs-slash span[aria-hidden='true']").Filter(playwright.LocatorFilterOptions{
+		HasText: "/",
+	}).Count()
+	require.NoError(t, err)
+	assert.Equal(t, 2, slashCount)
+
+	iconTitle, err := page.Locator("#breadcrumbs-icon a").First().Locator("span").First().GetAttribute("title")
+	require.NoError(t, err)
+	assert.Equal(t, "Home", iconTitle)
+
+	require.NoError(t, page.Locator("table").Filter(playwright.LocatorFilterOptions{
+		HasText: "NavClass",
+	}).WaitFor())
+
+	before, err := page.Evaluate("() => document.documentElement.classList.contains('dark')", nil)
+	require.NoError(t, err)
+	_, err = page.Evaluate(`() => document.documentElement.classList.toggle('dark')`, nil)
+	require.NoError(t, err)
+	after, err := page.Evaluate("() => document.documentElement.classList.contains('dark')", nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, before, after, "dark class should toggle while breadcrumbs remain mounted")
+	require.NoError(t, page.Locator("#breadcrumbs-fragment").WaitFor())
+
+	require.Empty(t, pageErrors, "uncaught JS exceptions on breadcrumbs demo: %v", pageErrors)
+	require.Empty(t, filterIgnorable(consoleErrors), "console errors on breadcrumbs demo: %s", strings.Join(consoleErrors, "; "))
+}
+
+func TestBreadcrumbsCoverageFragmentNavigation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newPage(t, sharedBrowser)
+
+	var consoleErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			consoleErrors = append(consoleErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/getting-started", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	link := page.Locator("a[href='/components/breadcrumbs']").First()
+	require.NoError(t, link.ScrollIntoViewIfNeeded())
+	require.NoError(t, link.Click())
+	require.NoError(t, page.Locator("#breadcrumbs-fragment").WaitFor())
+	require.NoError(t, page.Locator("#breadcrumbs-slash nav[aria-label='breadcrumb']").WaitFor())
+	require.NoError(t, page.Locator("main").Filter(playwright.LocatorFilterOptions{
+		HasText: "Slash Separator",
+	}).First().WaitFor())
+
+	require.Empty(t, filterIgnorable(consoleErrors), "console errors after fragment navigation: %s", strings.Join(consoleErrors, "; "))
+}


### PR DESCRIPTION
Harness: Codex
Taken: 028-breadcrumbs.md
Coverage focus: components/breadcrumbs
Verification: go test ./components/breadcrumbs -count=1; go test ./site/tests/e2e/... -count=1 -timeout 5m -run 'Breadcrumbs'; just coverage\nAuto-merge: OK once CI is green