### PR TITLE
test(select): add unit + E2E coverage (55.7% → 76.5%)

### DIFF
--- a/components/select/select_coverage_test.go
+++ b/components/select/select_coverage_test.go
@@ -1,0 +1,228 @@
+package selectfield
+
+import (
+	"html"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Pure helper coverage ---
+
+func TestHelperTextClasses_AllStates(t *testing.T) {
+	assert.Equal(t, "pl-0.5 text-danger", helperTextClasses(StateError))
+	assert.Equal(t, "pl-0.5 text-success", helperTextClasses(StateSuccess))
+	assert.Equal(t, "pl-0.5 text-on-surface-muted dark:text-on-surface-dark-muted", helperTextClasses(StateDefault))
+}
+
+func TestToOptions_MapsAndMarksSelected(t *testing.T) {
+	type region struct{ Code, Name string }
+	regions := []region{
+		{Code: "us-east-1", Name: "US East"},
+		{Code: "eu-west-1", Name: "EU West"},
+	}
+
+	opts := ToOptions(regions,
+		func(r region) string { return r.Code },
+		func(r region) string { return r.Name },
+		"eu-west-1",
+	)
+
+	assert.Len(t, opts, 2)
+	assert.Equal(t, Option{Value: "us-east-1", Label: "US East", Selected: false}, opts[0])
+	assert.Equal(t, Option{Value: "eu-west-1", Label: "EU West", Selected: true}, opts[1])
+}
+
+func TestToOptions_EmptyInput(t *testing.T) {
+	opts := ToOptions(nil,
+		func(s string) string { return s },
+		func(s string) string { return s },
+		"",
+	)
+	assert.Empty(t, opts)
+}
+
+func TestSelectClasses_AllStates(t *testing.T) {
+	errClasses := Config{State: StateError}.SelectClasses()
+	assert.Contains(t, errClasses, "border-danger")
+
+	okClasses := Config{State: StateSuccess}.SelectClasses()
+	assert.Contains(t, okClasses, "border-success")
+
+	defClasses := Config{}.SelectClasses()
+	assert.Contains(t, defClasses, "border-outline dark:border-outline-dark")
+	// shared base survives across states
+	assert.Contains(t, defClasses, "appearance-none")
+}
+
+func TestSelectedValue_ReturnsFirstSelected(t *testing.T) {
+	cfg := Config{Options: []Option{
+		{Value: "a", Label: "A"},
+		{Value: "b", Label: "B", Selected: true},
+		{Value: "c", Label: "C", Selected: true},
+	}}
+	assert.Equal(t, "b", cfg.SelectedValue())
+}
+
+func TestSelectedValue_NoneSelected(t *testing.T) {
+	cfg := Config{Options: []Option{{Value: "a", Label: "A"}}}
+	assert.Equal(t, "", cfg.SelectedValue())
+	assert.Equal(t, "", Config{}.SelectedValue())
+}
+
+func TestLabelClasses_AllStates(t *testing.T) {
+	assert.Equal(t, "flex w-fit gap-1 pl-0.5 text-sm text-danger", Config{State: StateError}.LabelClasses())
+	assert.Equal(t, "flex w-fit gap-1 pl-0.5 text-sm text-success", Config{State: StateSuccess}.LabelClasses())
+	assert.Equal(t, "w-fit pl-0.5 text-sm", Config{}.LabelClasses())
+}
+
+func TestTriggerClasses_StateBranches(t *testing.T) {
+	errClasses := Config{State: StateError}.TriggerClasses()
+	assert.Contains(t, errClasses, "border-danger")
+	assert.Contains(t, errClasses, "bg-surface")
+
+	okClasses := Config{State: StateSuccess}.TriggerClasses()
+	assert.Contains(t, okClasses, "border-success")
+
+	// Readonly is also "effectively disabled" → disabled vocabulary
+	roClasses := Config{Readonly: true, State: StateError}.TriggerClasses()
+	assert.Contains(t, roClasses, "cursor-not-allowed")
+	assert.Contains(t, roClasses, "bg-surface-alt")
+}
+
+func TestContainerClasses_RootClass(t *testing.T) {
+	base := Config{}.ContainerClasses()
+	assert.Contains(t, base, "relative flex w-full flex-col")
+	assert.NotContains(t, base, "custom-root")
+
+	withRoot := Config{RootClass: "custom-root"}.ContainerClasses()
+	assert.Contains(t, withRoot, "custom-root")
+	assert.True(t, strings.HasSuffix(withRoot, " custom-root"))
+}
+
+func TestGetPlaceholder_DefaultAndCustom(t *testing.T) {
+	assert.Equal(t, "Please Select", Config{}.GetPlaceholder())
+	assert.Equal(t, "Pick one", Config{Placeholder: "Pick one"}.GetPlaceholder())
+}
+
+func TestIsEffectivelyDisabled(t *testing.T) {
+	assert.False(t, Config{}.IsEffectivelyDisabled())
+	assert.True(t, Config{Disabled: true}.IsEffectivelyDisabled())
+	assert.True(t, Config{Readonly: true}.IsEffectivelyDisabled())
+}
+
+func TestOptionsToJS_EmptyAndPopulated(t *testing.T) {
+	assert.Equal(t, "[]", optionsToJS(nil))
+	assert.Equal(t, "[]", optionsToJS([]Option{}))
+	assert.Equal(t,
+		"[{value:'a',label:'A'},{value:'b',label:'B'}]",
+		optionsToJS([]Option{{Value: "a", Label: "A"}, {Value: "b", Label: "B"}}),
+	)
+}
+
+// --- Render branch coverage ---
+
+func TestRenderSelect_LabelWithErrorIconAndHelperText(t *testing.T) {
+	out := renderSelect(t, Config{
+		ID:         "country",
+		Label:      "Country",
+		State:      StateError,
+		HelperText: "Required",
+		Options:    []Option{{Value: "us", Label: "US"}},
+	}, nil)
+
+	assert.Contains(t, out, `<label for="country"`)
+	assert.Contains(t, out, "Country")
+	// error icon path fragment
+	assert.Contains(t, out, "M5.28 4.22a.75.75")
+	assert.Contains(t, out, "Required")
+	assert.Contains(t, out, "text-danger")
+}
+
+func TestRenderSelect_LabelWithSuccessIcon(t *testing.T) {
+	out := renderSelect(t, Config{
+		ID:      "country",
+		Label:   "Country",
+		State:   StateSuccess,
+		Options: []Option{{Value: "us", Label: "US"}},
+	}, nil)
+
+	// success icon path fragment
+	assert.Contains(t, out, "M12.416 3.376a.75.75")
+}
+
+func TestRenderSelect_AutocompleteAttribute(t *testing.T) {
+	out := renderSelect(t, Config{
+		ID:           "country",
+		Name:         "country",
+		Autocomplete: "country-name",
+		Options:      []Option{{Value: "us", Label: "US"}},
+	}, nil)
+
+	assert.Contains(t, out, `autocomplete="country-name"`)
+}
+
+func TestRenderSelect_AlpineBindDisabled(t *testing.T) {
+	out := renderSelect(t, Config{
+		ID:      "country",
+		Alpine:  &AlpineConfig{BindDisabled: "isLoading"},
+		Options: []Option{{Value: "us", Label: "US"}},
+	}, nil)
+
+	browserHTML := html.UnescapeString(out)
+	assert.Contains(t, browserHTML, `x-bind:disabled="isLoading"`)
+}
+
+func TestRenderSelect_AlpineModelInitWatcher(t *testing.T) {
+	out := renderSelect(t, Config{
+		ID:      "country",
+		Alpine:  &AlpineConfig{Model: "form.country"},
+		Options: []Option{{Value: "us", Label: "US", Selected: true}},
+	}, nil)
+
+	browserHTML := html.UnescapeString(out)
+	assert.Contains(t, browserHTML, "this.$watch('selectedOption'")
+	assert.Contains(t, browserHTML, "form.country")
+}
+
+func TestRenderSelect_ShellModeWithTriggerLabel(t *testing.T) {
+	out := renderSelect(t, Config{
+		ID:           "role",
+		Shell:        true,
+		TriggerLabel: "Role",
+		ValueExpr:    "roleLabel()",
+		Label:        "Access",
+	}, nil)
+
+	browserHTML := html.UnescapeString(out)
+	assert.Contains(t, browserHTML, "Role")
+	assert.Contains(t, browserHTML, `x-text="roleLabel()"`)
+	// shell mode omits the hidden form input + option list
+	assert.NotContains(t, out, `type="text"`)
+	assert.NotContains(t, out, "allOptions")
+}
+
+func TestRenderSelect_ShellModeWithTriggerLeading(t *testing.T) {
+	out := renderSelect(t, Config{
+		ID:             "swatch",
+		Shell:          true,
+		ValueExpr:      "swatchLabel()",
+		TriggerLeading: templ.Raw(`<span data-test-swatch aria-hidden="true"></span>`),
+	}, templ.Raw(`<div data-test-body></div>`))
+
+	assert.Contains(t, out, "data-test-swatch")
+	assert.Contains(t, out, "data-test-body")
+}
+
+func TestRenderSelect_DisabledTrigger(t *testing.T) {
+	out := renderSelect(t, Config{
+		ID:       "country",
+		Disabled: true,
+		Options:  []Option{{Value: "us", Label: "US"}},
+	}, nil)
+
+	assert.Contains(t, out, "disabled")
+	assert.Contains(t, out, "cursor-not-allowed")
+}

--- a/site/tests/e2e/select_coverage_test.go
+++ b/site/tests/e2e/select_coverage_test.go
@@ -1,0 +1,159 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gotoSelectDemo opens the select demo on a fresh isolated page, wires up
+// console/page-error capture, waits for Alpine, and returns the page plus
+// accessors for any errors collected. filterIgnorable is defined in
+// alert_coverage_test.go.
+func gotoSelectDemo(t *testing.T) (playwright.Page, func() (pageErrs, consoleErrs []string)) {
+	t.Helper()
+	page := newIsolatedPage(t)
+
+	var pageErrors, consoleErrors []string
+	page.On("pageerror", func(err error) { pageErrors = append(pageErrors, err.Error()) })
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			consoleErrors = append(consoleErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/select", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	return page, func() ([]string, []string) { return pageErrors, consoleErrors }
+}
+
+// TestSelectOpenAndSelect exercises the live Alpine selection flow that static
+// rendering tests can't reach: the aria-expanded toggle, revealing the option
+// list, picking an option, and the hidden input mirroring the chosen value.
+func TestSelectOpenAndSelect(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page, errs := gotoSelectDemo(t)
+
+	trigger := page.Locator("#os-trigger")
+	require.NoError(t, trigger.WaitFor())
+
+	// Live attribute starts false (Alpine binds isOpen || openedWithKeyboard).
+	expanded, err := trigger.Evaluate("el => el.getAttribute('aria-expanded')", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "false", expanded)
+
+	require.NoError(t, trigger.Click())
+	require.NoError(t, page.Locator("#os-option-0").WaitFor())
+
+	expanded, err = trigger.Evaluate("el => el.getAttribute('aria-expanded')", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "true", expanded)
+
+	// Pick Linux (index 2); selectOption() closes the dropdown and updates state.
+	require.NoError(t, page.Locator("#os-option-2").Click())
+	_, err = page.WaitForFunction(
+		"() => document.querySelector('#os-trigger span').textContent.trim() === 'Linux'",
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)})
+	require.NoError(t, err)
+
+	value, err := page.Locator("input#os").InputValue()
+	require.NoError(t, err)
+	assert.Equal(t, "linux", value, "hidden input should mirror the selected value")
+
+	expanded, err = trigger.Evaluate("el => el.getAttribute('aria-expanded')", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "false", expanded, "dropdown should close after selecting")
+
+	pageErrs, consoleErrs := errs()
+	assert.Empty(t, filterIgnorable(pageErrs), "unexpected page errors")
+	assert.Empty(t, filterIgnorable(consoleErrs), "unexpected console errors")
+}
+
+// TestSelectClickOutsideCloses verifies the x-on:click.outside handler closes
+// an open dropdown.
+func TestSelectClickOutsideCloses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page, _ := gotoSelectDemo(t)
+
+	require.NoError(t, page.Locator("#os-trigger").Click())
+	require.NoError(t, page.Locator("#os-option-0").WaitFor())
+
+	// Click the page heading, well outside the dropdown.
+	require.NoError(t, page.Locator("main h1, main h2").First().Click())
+
+	_, err := page.WaitForFunction(
+		"() => document.querySelector('#os-trigger').getAttribute('aria-expanded') === 'false'",
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)})
+	require.NoError(t, err)
+}
+
+// TestSelectKeyboardOpenClose covers the keyboard-open path (openedWithKeyboard
+// via ArrowDown) and the window-level Escape handler that closes it.
+func TestSelectKeyboardOpenClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page, _ := gotoSelectDemo(t)
+
+	trigger := page.Locator("#country-trigger")
+	require.NoError(t, trigger.WaitFor())
+	require.NoError(t, trigger.Focus())
+	require.NoError(t, page.Keyboard().Press("ArrowDown"))
+
+	_, err := page.WaitForFunction(
+		"() => document.querySelector('#country-trigger').getAttribute('aria-expanded') === 'true'",
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)})
+	require.NoError(t, err)
+
+	require.NoError(t, page.Keyboard().Press("Escape"))
+	_, err = page.WaitForFunction(
+		"() => document.querySelector('#country-trigger').getAttribute('aria-expanded') === 'false'",
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)})
+	require.NoError(t, err)
+}
+
+// TestSelectDependentBinding covers the Alpine Model + BindDisabled wiring: the
+// second select stays disabled until the first has a value, then enables once a
+// model is chosen.
+func TestSelectDependentBinding(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page, errs := gotoSelectDemo(t)
+
+	require.NoError(t, page.Locator("#year-trigger").ScrollIntoViewIfNeeded())
+
+	// BindDisabled "!firstValue" → disabled while firstValue is empty.
+	_, err := page.WaitForFunction(
+		"() => document.querySelector('#year-trigger').disabled === true",
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)})
+	require.NoError(t, err)
+
+	// Choose a model; the Alpine Model watcher sets firstValue.
+	require.NoError(t, page.Locator("#modelName-trigger").Click())
+	require.NoError(t, page.Locator("#modelName-option-0").WaitFor())
+	require.NoError(t, page.Locator("#modelName-option-0").Click())
+
+	_, err = page.WaitForFunction(
+		"() => document.querySelector('#year-trigger').disabled === false",
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)})
+	require.NoError(t, err, "year select should enable once a model is chosen")
+
+	pageErrs, consoleErrs := errs()
+	assert.Empty(t, filterIgnorable(pageErrs), "unexpected page errors")
+	assert.Empty(t, filterIgnorable(consoleErrs), "unexpected console errors")
+}


### PR DESCRIPTION
Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 029-select.md
Coverage focus: components/select

Raises component-only coverage for `components/select` from 55.7% to 76.5% by adding behavior-focused unit and E2E tests. No production changes — the existing code already passed.

## Unit (`components/select/select_coverage_test.go`)
Covers the previously-zero/low functions: `helperTextClasses`, `ToOptions`, `SelectClasses`, `SelectedValue`, `LabelClasses`, `TriggerClasses`, `ContainerClasses`, `GetPlaceholder`, `IsEffectivelyDisabled`, `optionsToJS`, plus render-branch assertions for label state icons, autocomplete, the Alpine `BindDisabled`/`Model` wiring, and shell mode (`TriggerLabel` + `TriggerLeading`).

## E2E (`site/tests/e2e/select_coverage_test.go`)
Live Alpine behavior: aria-expanded toggle, picking an option updating the trigger text + hidden input, click-outside close, keyboard open + Escape, and the dependent `Model`/`BindDisabled` enable flow. Each behavior runs on its own isolated page to avoid cross-subtest focus-trap contamination, with inline console/page-error capture.

Verification: `go test ./components/select -count=1`; `go test ./tests/e2e/... -run TestSelect`; `just coverage` (green, exit 0)

Auto-merge: OK once CI is green