### PR TITLE
test(kbd): add coverage

### DIFF
--- a/components/kbd/kbd_coverage_test.go
+++ b/components/kbd/kbd_coverage_test.go
@@ -1,0 +1,121 @@
+package kbd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKbdCoverageHelperBranches(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       Config
+		sizeClass string
+		iconClass string
+	}{
+		{
+			name:      "extra small",
+			cfg:       Config{Size: SizeXS},
+			sizeClass: "min-h-5 min-w-5 px-1 py-0.5 text-[10px] leading-none",
+			iconClass: "size-3",
+		},
+		{
+			name:      "small",
+			cfg:       Config{Size: SizeSM},
+			sizeClass: "min-h-6 min-w-6 px-1.5 py-0.5 text-xs leading-none",
+			iconClass: "size-3.5",
+		},
+		{
+			name:      "medium default",
+			cfg:       Config{Size: SizeMD},
+			sizeClass: "min-h-7 min-w-7 px-2 py-1 text-sm leading-none",
+			iconClass: "size-4",
+		},
+		{
+			name:      "large",
+			cfg:       Config{Size: SizeLG},
+			sizeClass: "min-h-9 min-w-9 px-2.5 py-1 text-base leading-none",
+			iconClass: "size-5",
+		},
+		{
+			name:      "unknown size falls back to medium",
+			cfg:       Config{Size: Size("wide")},
+			sizeClass: "min-h-7 min-w-7 px-2 py-1 text-sm leading-none",
+			iconClass: "size-4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.sizeClass, tt.cfg.SizeClasses())
+			assert.Equal(t, tt.iconClass, tt.cfg.IconClasses())
+			assert.Contains(t, tt.cfg.RootClasses(), tt.sizeClass)
+		})
+	}
+
+	assert.Contains(t, Config{Class: "shortcut-key"}.RootClasses(), "shortcut-key")
+}
+
+func TestKbdCoverageAccessibleLabelBranches(t *testing.T) {
+	assert.Empty(t, Config{Text: "Esc", Label: "Escape"}.AccessibleLabel())
+	assert.Equal(t, "Command", Config{Label: "  Command  "}.AccessibleLabel())
+	assert.Empty(t, Config{Label: "   "}.AccessibleLabel())
+}
+
+func TestKbdCoverageRenderTextLabelAndAttributes(t *testing.T) {
+	rendered := renderCoverageKbd(t, Config{
+		Text:  "<Esc>",
+		Label: "Escape key",
+		Size:  SizeLG,
+		Class: "shortcut-key",
+		Attrs: templ.Attributes{
+			"id":            "escape-key",
+			"data-shortcut": "escape",
+			"aria-hidden":   "false",
+		},
+	})
+
+	assert.Contains(t, rendered, `<kbd`)
+	assert.Contains(t, rendered, `id="escape-key"`)
+	assert.Contains(t, rendered, `data-shortcut="escape"`)
+	assert.Contains(t, rendered, `aria-label="Escape key"`)
+	assert.Contains(t, rendered, `aria-hidden="false"`)
+	assert.Contains(t, rendered, `shortcut-key`)
+	assert.Contains(t, rendered, `min-h-9`)
+	assert.Contains(t, rendered, `&lt;Esc&gt;`)
+	assert.NotContains(t, rendered, `sr-only`)
+}
+
+func TestKbdCoverageRenderIconOnlyUsesTrimmedScreenReaderLabel(t *testing.T) {
+	icon := templ.ComponentFunc(func(ctx context.Context, w io.Writer) error {
+		_, err := io.WriteString(w, `<svg data-testid="coverage-icon"></svg>`)
+		return err
+	})
+
+	rendered := renderCoverageKbd(t, Config{
+		Label: "  Shift  ",
+		Icon:  icon,
+		Size:  SizeXS,
+	})
+
+	assert.Contains(t, rendered, `aria-label="  Shift  "`)
+	assert.Contains(t, rendered, `aria-hidden="true"`)
+	assert.Contains(t, rendered, `data-testid="coverage-icon"`)
+	assert.Contains(t, rendered, `class="shrink-0 size-3"`)
+	assert.Contains(t, rendered, `<span class="sr-only">Shift</span>`)
+}
+
+func renderCoverageKbd(t *testing.T, cfg Config) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	err := Kbd(cfg).Render(context.Background(), &buf)
+	require.NoError(t, err)
+	return strings.TrimSpace(buf.String())
+}

--- a/site/tests/e2e/kbd_coverage_test.go
+++ b/site/tests/e2e/kbd_coverage_test.go
@@ -1,0 +1,128 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKbdCoverageDemo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newPage(t, sharedBrowser)
+
+	var pageErrors []string
+	page.On("pageerror", func(err error) { pageErrors = append(pageErrors, err.Error()) })
+
+	var consoleErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			consoleErrors = append(consoleErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/kbd", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	require.NoError(t, page.Locator("#kbd-fragment").WaitFor())
+	require.NoError(t, page.Locator("main").Filter(playwright.LocatorFilterOptions{
+		HasText: "KBD",
+	}).First().WaitFor())
+
+	frequentlyUsed := page.Locator("#kbd-frequently-used")
+	for _, key := range []string{"Option", "Backspace", "Delete", "Caps Lock"} {
+		require.NoError(t, frequentlyUsed.Locator("kbd").Filter(playwright.LocatorFilterOptions{
+			HasText: key,
+		}).WaitFor())
+	}
+
+	iconKey := page.Locator("#kbd-icons kbd[aria-label='Command']")
+	require.NoError(t, iconKey.WaitFor())
+	ariaLabel, err := iconKey.GetAttribute("aria-label")
+	require.NoError(t, err)
+	assert.Equal(t, "Command", ariaLabel)
+	require.NoError(t, iconKey.Locator("span[aria-hidden='true'] svg").WaitFor())
+	require.NoError(t, iconKey.Locator(".sr-only").Filter(playwright.LocatorFilterOptions{
+		HasText: "Command",
+	}).WaitFor())
+
+	inlineClass, err := page.Locator("#kbd-inline kbd").First().GetAttribute("class")
+	require.NoError(t, err)
+	assert.Contains(t, inlineClass, "min-h-6")
+	assert.Contains(t, inlineClass, "text-xs")
+
+	sizeClasses := map[string]string{
+		"xs": "min-h-5",
+		"sm": "min-h-6",
+		"md": "min-h-7",
+		"lg": "min-h-9",
+	}
+	for label, className := range sizeClasses {
+		count, err := page.Locator("#kbd-sizes kbd." + className).Count()
+		require.NoError(t, err)
+		assert.Equal(t, 1, count, "expected one %s size key", label)
+	}
+
+	functionCount, err := page.Locator("#kbd-functions kbd").Count()
+	require.NoError(t, err)
+	assert.Equal(t, 11, functionCount)
+	require.NoError(t, page.Locator("#kbd-functions kbd").Filter(playwright.LocatorFilterOptions{
+		HasText: "F12",
+	}).WaitFor())
+
+	require.NoError(t, page.Locator("table").Filter(playwright.LocatorFilterOptions{
+		HasText: "Accessible label",
+	}).WaitFor())
+
+	before, err := page.Evaluate("() => document.documentElement.classList.contains('dark')", nil)
+	require.NoError(t, err)
+	_, err = page.Evaluate(`() => document.documentElement.classList.toggle('dark')`, nil)
+	require.NoError(t, err)
+	after, err := page.Evaluate("() => document.documentElement.classList.contains('dark')", nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, before, after, "dark class should toggle while kbd demo remains mounted")
+	require.NoError(t, page.Locator("#kbd-fragment kbd").First().WaitFor())
+
+	require.Empty(t, pageErrors, "uncaught JS exceptions on kbd demo: %v", pageErrors)
+	require.Empty(t, filterIgnorable(consoleErrors), "console errors on kbd demo: %s", strings.Join(consoleErrors, "; "))
+}
+
+func TestKbdCoverageFragmentNavigation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newPage(t, sharedBrowser)
+
+	var consoleErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			consoleErrors = append(consoleErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/getting-started", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	link := page.Locator("a[href='/components/kbd']").First()
+	require.NoError(t, link.ScrollIntoViewIfNeeded())
+	require.NoError(t, link.Click())
+	require.NoError(t, page.Locator("#kbd-fragment").WaitFor())
+	require.NoError(t, page.Locator("#kbd-icons kbd[aria-label='Shift']").WaitFor())
+	require.NoError(t, page.Locator("main").Filter(playwright.LocatorFilterOptions{
+		HasText: "Keys With Icons",
+	}).First().WaitFor())
+
+	require.Empty(t, filterIgnorable(consoleErrors), "console errors after kbd fragment navigation: %s", strings.Join(consoleErrors, "; "))
+}


### PR DESCRIPTION
Harness: Codex
Taken: 039-kbd.md
Coverage focus: components/kbd
Verification: go test ./components/kbd -count=1 -cover; go test ./components/kbd -count=1; cd site && go test ./tests/e2e/... -count=1 -timeout 5m -run 'Kbd'; just coverage
Auto-merge: OK once CI is green
