### PR TITLE
test(rating): add unit + e2e coverage

### DIFF
--- a/components/rating/rating_coverage_test.go
+++ b/components/rating/rating_coverage_test.go
@@ -1,0 +1,276 @@
+package rating
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+)
+
+func renderRating(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := Rating(cfg).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("render rating: %v", err)
+	}
+	return buf.String()
+}
+
+func TestResolvedIDFallbacks(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"explicit id", Config{ID: "explicit", Name: "n"}, "explicit"},
+		{"name fallback", Config{Name: "field"}, "field"},
+		{"default", Config{}, "rating"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.ResolvedID(); got != tt.want {
+				t.Fatalf("ResolvedID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvedName(t *testing.T) {
+	if got := (Config{Name: "field"}).ResolvedName(); got != "field" {
+		t.Fatalf("ResolvedName with Name = %q, want %q", got, "field")
+	}
+	// No name: falls back to ResolvedID which falls back to "rating".
+	if got := (Config{ID: "rid"}).ResolvedName(); got != "rid" {
+		t.Fatalf("ResolvedName fallback to ID = %q, want %q", got, "rid")
+	}
+	if got := (Config{}).ResolvedName(); got != "rating" {
+		t.Fatalf("ResolvedName default = %q, want %q", got, "rating")
+	}
+}
+
+func TestResolvedMax(t *testing.T) {
+	if got := (Config{Max: 10}).ResolvedMax(); got != 10 {
+		t.Fatalf("ResolvedMax(10) = %d, want 10", got)
+	}
+	if got := (Config{}).ResolvedMax(); got != 5 {
+		t.Fatalf("ResolvedMax default = %d, want 5", got)
+	}
+	if got := (Config{Max: -2}).ResolvedMax(); got != 5 {
+		t.Fatalf("ResolvedMax(-2) = %d, want default 5", got)
+	}
+}
+
+func TestResolvedValueClamping(t *testing.T) {
+	if got := (Config{Value: -5}).ResolvedValue(); got != 0 {
+		t.Fatalf("ResolvedValue(-5) = %d, want 0", got)
+	}
+	if got := (Config{Value: 99, Max: 5}).ResolvedValue(); got != 5 {
+		t.Fatalf("ResolvedValue(99) = %d, want 5", got)
+	}
+	if got := (Config{Value: 3}).ResolvedValue(); got != 3 {
+		t.Fatalf("ResolvedValue(3) = %d, want 3", got)
+	}
+}
+
+func TestResolvedLabel(t *testing.T) {
+	if got := (Config{Label: "Stars"}).ResolvedLabel(); got != "Stars" {
+		t.Fatalf("ResolvedLabel(Stars) = %q", got)
+	}
+	if got := (Config{}).ResolvedLabel(); got != "Rating" {
+		t.Fatalf("ResolvedLabel default = %q, want Rating", got)
+	}
+}
+
+func TestRootClasses(t *testing.T) {
+	base := (Config{}).RootClasses()
+	if !strings.Contains(base, "inline-flex flex-col gap-2") {
+		t.Fatalf("RootClasses missing base: %q", base)
+	}
+	if strings.Contains(base, "custom") {
+		t.Fatalf("RootClasses should not contain custom when Class empty: %q", base)
+	}
+	withClass := (Config{Class: "custom-class"}).RootClasses()
+	if !strings.Contains(withClass, "custom-class") {
+		t.Fatalf("RootClasses missing appended Class: %q", withClass)
+	}
+}
+
+func TestControlClasses(t *testing.T) {
+	interactive := (Config{}).ControlClasses()
+	if !strings.Contains(interactive, "focus-within:outline-2") {
+		t.Fatalf("interactive ControlClasses should add focus outline: %q", interactive)
+	}
+	readOnly := (Config{ReadOnly: true}).ControlClasses()
+	if strings.Contains(readOnly, "focus-within:outline-2") {
+		t.Fatalf("read-only ControlClasses should not add focus outline: %q", readOnly)
+	}
+}
+
+func TestIconClassesSizes(t *testing.T) {
+	tests := []struct {
+		size Size
+		want string
+	}{
+		{SizeSM, "size-5 text-lg"},
+		{SizeLG, "size-8 text-3xl"},
+		{SizeXL, "size-10 text-4xl"},
+		{SizeMD, "size-6 text-2xl"},
+		{Size("unknown"), "size-6 text-2xl"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.size), func(t *testing.T) {
+			got := (Config{Size: tt.size}).IconClasses()
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("IconClasses(%q) = %q, want substring %q", tt.size, got, tt.want)
+			}
+			if strings.Contains(got, "opacity-60") {
+				t.Fatalf("IconClasses should not dim when enabled: %q", got)
+			}
+		})
+	}
+	disabled := (Config{Disabled: true}).IconClasses()
+	if !strings.Contains(disabled, "opacity-60") {
+		t.Fatalf("disabled IconClasses should dim: %q", disabled)
+	}
+}
+
+func TestActiveInactiveIconClasses(t *testing.T) {
+	star := Config{Style: StyleStars}
+	if got := star.ActiveIconClasses(); got != "text-warning" {
+		t.Fatalf("star ActiveIconClasses = %q", got)
+	}
+	if !strings.Contains(star.InactiveIconClasses(), "text-on-surface-muted") {
+		t.Fatalf("star InactiveIconClasses = %q", star.InactiveIconClasses())
+	}
+	emoji := Config{Style: StyleEmoji}
+	if !strings.Contains(emoji.ActiveIconClasses(), "scale-110") {
+		t.Fatalf("emoji ActiveIconClasses = %q", emoji.ActiveIconClasses())
+	}
+	if !strings.Contains(emoji.InactiveIconClasses(), "grayscale") {
+		t.Fatalf("emoji InactiveIconClasses = %q", emoji.InactiveIconClasses())
+	}
+}
+
+func TestXDataAndInputID(t *testing.T) {
+	if got := (Config{Value: 2}).XData(); got != "{ currentVal: 2 }" {
+		t.Fatalf("XData = %q", got)
+	}
+	if got := (Config{ID: "r"}).InputID(3); got != "r-3" {
+		t.Fatalf("InputID = %q, want r-3", got)
+	}
+}
+
+func TestValueLabel(t *testing.T) {
+	star := Config{Style: StyleStars}
+	if got := star.ValueLabel(1); got != "one star" {
+		t.Fatalf("ValueLabel(1) = %q, want 'one star'", got)
+	}
+	if got := star.ValueLabel(3); got != "3 stars" {
+		t.Fatalf("ValueLabel(3) = %q, want '3 stars'", got)
+	}
+	emoji := Config{Style: StyleEmoji}
+	if got := emoji.ValueLabel(3); got != "neutral" {
+		t.Fatalf("emoji ValueLabel(3) = %q, want 'neutral'", got)
+	}
+	// Emoji with value outside the default option set falls back to star wording.
+	if got := emoji.ValueLabel(9); got != "9 stars" {
+		t.Fatalf("emoji ValueLabel(9) = %q, want '9 stars'", got)
+	}
+	if got := emoji.ValueLabel(1); got != "very dissatisfied" {
+		t.Fatalf("emoji ValueLabel(1) = %q", got)
+	}
+}
+
+func TestEmojiIcon(t *testing.T) {
+	cfg := Config{Style: StyleEmoji}
+	if got := cfg.EmojiIcon(5); got != "😍" {
+		t.Fatalf("EmojiIcon(5) = %q, want 😍", got)
+	}
+	if got := cfg.EmojiIcon(99); got != "🙂" {
+		t.Fatalf("EmojiIcon(99) fallback = %q, want 🙂", got)
+	}
+}
+
+func TestBindClass(t *testing.T) {
+	emoji := (Config{Style: StyleEmoji}).BindClass(2)
+	if !strings.Contains(emoji, "currentVal === 2") {
+		t.Fatalf("emoji BindClass = %q", emoji)
+	}
+	star := (Config{Style: StyleStars}).BindClass(2)
+	if !strings.Contains(star, "currentVal >= 2") {
+		t.Fatalf("star BindClass = %q", star)
+	}
+}
+
+func TestReadOnlyIconState(t *testing.T) {
+	cfg := Config{Style: StyleStars, Value: 3}
+	if got := readOnlyIconState(cfg, 2); got != cfg.ActiveIconClasses() {
+		t.Fatalf("readOnlyIconState active = %q", got)
+	}
+	if got := readOnlyIconState(cfg, 4); got != cfg.InactiveIconClasses() {
+		t.Fatalf("readOnlyIconState inactive = %q", got)
+	}
+}
+
+func TestRenderShowLabel(t *testing.T) {
+	html := renderRating(t, Config{Label: "Quality", ShowLabel: true, Value: 2})
+	if !strings.Contains(html, ">Quality<") {
+		t.Fatalf("ShowLabel should render visible label:\n%s", html)
+	}
+	hidden := renderRating(t, Config{Label: "Quality", Value: 2})
+	if strings.Contains(hidden, `class="text-sm font-medium`) {
+		t.Fatalf("label span should be absent when ShowLabel false:\n%s", hidden)
+	}
+}
+
+func TestRenderDisabledInputs(t *testing.T) {
+	html := renderRating(t, Config{Value: 2, Disabled: true})
+	if !strings.Contains(html, "disabled") {
+		t.Fatalf("disabled rating should render disabled inputs:\n%s", html)
+	}
+	if !strings.Contains(html, "opacity-60") {
+		t.Fatalf("disabled rating icons should dim:\n%s", html)
+	}
+}
+
+func TestRenderReadOnlyEmoji(t *testing.T) {
+	html := renderRating(t, Config{Style: StyleEmoji, ReadOnly: true, Value: 3})
+	if strings.Contains(html, `type="radio"`) {
+		t.Fatalf("read-only emoji must not render radios:\n%s", html)
+	}
+	if !strings.Contains(html, `role="img"`) {
+		t.Fatalf("read-only rating should render role=img:\n%s", html)
+	}
+	if !strings.Contains(html, `aria-label="neutral"`) {
+		t.Fatalf("read-only emoji aria-label should use sentiment:\n%s", html)
+	}
+	if !strings.Contains(html, "😐") {
+		t.Fatalf("read-only emoji should render emoji icons:\n%s", html)
+	}
+}
+
+func TestRenderSizesAndAttrs(t *testing.T) {
+	html := renderRating(t, Config{
+		Size:  SizeLG,
+		Value: 1,
+		Attrs: templ.Attributes{"data-test": "rating-root"},
+	})
+	if !strings.Contains(html, "size-8") {
+		t.Fatalf("large rating should use size-8 icons:\n%s", html)
+	}
+	if !strings.Contains(html, `data-test="rating-root"`) {
+		t.Fatalf("Attrs escape hatch should apply to root:\n%s", html)
+	}
+}
+
+func TestRenderCustomMax(t *testing.T) {
+	html := renderRating(t, Config{ID: "r", Max: 3, Value: 2})
+	if !strings.Contains(html, `id="r-3"`) {
+		t.Fatalf("custom max should render option 3:\n%s", html)
+	}
+	if strings.Contains(html, `id="r-4"`) {
+		t.Fatalf("custom max=3 should not render option 4:\n%s", html)
+	}
+}

--- a/site/tests/e2e/rating_coverage_test.go
+++ b/site/tests/e2e/rating_coverage_test.go
@@ -1,0 +1,86 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// iconClassForLabel reads the live (Alpine-bound) class of the visual icon span
+// inside the label for the given input id.
+func iconClassForLabel(t *testing.T, page playwright.Page, inputID string) string {
+	t.Helper()
+	loc := page.Locator("label[for='" + inputID + "'] span[aria-hidden='true']")
+	v, err := loc.Evaluate("el => el.getAttribute('class')", nil)
+	require.NoError(t, err)
+	class, ok := v.(string)
+	require.True(t, ok)
+	return class
+}
+
+func TestRating_LiveStarBindingHighlightsCumulative(t *testing.T) {
+	page := newPage(t, sharedBrowser)
+	navigateToRatingDemo(t, page)
+
+	// Default value is 3: stars 1..3 active, 4..5 inactive.
+	assert.Contains(t, iconClassForLabel(t, page, "rating-stars-3"), "text-warning")
+	assert.NotContains(t, iconClassForLabel(t, page, "rating-stars-5"), "text-warning")
+
+	require.NoError(t, page.Locator("label[for='rating-stars-5']").Click())
+
+	// After selecting 5, all stars become active (cumulative binding).
+	for _, id := range []string{"rating-stars-1", "rating-stars-3", "rating-stars-5"} {
+		assert.Contains(t, iconClassForLabel(t, page, id), "text-warning",
+			"star %s should be active after selecting 5", id)
+	}
+}
+
+func TestRating_KeyboardArrowSelects(t *testing.T) {
+	page := newPage(t, sharedBrowser)
+	navigateToRatingDemo(t, page)
+
+	require.NoError(t, page.Locator("#rating-stars-3").Focus())
+	require.NoError(t, page.Keyboard().Press("ArrowRight"))
+
+	assert.True(t, ratingChecked(t, page, "#rating-stars-4"),
+		"arrow-right should move radio selection to the next star")
+	// Live binding should follow the keyboard-driven selection.
+	assert.Contains(t, iconClassForLabel(t, page, "rating-stars-4"), "text-warning")
+}
+
+func TestRating_SizesRenderDistinctIconScales(t *testing.T) {
+	page := newPage(t, sharedBrowser)
+	navigateToRatingDemo(t, page)
+
+	cases := map[string]string{
+		"rating-size-sm-1": "size-5",
+		"rating-size-lg-1": "size-8",
+		"rating-size-xl-1": "size-10",
+	}
+	for inputID, wantClass := range cases {
+		assert.Contains(t, iconClassForLabel(t, page, inputID), wantClass,
+			"icon for %s should carry %s", inputID, wantClass)
+	}
+}
+
+func TestRating_DemoLoadsWithoutConsoleErrors(t *testing.T) {
+	page := newPage(t, sharedBrowser)
+
+	var consoleErrors []string
+	page.On("console", func(msg playwright.ConsoleMessage) {
+		if msg.Type() == "error" {
+			consoleErrors = append(consoleErrors, msg.Text())
+		}
+	})
+
+	navigateToRatingDemo(t, page)
+
+	require.NoError(t, page.Locator("label[for='rating-stars-4']").Click())
+	require.NoError(t, page.Locator("label[for='rating-sentiment-2']").Click())
+
+	assert.Empty(t, consoleErrors,
+		"rating demo should not log console errors: %s", strings.Join(consoleErrors, "; "))
+}


### PR DESCRIPTION
Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 033-rating.md
Coverage focus: components/rating

Raises `components/rating` coverage from 65.7% to 71.9%. All `types.go` config helpers now at 100%; remaining gap is generated `_templ.go` error/boilerplate branches.

## Unit (`components/rating/rating_coverage_test.go`)
- `ResolvedID`/`ResolvedName`/`ResolvedMax`/`ResolvedValue`/`ResolvedLabel` fallback + clamp branches
- `RootClasses`, `ControlClasses` (interactive vs read-only), `IconClasses` (all sizes + disabled dim)
- `ActiveIconClasses`/`InactiveIconClasses` (star vs emoji), `BindClass`, `readOnlyIconState`
- `ValueLabel` (one star / N stars / emoji sentiment / emoji-out-of-range fallback), `EmojiIcon` fallback
- Render variants: ShowLabel, disabled inputs, read-only emoji (role=img), sizes, `Attrs` escape hatch, custom Max

## E2E (`site/tests/e2e/rating_coverage_test.go`)
- Live Alpine cumulative star highlight via `x-bind:class`
- Keyboard ArrowRight radio selection + live binding follow
- Distinct icon scale classes per size (sm/lg/xl)
- Console-error-free demo load + selection (inline `page.On("console", ...)`)

Verification: `go test ./components/rating -count=1`; `go test ./site/tests/e2e/... -run TestRating_ -timeout 5m`; `just coverage` (exit 0, rating 71.9%)

Auto-merge: OK once CI is green