### PR TITLE
test(link): add unit + e2e coverage

### DIFF
--- a/components/link/link_coverage_test.go
+++ b/components/link/link_coverage_test.go
@@ -1,0 +1,157 @@
+package link
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+)
+
+// iconStub renders a tiny marker element used to assert icon placement.
+func iconStub() templ.Component {
+	return templ.ComponentFunc(func(ctx context.Context, w io.Writer) error {
+		_, err := io.WriteString(w, `<svg data-icon="stub"></svg>`)
+		return err
+	})
+}
+
+func renderCfg(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := Link(cfg).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("render Link: %v", err)
+	}
+	return buf.String()
+}
+
+func TestButtonSizeClasses(t *testing.T) {
+	cases := []struct {
+		name string
+		size Size
+		want string
+	}{
+		{"small", SizeSmall, "text-xs"},
+		{"medium explicit", SizeMedium, "text-sm"},
+		{"large", SizeLarge, "text-base"},
+		{"xlarge", SizeXLarge, "text-lg"},
+		{"default empty", Size(""), "text-sm"},
+		{"unknown falls back", Size("bogus"), "text-sm"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Config{Size: tc.size}.buttonSizeClasses()
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("size %q: want %q in %q", tc.size, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestRelExplicitOverride(t *testing.T) {
+	// Explicit Rel wins even for a _blank target.
+	html := renderCfg(t, Config{Href: "https://example.com", Target: "_blank", Rel: "nofollow"})
+	if !strings.Contains(html, `rel="nofollow"`) {
+		t.Fatalf("expected explicit rel override: %s", html)
+	}
+	if strings.Contains(html, "noopener") {
+		t.Fatalf("explicit rel should suppress default: %s", html)
+	}
+}
+
+func TestRelOmittedWithoutBlankTarget(t *testing.T) {
+	html := renderCfg(t, Config{Href: "https://example.com", Target: "_self"})
+	if strings.Contains(html, "rel=") {
+		t.Fatalf("expected no rel attribute for non-blank target: %s", html)
+	}
+	if !strings.Contains(html, `target="_self"`) {
+		t.Fatalf("expected target attribute rendered: %s", html)
+	}
+}
+
+func TestRoleExplicitOverride(t *testing.T) {
+	// Explicit Role wins over the StyleButton default.
+	html := renderCfg(t, Config{Style: StyleButton, Role: "link"})
+	if !strings.Contains(html, `role="link"`) {
+		t.Fatalf("expected explicit role override: %s", html)
+	}
+}
+
+func TestRoleOmittedForTextStyle(t *testing.T) {
+	html := renderCfg(t, Config{})
+	if strings.Contains(html, "role=") {
+		t.Fatalf("text link should not emit a role: %s", html)
+	}
+}
+
+func TestIDAttributeRendered(t *testing.T) {
+	html := renderCfg(t, Config{ID: "cta-link"})
+	if !strings.Contains(html, `id="cta-link"`) {
+		t.Fatalf("expected id attribute: %s", html)
+	}
+}
+
+func TestClassAppended(t *testing.T) {
+	html := renderCfg(t, Config{Class: "mt-4 custom-link"})
+	if !strings.Contains(html, "mt-4") || !strings.Contains(html, "custom-link") {
+		t.Fatalf("expected custom classes appended: %s", html)
+	}
+	// Base text classes still present alongside custom ones.
+	if !strings.Contains(html, "text-primary") {
+		t.Fatalf("expected base text classes retained: %s", html)
+	}
+}
+
+func TestIconTrailingDefault(t *testing.T) {
+	html := renderCfg(t, Config{Icon: iconStub()})
+	if !strings.Contains(html, `data-icon="stub"`) {
+		t.Fatalf("expected icon rendered: %s", html)
+	}
+	if !strings.Contains(html, "inline-flex") || !strings.Contains(html, "gap-1.5") {
+		t.Fatalf("expected icon layout classes: %s", html)
+	}
+}
+
+func TestIconLeadingPlacement(t *testing.T) {
+	html := renderCfg(t, Config{
+		Icon:         iconStub(),
+		IconPosition: IconLeading,
+	})
+	iconIdx := strings.Index(html, `data-icon="stub"`)
+	textIdx := strings.Index(html, "</a>")
+	if iconIdx < 0 {
+		t.Fatalf("expected icon rendered: %s", html)
+	}
+	// Leading icon should appear before the closing tag content marker; assert
+	// it precedes any trailing position by checking it renders right after <a>.
+	openIdx := strings.Index(html, ">")
+	if !(openIdx < iconIdx && iconIdx < textIdx) {
+		t.Fatalf("expected leading icon between open tag and close: %s", html)
+	}
+}
+
+func TestAttrsSpread(t *testing.T) {
+	html := renderCfg(t, Config{Attrs: templ.Attributes{
+		"data-testid": "promo",
+		"hx-get":      "/api/x",
+	}})
+	if !strings.Contains(html, `data-testid="promo"`) {
+		t.Fatalf("expected spread data attribute: %s", html)
+	}
+	if !strings.Contains(html, `hx-get="/api/x"`) {
+		t.Fatalf("expected spread hx attribute: %s", html)
+	}
+}
+
+func TestButtonStyleSmallAndXLarge(t *testing.T) {
+	small := renderCfg(t, Config{Style: StyleButton, Size: SizeSmall})
+	if !strings.Contains(small, "text-xs") || !strings.Contains(small, "bg-primary") {
+		t.Fatalf("expected small button classes: %s", small)
+	}
+	xl := renderCfg(t, Config{Style: StyleButton, Size: SizeXLarge})
+	if !strings.Contains(xl, "text-lg") {
+		t.Fatalf("expected xl button classes: %s", xl)
+	}
+}

--- a/site/tests/e2e/link_coverage_test.go
+++ b/site/tests/e2e/link_coverage_test.go
@@ -1,0 +1,77 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLinkCoverageDemo exercises live browser behavior for the link demo:
+// every variant container renders, links are keyboard-focusable, the button
+// link keeps its themed focus-visible outline, and the page stays console
+// clean across the interactions.
+func TestLinkCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	_, browser, _ := setupPlaywright(t)
+	page := newPage(t, browser)
+
+	var consoleErrors []string
+	page.On("console", func(msg playwright.ConsoleMessage) {
+		if msg.Type() == "error" {
+			consoleErrors = append(consoleErrors, msg.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/link", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("#link-fragment").WaitFor())
+
+	t.Run("all variant containers render", func(t *testing.T) {
+		for _, id := range []string{"#link-default", "#link-inline", "#link-icon", "#link-button"} {
+			loc := page.Locator(id)
+			require.NoError(t, loc.WaitFor())
+			anchor := loc.Locator("a").First()
+			require.NoError(t, anchor.WaitFor())
+			visible, err := anchor.IsVisible()
+			require.NoError(t, err)
+			assert.True(t, visible, "anchor in %s should be visible", id)
+		}
+	})
+
+	t.Run("default link is keyboard focusable", func(t *testing.T) {
+		defaultLink := page.Locator("#link-default a").First()
+		require.NoError(t, defaultLink.Focus())
+		focused, err := defaultLink.Evaluate("el => el === document.activeElement", nil)
+		require.NoError(t, err)
+		assert.Equal(t, true, focused)
+	})
+
+	t.Run("button link exposes themed focus outline", func(t *testing.T) {
+		buttonLink := page.Locator("#link-button a").First()
+		className := mustAttribute(t, buttonLink, "class")
+		assert.Contains(t, className, "focus-visible:outline-primary")
+		assert.Contains(t, className, "active:opacity-100")
+
+		require.NoError(t, buttonLink.Focus())
+		focused, err := buttonLink.Evaluate("el => el === document.activeElement", nil)
+		require.NoError(t, err)
+		assert.Equal(t, true, focused)
+	})
+
+	t.Run("inline link stays within paragraph flow", func(t *testing.T) {
+		inlineAnchor := page.Locator("#link-inline p a").First()
+		require.NoError(t, inlineAnchor.WaitFor())
+		href := mustAttribute(t, inlineAnchor, "href")
+		assert.Equal(t, "#", href)
+	})
+
+	assert.Empty(t, consoleErrors, "demo page should not log console errors")
+}


### PR DESCRIPTION
Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 032-link.md
Coverage focus: components/link

Raises component-only coverage for `components/link` from 64.7% baseline. All `types.go` helpers (`href`, `rel`, `role`, `classes`, `textClasses`, `buttonClasses`, `buttonSizeClasses`) now at 100%; the remaining `Link` templ gap (72.8%) is generated error-guard glue not reachable from tests.

## What

- **Unit** (`components/link/link_coverage_test.go`): every config branch — `buttonSizeClasses` (sm/md/lg/xl/default/unknown), explicit `Rel`/`Role` overrides, `ID`/`Target`/`Class`/`Attrs` rendering, leading vs trailing icon placement.
- **E2E** (`site/tests/e2e/link_coverage_test.go`, `TestLinkCoverageDemo`): all four variant containers render, links keyboard-focusable, button link keeps themed focus-visible outline, demo stays console clean.

No production changes — no bugs exposed. No `.templ` changes.

Verification: `go test ./components/link -count=1`; `go test ./site/tests/e2e/... -run 'Link'`; `just coverage` (full gate green, total 62.8%, E2E suite 234s)
Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)