### PR TITLE
test(range): add unit + E2E coverage

### DIFF
--- a/components/range/range_coverage_test.go
+++ b/components/range/range_coverage_test.go
@@ -1,0 +1,177 @@
+package rangeinput
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+)
+
+func renderCov(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := Range(cfg).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("render range: %v", err)
+	}
+	return buf.String()
+}
+
+// Icons exercise IconClasses (0% baseline), the leading/trailing icon
+// branches in rangeInner, the icon-aware ControlClasses path, and the
+// label-with-decorations branch.
+func TestCoverageWithIcons(t *testing.T) {
+	html := renderCov(t, Config{
+		ID:           "brightness",
+		Label:        "Brightness",
+		LeadingIcon:  templ.Raw(`<svg id="lead"></svg>`),
+		TrailingIcon: templ.Raw(`<svg id="trail"></svg>`),
+	})
+
+	for _, want := range []string{
+		`<svg id="lead">`,
+		`<svg id="trail">`,
+		`aria-hidden="true"`,
+		`shrink-0`,                       // IconClasses
+		`flex w-full items-center gap-3`, // ControlClasses with decorations
+		`Brightness`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("expected %q in:\n%s", want, html)
+		}
+	}
+
+	// With decorations present the label moves inside the control row, so the
+	// standalone top label branch must NOT render twice.
+	if got := strings.Count(html, `>Brightness</label>`); got != 1 {
+		t.Fatalf("expected exactly one label, got %d in:\n%s", got, html)
+	}
+}
+
+// LeadingIcon alone still takes the decorated ControlClasses branch.
+func TestCoverageLeadingIconOnly(t *testing.T) {
+	html := renderCov(t, Config{ID: "x", LeadingIcon: templ.Raw(`<svg id="only"></svg>`)})
+
+	if !strings.Contains(html, `<svg id="only">`) {
+		t.Fatalf("expected leading icon in:\n%s", html)
+	}
+	if !strings.Contains(html, `flex w-full items-center gap-3`) {
+		t.Fatalf("expected decorated control row in:\n%s", html)
+	}
+}
+
+// RootClass and InputClass exercise the non-empty branches of RootClasses and
+// InputClasses.
+func TestCoverageExtraClasses(t *testing.T) {
+	html := renderCov(t, Config{
+		ID:         "x",
+		RootClass:  "my-root-extra",
+		InputClass: "my-input-extra",
+	})
+
+	for _, want := range []string{"my-root-extra", "my-input-extra"} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("expected %q in:\n%s", want, html)
+		}
+	}
+}
+
+// InputAttrs spreads arbitrary hx-*/x-* hooks onto the native input.
+func TestCoverageInputAttrs(t *testing.T) {
+	html := renderCov(t, Config{
+		ID:   "x",
+		Name: "x",
+		InputAttrs: templ.Attributes{
+			"hx-post":   "/api/range",
+			"data-test": "range-hook",
+		},
+	})
+
+	for _, want := range []string{`hx-post="/api/range"`, `data-test="range-hook"`} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("expected %q in:\n%s", want, html)
+		}
+	}
+}
+
+// AlpineData must fall back to 0 for non-numeric values rather than emitting
+// invalid Alpine state.
+func TestCoverageAlpineDataInvalidValue(t *testing.T) {
+	cfg := Config{ID: "x", Value: "not-a-number", ShowValue: true}
+	if got := cfg.AlpineData(); got != "{ currentVal: 0 }" {
+		t.Fatalf("expected fallback alpine data, got %q", got)
+	}
+
+	html := renderCov(t, cfg)
+	if !strings.Contains(html, `x-data="{ currentVal: 0 }"`) {
+		t.Fatalf("expected sanitized x-data in:\n%s", html)
+	}
+}
+
+// AlpineData should preserve fractional values exactly.
+func TestCoverageAlpineDataFractional(t *testing.T) {
+	cfg := Config{Value: "12.5"}
+	if got := cfg.AlpineData(); got != "{ currentVal: 12.5 }" {
+		t.Fatalf("expected fractional alpine data, got %q", got)
+	}
+}
+
+// Custom Ticks take the override branch of TickLabels and render verbatim.
+func TestCoverageCustomTicks(t *testing.T) {
+	html := renderCov(t, Config{
+		ID:        "x",
+		ShowTicks: true,
+		Ticks: []Tick{
+			{Label: "Low"},
+			{Label: "Mid", HideOnMobile: true},
+			{Label: "High"},
+		},
+	})
+
+	for _, want := range []string{`>Low</span>`, `>Mid</span>`, `>High</span>`, `hidden sm:inline`} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("expected %q in:\n%s", want, html)
+		}
+	}
+	// Exactly the three custom ticks, not the default 21-mark scale.
+	if got := strings.Count(html, `aria-hidden="true"`); got != 1 {
+		t.Fatalf("expected single tick row wrapper, got %d in:\n%s", got, html)
+	}
+}
+
+// TickClasses returns the non-hidden base classes when HideOnMobile is false.
+func TestCoverageTickClassesVisible(t *testing.T) {
+	cfg := Config{}
+	visible := cfg.TickClasses(Tick{Label: "0"})
+	if strings.Contains(visible, "hidden") {
+		t.Fatalf("expected visible tick classes, got %q", visible)
+	}
+	hidden := cfg.TickClasses(Tick{Label: "|", HideOnMobile: true})
+	if !strings.Contains(hidden, "hidden sm:inline") {
+		t.Fatalf("expected hidden tick classes, got %q", hidden)
+	}
+}
+
+// StepOrDefault defaults to "1" and honors an explicit step.
+func TestCoverageStepOrDefault(t *testing.T) {
+	if got := (Config{}).StepOrDefault(); got != "1" {
+		t.Fatalf("expected default step 1, got %q", got)
+	}
+	if got := (Config{Step: "5"}).StepOrDefault(); got != "5" {
+		t.Fatalf("expected step 5, got %q", got)
+	}
+}
+
+// ShowValue with no label and no icons still routes through the decorated
+// control row (ShowValue forces it) and renders the live badge.
+func TestCoverageShowValueNoLabel(t *testing.T) {
+	html := renderCov(t, Config{ID: "x", Value: "7", ShowValue: true})
+
+	if !strings.Contains(html, `flex w-full items-center gap-3`) {
+		t.Fatalf("expected decorated control row in:\n%s", html)
+	}
+	if !strings.Contains(html, `x-text="currentVal"`) || !strings.Contains(html, `>7</span>`) {
+		t.Fatalf("expected live value badge in:\n%s", html)
+	}
+}

--- a/site/tests/e2e/range_coverage_test.go
+++ b/site/tests/e2e/range_coverage_test.go
@@ -1,0 +1,111 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRangeCoverageDemo complements range_test.go with a clean-load check (no JS
+// exceptions / console errors), keyboard-driven live value updates, icon
+// decoration semantics, and a dark-mode regression. filterIgnorable is defined
+// in alert_coverage_test.go; waitForAlpine in modal_test.go.
+func TestRangeCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newIsolatedPage(t)
+
+	var pageErrors []string
+	page.On("pageerror", func(err error) { pageErrors = append(pageErrors, err.Error()) })
+
+	var consoleErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			consoleErrors = append(consoleErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/range", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, page.Locator("#range-fragment").WaitFor())
+	require.NoError(t, waitForAlpine(page))
+
+	t.Run("heading and all variant frames render", func(t *testing.T) {
+		require.NoError(t, page.Locator("main").Filter(playwright.LocatorFilterOptions{
+			HasText: "Range",
+		}).First().WaitFor())
+
+		for _, id := range []string{
+			"#range-default", "#range-ticks", "#range-icons",
+			"#range-value", "#range-disabled",
+		} {
+			require.NoError(t, page.Locator(id).WaitFor(), "missing variant frame %s", id)
+		}
+	})
+
+	t.Run("keyboard arrow drives the live value badge", func(t *testing.T) {
+		input := page.Locator("#rangeValue")
+		require.NoError(t, input.WaitFor())
+
+		// Start from a known value, then step up once with the keyboard. The
+		// Alpine x-model badge should track the native input live.
+		require.NoError(t, input.Fill("50"))
+		_, err := page.WaitForFunction(
+			"() => document.querySelector('#range-value [x-text=\"currentVal\"]').textContent === '50'", nil)
+		require.NoError(t, err)
+
+		require.NoError(t, input.Focus())
+		require.NoError(t, page.Keyboard().Press("ArrowRight"))
+
+		_, err = page.WaitForFunction(
+			"() => document.querySelector('#range-value [x-text=\"currentVal\"]').textContent === '51'", nil)
+		require.NoError(t, err)
+
+		badge, err := page.Locator("#range-value [x-text='currentVal']").TextContent()
+		require.NoError(t, err)
+		assert.Equal(t, "51", badge)
+	})
+
+	t.Run("icons are aria-hidden decorations around the native input", func(t *testing.T) {
+		decorations := page.Locator("#range-icons span[aria-hidden='true']")
+		count, err := decorations.Count()
+		require.NoError(t, err)
+		assert.Equal(t, 2, count, "leading and trailing icon wrappers")
+
+		// The native range input stays the single interactive control.
+		inputs, err := page.Locator("#range-icons input[type='range']").Count()
+		require.NoError(t, err)
+		assert.Equal(t, 1, inputs)
+	})
+
+	t.Run("disabled range blocks interaction", func(t *testing.T) {
+		disabled, err := page.Locator("#rangeDisabled").IsDisabled()
+		require.NoError(t, err)
+		assert.True(t, disabled)
+	})
+
+	t.Run("sliders survive a dark-mode toggle", func(t *testing.T) {
+		before, err := page.Evaluate("() => document.documentElement.classList.contains('dark')", nil)
+		require.NoError(t, err)
+		beforeBool, _ := before.(bool)
+
+		_, err = page.Evaluate(`() => { document.documentElement.classList.toggle('dark'); }`, nil)
+		require.NoError(t, err)
+
+		after, err := page.Evaluate("() => document.documentElement.classList.contains('dark')", nil)
+		require.NoError(t, err)
+		afterBool, _ := after.(bool)
+		assert.NotEqual(t, beforeBool, afterBool, "dark class should toggle")
+
+		require.NoError(t, page.Locator("#rangeDefault").WaitFor())
+	})
+
+	require.Empty(t, pageErrors, "uncaught JS exceptions on range demo")
+	require.Empty(t, filterIgnorable(consoleErrors), "console errors on range demo")
+}


### PR DESCRIPTION
Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 030-range.md
Coverage focus: components/range

Raises `components/range` coverage from 59.4% by exercising previously-uncovered branches:
- `IconClasses` (0% baseline) + leading/trailing icon and decorated control-row paths in `rangeInner`
- custom `Ticks` override branch of `TickLabels`
- `AlpineData` non-numeric fallback to `0` and fractional preservation
- `RootClass` / `InputClass` / `InputAttrs` config hooks
- `StepOrDefault` and `TickClasses` visible/hidden branches

All `types.go` funcs now report 100%. E2E (`TestRangeCoverageDemo`) adds a clean-load check (no console/pageerror), keyboard-driven live value updates via Alpine `x-model`, icon `aria-hidden` decoration semantics, disabled state, and a dark-mode regression — following existing harness conventions (`newIsolatedPage`, `waitForAlpine`, inline `page.On("console", ...)`, `filterIgnorable`).

No production source changed (no bugs exposed); no `.templ` changes so no regeneration. `badges/coverage.svg` intentionally excluded to avoid parallel-PR conflicts.

Verification:
- `go test ./components/range -count=1`
- `go test ./site/tests/e2e/... -run 'Range' -timeout 5m`
- `just coverage` (full gate, green — total 63.0%)

Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)