### PR TITLE
test(structuredinput): raise components/structuredinput coverage 71.2% -> 73.0%

### DIFF
--- a/components/structuredinput/structuredinput_coverage_test.go
+++ b/components/structuredinput/structuredinput_coverage_test.go
@@ -1,0 +1,153 @@
+package structuredinput
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func renderConfig(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf strings.Builder
+	if err := StructuredInput(cfg).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	return buf.String()
+}
+
+func TestOptionLabelFallsBackToValue(t *testing.T) {
+	if got := (Option{Value: "NoExecute"}).OptionLabel(); got != "NoExecute" {
+		t.Fatalf("OptionLabel() = %q, want value fallback", got)
+	}
+	if got := (Option{Value: "x", Label: "Explicit"}).OptionLabel(); got != "Explicit" {
+		t.Fatalf("OptionLabel() = %q, want explicit label", got)
+	}
+}
+
+func TestGetAddLabelUsesCustomAndDefault(t *testing.T) {
+	if got := (Config{}).GetAddLabel(); got != "Add row" {
+		t.Fatalf("GetAddLabel() = %q, want default", got)
+	}
+	if got := (Config{AddActionLabel: "Add taint"}).GetAddLabel(); got != "Add taint" {
+		t.Fatalf("GetAddLabel() = %q, want custom", got)
+	}
+}
+
+func TestContainerClassesAppendsRootClass(t *testing.T) {
+	base := (Config{}).ContainerClasses()
+	if base != "flex flex-col gap-2" {
+		t.Fatalf("ContainerClasses() = %q, want base only", base)
+	}
+	withRoot := (Config{RootClass: "mt-4 w-full"}).ContainerClasses()
+	if !strings.HasPrefix(withRoot, "flex flex-col gap-2 ") || !strings.Contains(withRoot, "mt-4 w-full") {
+		t.Fatalf("ContainerClasses() = %q, want base plus RootClass", withRoot)
+	}
+}
+
+func TestDefaultValueBranches(t *testing.T) {
+	if got := (Column{Default: "explicit"}).DefaultValue(); got != "explicit" {
+		t.Fatalf("DefaultValue() = %q, want explicit default", got)
+	}
+	sel := Column{Type: ColumnSelect, Options: []Option{{Value: "first"}, {Value: "second"}}}
+	if got := sel.DefaultValue(); got != "first" {
+		t.Fatalf("DefaultValue() = %q, want first option", got)
+	}
+	if got := (Column{Type: ColumnSelect}).DefaultValue(); got != "" {
+		t.Fatalf("DefaultValue() = %q, want empty for optionless select", got)
+	}
+	if got := (Column{}).DefaultValue(); got != "" {
+		t.Fatalf("DefaultValue() = %q, want empty text default", got)
+	}
+}
+
+// TestDisabledRendersDisabledControlsAndHidesActions exercises the disabled
+// branch in textColumn/selectColumn and the !cfg.Disabled false branches in
+// StructuredInput (no add button, no remove button).
+func TestDisabledRendersDisabledControlsAndHidesActions(t *testing.T) {
+	html := renderConfig(t, Config{
+		ID:       "disabledDemo",
+		Name:     "labels",
+		Disabled: true,
+		Columns: []Column{
+			{Key: "key", Label: "Key", Placeholder: "key"},
+			{Key: "effect", Label: "Effect", Type: ColumnSelect, Options: []Option{{Value: "NoSchedule"}}},
+		},
+		Entries: []Entry{{"key": "app", "effect": "NoSchedule"}},
+	})
+
+	if strings.Count(html, "disabled") < 2 {
+		t.Fatalf("disabled render missing disabled attributes:\n%s", html)
+	}
+	if strings.Contains(html, "data-add-row") {
+		t.Fatalf("disabled render must not include add button:\n%s", html)
+	}
+	if strings.Contains(html, `aria-label="Remove row"`) {
+		t.Fatalf("disabled render must not include remove button:\n%s", html)
+	}
+}
+
+// TestEnabledRendersAddAndRemoveActions covers the !cfg.Disabled true branches.
+func TestEnabledRendersAddAndRemoveActions(t *testing.T) {
+	html := renderConfig(t, Config{
+		Name:           "labels",
+		AddActionLabel: "Add row",
+		Columns:        []Column{{Key: "key", Label: "Key"}},
+		Entries:        []Entry{{"key": "app"}},
+	})
+
+	if !strings.Contains(html, "data-add-row") {
+		t.Fatalf("enabled render missing add button:\n%s", html)
+	}
+	if !strings.Contains(html, `aria-label="Remove row"`) {
+		t.Fatalf("enabled render missing remove button:\n%s", html)
+	}
+}
+
+// TestRenderWithoutIDOmitsIDAttribute covers the cfg.ID == "" branch.
+func TestRenderWithoutIDOmitsIDAttribute(t *testing.T) {
+	html := renderConfig(t, Config{
+		Name:    "labels",
+		Columns: []Column{{Key: "key", Label: "Key"}},
+	})
+
+	if strings.Contains(html, " id=") {
+		t.Fatalf("render without ID must omit id attribute:\n%s", html)
+	}
+	if !strings.Contains(html, `x-data="structuredInput($el)"`) {
+		t.Fatalf("render missing x-data root:\n%s", html)
+	}
+}
+
+// TestSelectOptionLabelFallbackRenders ensures an option without an explicit
+// Label renders its Value as the visible text.
+func TestSelectOptionLabelFallbackRenders(t *testing.T) {
+	html := renderConfig(t, Config{
+		Name: "taints",
+		Columns: []Column{
+			{Key: "effect", Type: ColumnSelect, Options: []Option{{Value: "NoExecute"}}},
+		},
+	})
+
+	if !strings.Contains(html, `<option value="NoExecute">NoExecute</option>`) {
+		t.Fatalf("select missing value-fallback option text:\n%s", html)
+	}
+}
+
+// TestEntriesJSONOrdersValuesByColumn confirms entry rows serialize in column
+// order, dropping keys not present in the schema.
+func TestEntriesJSONOrdersValuesByColumn(t *testing.T) {
+	cfg := Config{
+		Name: "labels",
+		Columns: []Column{
+			{Key: "key"},
+			{Key: "value"},
+		},
+		Entries: []Entry{
+			{"value": "web", "key": "app", "ignored": "x"},
+		},
+	}
+
+	if got := cfg.EntriesJSON(); got != `[["app","web"]]` {
+		t.Fatalf("EntriesJSON() = %s, want column-ordered rows", got)
+	}
+}

--- a/site/tests/e2e/structuredinput_coverage_test.go
+++ b/site/tests/e2e/structuredinput_coverage_test.go
@@ -1,0 +1,137 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStructuredInputCoverageDemo exercises the /components/structured-input
+// demo end to end: page load, x-model text round-trip into the bound hidden
+// input, select-column change propagation, add/remove row name re-indexing,
+// and the empty-starter add flow. It asserts the demo stays console-error free.
+func TestStructuredInputCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+
+	var consoleErrors []string
+	page.On("console", func(msg playwright.ConsoleMessage) {
+		if msg.Type() == "error" {
+			consoleErrors = append(consoleErrors, msg.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/structured-input", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+	_, err = page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("#structured-input-fragment").WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateAttached,
+	}))
+
+	t.Run("Page_Loads", func(t *testing.T) {
+		title, err := page.Title()
+		require.NoError(t, err)
+		assert.Contains(t, title, "Structured Input")
+	})
+
+	t.Run("Text_Model_Round_Trip", func(t *testing.T) {
+		container := page.Locator("#labelsDemo")
+		require.NoError(t, container.WaitFor())
+
+		firstText := container.Locator("input[type='text']").First()
+		require.NoError(t, firstText.Fill("region"))
+
+		// x-model on the visible text input drives the bound hidden input value.
+		firstHidden := container.Locator("input[type='hidden']").First()
+		require.NoError(t, expectHiddenValue(page, "#labelsDemo", "region"))
+
+		name, err := firstHidden.GetAttribute("name")
+		require.NoError(t, err)
+		assert.Equal(t, "labels[0][key]", name)
+	})
+
+	t.Run("Select_Change_Propagates", func(t *testing.T) {
+		container := page.Locator("#taintsDemo")
+		require.NoError(t, container.WaitFor())
+
+		sel := container.Locator("select").First()
+		_, err := sel.SelectOption(playwright.SelectOptionValues{
+			Values: &[]string{"NoExecute"},
+		})
+		require.NoError(t, err)
+
+		value, err := sel.InputValue()
+		require.NoError(t, err)
+		assert.Equal(t, "NoExecute", value)
+	})
+
+	t.Run("Add_Remove_Reindexes_Names", func(t *testing.T) {
+		container := page.Locator("#taintsDemo")
+		hidden := container.Locator("input[type='hidden']")
+
+		before, err := hidden.Count()
+		require.NoError(t, err)
+
+		require.NoError(t, container.Locator("[data-add-row]").Click())
+		after, err := hidden.Count()
+		require.NoError(t, err)
+		assert.Equal(t, before+3, after, "adding one three-column row adds three hidden inputs")
+
+		// The newly added row indexes its hidden input names at the next index.
+		lastName, err := hidden.Last().GetAttribute("name")
+		require.NoError(t, err)
+		assert.Equal(t, "taints[1][effect]", lastName)
+
+		require.NoError(t, container.Locator("button[aria-label='Remove row']").First().Click())
+		reduced, err := hidden.Count()
+		require.NoError(t, err)
+		assert.Equal(t, before, reduced, "removing a row restores the original hidden input count")
+	})
+
+	t.Run("Empty_Starter_Adds_From_Defaults", func(t *testing.T) {
+		container := page.Locator("#rulesDemo")
+		require.NoError(t, container.WaitFor())
+
+		hidden := container.Locator("input[type='hidden']")
+		count, err := hidden.Count()
+		require.NoError(t, err)
+		assert.Equal(t, 0, count, "empty starter renders no rows")
+
+		require.NoError(t, container.Locator("[data-add-row]").Click())
+		count, err = hidden.Count()
+		require.NoError(t, err)
+		assert.Equal(t, 3, count, "one three-column row renders three hidden inputs")
+
+		sel := container.Locator("select").First()
+		value, err := sel.InputValue()
+		require.NoError(t, err)
+		assert.Equal(t, "high", value, "select column defaults to the first option")
+	})
+
+	assert.Empty(t, consoleErrors, "structured input demo should not log console errors")
+}
+
+// expectHiddenValue waits until the first hidden input inside the given
+// container reports the expected value, which Alpine sets via x-bind:value.
+func expectHiddenValue(page playwright.Page, containerSelector, want string) error {
+	_, err := page.WaitForFunction(
+		"([sel, want]) => { const el = document.querySelector(sel + \" input[type='hidden']\"); return el && el.value === want; }",
+		[]any{containerSelector, want},
+	)
+	return err
+}


### PR DESCRIPTION
Adds behavior-focused unit and E2E coverage for `components/structuredinput`.

- Unit: cover `OptionLabel` value fallback, `GetAddLabel` custom label, `ContainerClasses` RootClass, `DefaultValue` variants, plus disabled / no-ID server-render branches — takes `types.go` helpers to 100%.
- E2E: x-model text round-trip into bound hidden inputs, select-column change propagation, add/remove row name re-indexing, empty-starter add-from-defaults, console-error clean assertion.

Combined component coverage: 272/382 (71.2%) -> 279/382 (73.0%). No production code changed; no tests exposed bugs.

Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 036-structuredinput.md
Coverage focus: components/structuredinput
Verification: go test ./components/structuredinput -count=1; go test ./site/tests/e2e/... -run 'StructuredInput' -timeout 5m; just coverage
Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)