### PR TITLE
test(palette): add unit + e2e coverage

### DIFF
--- a/components/palette/palette_coverage_test.go
+++ b/components/palette/palette_coverage_test.go
@@ -1,0 +1,88 @@
+package palette
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPalette_CustomHuesShades exercises the c.Hues / c.Shades override
+// branches in hues()/shades() and the swatchGrid loops over custom sets.
+func TestPalette_CustomHuesShades(t *testing.T) {
+	html := render(t, Config{
+		ID:     "p",
+		Hues:   []string{"red", "blue"},
+		Shades: []string{"100", "500"},
+	})
+	// 2 hues × 2 shades = 4 grid swatches, plus white/black neutrals.
+	assert.Equal(t, 4, strings.Count(html, "background-color: var(--color-"))
+	assert.Contains(t, html, `data-cls="red-100"`)
+	assert.Contains(t, html, `data-cls="red-500"`)
+	assert.Contains(t, html, `data-cls="blue-100"`)
+	assert.Contains(t, html, `data-cls="blue-500"`)
+	// Default sets must NOT leak when overridden.
+	assert.NotContains(t, html, `data-cls="green-700"`)
+	assert.NotContains(t, html, `data-cls="red-950"`)
+}
+
+// TestConfig_HuesShadesDefaults covers the default-return branch directly.
+func TestConfig_HuesShadesDefaults(t *testing.T) {
+	c := Config{}
+	assert.Equal(t, DefaultHues, c.hues())
+	assert.Equal(t, DefaultShades, c.shades())
+
+	c2 := Config{Hues: []string{"teal"}, Shades: []string{"300"}}
+	assert.Equal(t, []string{"teal"}, c2.hues())
+	assert.Equal(t, []string{"300"}, c2.shades())
+}
+
+// TestConfig_ContainerClasses covers both the plain and RootClass-appended
+// branches of ContainerClasses().
+func TestConfig_ContainerClasses(t *testing.T) {
+	assert.Equal(t, "p-2 space-y-2", Config{}.ContainerClasses())
+	assert.Equal(t, "p-2 space-y-2 my-extra", Config{RootClass: "my-extra"}.ContainerClasses())
+}
+
+// TestPalette_RootClassRendered confirms RootClass reaches the wrapper class.
+func TestPalette_RootClassRendered(t *testing.T) {
+	html := render(t, Config{ID: "p", RootClass: "w-64 shadow"})
+	assert.Contains(t, html, `class="p-2 space-y-2 w-64 shadow"`)
+}
+
+// TestPalette_LazyWhen wraps the swatch grid in <template x-if> so the grid
+// mounts lazily; covers the LazyWhen branch in Palette.
+func TestPalette_LazyWhen(t *testing.T) {
+	html := render(t, Config{ID: "p", LazyWhen: "open"})
+	assert.Contains(t, html, `<template x-if="open">`)
+	// Grid still rendered inside the template.
+	assert.Contains(t, html, `data-cls="blue-700"`)
+
+	// Without LazyWhen, no x-if template wraps the grid.
+	plain := render(t, Config{ID: "p"})
+	assert.NotContains(t, plain, "<template x-if")
+}
+
+// TestConfig_ModelAssignExpr covers both branches of modelAssignExpr().
+func TestConfig_ModelAssignExpr(t *testing.T) {
+	assert.Equal(t, "", Config{}.modelAssignExpr())
+	assert.Equal(t, "", Config{Alpine: &AlpineConfig{}}.modelAssignExpr())
+	assert.Equal(t, "c = $event.detail", Config{Alpine: &AlpineConfig{Model: "c"}}.modelAssignExpr())
+}
+
+// TestPalette_NoModelNoListener confirms the x-on:select-close attribute is
+// absent when no Alpine model is configured.
+func TestPalette_NoModelNoListener(t *testing.T) {
+	html := render(t, Config{ID: "p"})
+	assert.NotContains(t, html, "x-on:select-close")
+}
+
+// TestPalette_HideNeutralKeepsGrid covers HideNeutral while keeping the hue
+// grid, ensuring only the white/black quick swatches drop.
+func TestPalette_HideNeutralKeepsGrid(t *testing.T) {
+	html := render(t, Config{ID: "p", HideNeutral: true})
+	assert.NotContains(t, html, `data-cls="white"`)
+	assert.NotContains(t, html, `data-cls="black"`)
+	assert.Contains(t, html, `data-cls="blue-700"`)
+	assert.Contains(t, html, "Reset") // reset still present
+}

--- a/site/tests/e2e/palette_coverage_test.go
+++ b/site/tests/e2e/palette_coverage_test.go
@@ -1,0 +1,113 @@
+package e2e
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/require"
+)
+
+// gotoPalette navigates to the palette demo and waits for Alpine to boot.
+func gotoPalette(t *testing.T, page playwright.Page) {
+	t.Helper()
+	_, err := page.Goto(baseURL+"/components/palette", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	_, err = page.WaitForFunction(`() => typeof Alpine !== 'undefined'`, nil,
+		playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)})
+	require.NoError(t, err)
+}
+
+// TestPalette_ResetClearsModel picks a swatch, then clicks Reset and asserts the
+// bound model returns to the empty placeholder ("—"). Covers the Reset
+// pick('', null) branch.
+func TestPalette_ResetClearsModel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+	gotoPalette(t, page)
+
+	require.NoError(t, page.Locator(`#demo-palette button[data-cls="blue-700"]`).Click())
+	_, err := page.WaitForFunction(
+		`() => document.querySelector('#palette-standalone p span[x-text]').textContent.trim() === 'blue-700'`,
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)})
+	require.NoError(t, err, "pick should set the model to blue-700")
+
+	// Reset is the button rendered next to the hovered label in the standalone root.
+	require.NoError(t, page.Locator(`#demo-palette button:has-text("Reset")`).Click())
+	_, err = page.WaitForFunction(
+		`() => document.querySelector('#palette-standalone p span[x-text]').textContent.trim() === '—'`,
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)})
+	require.NoError(t, err, "Reset should clear the model back to the placeholder")
+
+	// The hex text input should also be cleared by syncHex('').
+	val, err := page.Locator(`#demo-palette input[type="text"]`).InputValue()
+	require.NoError(t, err)
+	require.Equal(t, "", val)
+}
+
+// TestPalette_HoverShowsLabel hovers a swatch and asserts the hovered readout
+// (x-text="hovered || 'Pick a color'") reflects the swatch data-cls.
+func TestPalette_HoverShowsLabel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+	gotoPalette(t, page)
+
+	label := page.Locator(`#demo-palette span[x-text="hovered || 'Pick a color'"]`)
+	require.NoError(t, label.WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible, Timeout: playwright.Float(2000),
+	}))
+
+	require.NoError(t, page.Locator(`#demo-palette button[data-cls="green-500"]`).Hover())
+	_, err := page.WaitForFunction(
+		`() => document.querySelector('#demo-palette span[x-text="hovered || \'Pick a color\'"]').textContent.trim() === 'green-500'`,
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)})
+	require.NoError(t, err, "hovering a swatch should update the hovered label")
+}
+
+// TestPalette_NoConsoleErrors loads the demo, exercises a pick and a hex commit,
+// and asserts no console errors were emitted (Alpine binding / escaping smoke).
+func TestPalette_NoConsoleErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	var mu sync.Mutex
+	var consoleErrors []string
+	page.On("console", func(msg playwright.ConsoleMessage) {
+		if msg.Type() == "error" {
+			mu.Lock()
+			consoleErrors = append(consoleErrors, msg.Text())
+			mu.Unlock()
+		}
+	})
+
+	gotoPalette(t, page)
+
+	require.NoError(t, page.Locator(`#demo-palette button[data-cls="blue-700"]`).Click())
+	_, err := page.WaitForFunction(
+		`() => document.querySelector('#palette-standalone p span[x-text]').textContent.trim() === 'blue-700'`,
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)})
+	require.NoError(t, err)
+
+	input := page.Locator(`#demo-palette input[type="text"]`)
+	require.NoError(t, input.Fill("#abc"))
+	require.NoError(t, input.Blur())
+	_, err = page.WaitForFunction(
+		`() => document.querySelector('#palette-standalone p span[x-text]').textContent.trim() === '#aabbcc'`,
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Empty(t, consoleErrors, "palette demo should emit no console errors")
+}


### PR DESCRIPTION
Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 031-palette.md
Coverage focus: components/palette
Verification: go test ./components/palette -count=1; go test ./site/tests/e2e/... -run Palette; just coverage (exit 0)
Auto-merge: OK once CI is green

## Summary

Raise `components/palette` coverage 64.5% -> 73.8% (unit). All `types.go`
helpers (hues/shades/ContainerClasses/swatchStyle/modelAssignExpr) now 100%.
Remaining gaps are generated templ error-return branches.

**Unit** (`components/palette/palette_coverage_test.go`): custom Hues/Shades
override branches, RootClass append, LazyWhen `<template x-if>` wrap,
model-listener presence/absence, HideNeutral-keeps-grid.

**E2E** (`site/tests/e2e/palette_coverage_test.go`): Reset clears the bound
model and hex input, hover updates the hovered label, and a console-error
smoke check across pick + hex commit. Console errors captured inline via
`page.On("console", ...)`.

No production bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)