### PR TITLE
test(combobox): add unit + e2e coverage (71.6% -> 75.2%+)

### DIFF
--- a/components/combobox/combobox_coverage_test.go
+++ b/components/combobox/combobox_coverage_test.go
@@ -1,0 +1,258 @@
+package combobox
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func renderHTML(t *testing.T, c templ.Component) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, c.Render(context.Background(), &buf))
+	return buf.String()
+}
+
+func TestInitialState_CopiesStaticAndSelected(t *testing.T) {
+	cfg := Config{
+		ID:       "i",
+		Name:     "i",
+		Selected: []string{"tech"},
+		Source: Source{Static: []Option{
+			{Value: "tech", Label: "Technology"},
+			{Value: "fin", Label: "Finance"},
+		}},
+	}
+	st := cfg.InitialState()
+	assert.Equal(t, cfg.Source.Static, st.Options, "options seeded from Static")
+	assert.Equal(t, []string{"tech"}, st.Selected, "selection copied from cfg")
+	assert.Empty(t, st.Search)
+	assert.Nil(t, st.Deps)
+}
+
+func TestInitialState_EmptyWhenNoStatic(t *testing.T) {
+	st := Config{ID: "x", Name: "x"}.InitialState()
+	assert.Empty(t, st.Options)
+	assert.Empty(t, st.Selected)
+}
+
+func TestClientOptionLI_SingleMode_DisabledOption(t *testing.T) {
+	// Client single-select with a disabled option: no checkbox, but the
+	// disabled styling/ARIA branch of clientOptionLI is exercised.
+	cfg := Config{
+		ID: "industry", Name: "industry", Mode: ModeSingle,
+		Source: Source{Static: []Option{
+			{Value: "tech", Label: "Technology"},
+			{Value: "legacy", Label: "Legacy", Disabled: true},
+		}},
+	}
+	state := State{Options: cfg.Source.Static, Selected: []string{"tech"}}
+
+	html := renderHTML(t, OptionsList(cfg, state))
+
+	// Single mode never renders the checkbox.
+	assert.NotContains(t, html, `type="checkbox"`, "single-select has no per-row checkbox")
+
+	// Disabled branch attributes on the legacy row.
+	legacyIdx := strings.Index(html, `data-value="legacy"`)
+	require.Greater(t, legacyIdx, -1)
+	legacyRow := html[legacyIdx:]
+	assert.Contains(t, legacyRow, `aria-disabled="true"`)
+	assert.Contains(t, legacyRow, `tabindex="-1"`)
+	assert.Contains(t, legacyRow, `cursor-not-allowed`)
+	assert.Contains(t, legacyRow, `opacity-50`)
+
+	// Client mode: no hx-post on any row.
+	assert.NotContains(t, html, `hx-post`)
+
+	// Selected tech row carries the selected label styling.
+	techIdx := strings.Index(html, `data-value="tech"`)
+	require.Greater(t, techIdx, -1)
+	assert.Contains(t, html[techIdx:legacyIdx], `aria-selected="true"`)
+	assert.Contains(t, html[techIdx:legacyIdx], `font-semibold`)
+}
+
+func TestOptionCheckbox_CheckedReflectsSelection(t *testing.T) {
+	// Multi-select client mode renders a checkbox per row; the selected row's
+	// checkbox carries the `checked` attribute, the unselected one does not.
+	cfg := Config{
+		ID: "skills", Name: "skills", Mode: ModeMultiple,
+		Source: Source{Static: []Option{
+			{Value: "go", Label: "Go"},
+			{Value: "rust", Label: "Rust"},
+		}},
+	}
+	state := State{Options: cfg.Source.Static, Selected: []string{"go"}}
+
+	html := renderHTML(t, OptionsList(cfg, state))
+
+	goIdx := strings.Index(html, `data-value="go"`)
+	rustIdx := strings.Index(html, `data-value="rust"`)
+	require.Greater(t, goIdx, -1)
+	require.Greater(t, rustIdx, -1)
+
+	goRow := html[goIdx:rustIdx]
+	rustRow := html[rustIdx:]
+
+	// The boolean `checked` attribute renders right before tabindex on the input.
+	// (The class string also contains "checked:" utilities, so match the attribute.)
+	assert.Contains(t, goRow, `type="checkbox"`)
+	assert.Contains(t, goRow, `checked tabindex="-1"`, "selected option's checkbox is checked")
+	assert.Contains(t, rustRow, `type="checkbox"`)
+	assert.NotContains(t, rustRow, `checked tabindex="-1"`, "unselected option's checkbox is not checked")
+}
+
+func TestChevronClass_ReflectsSelection(t *testing.T) {
+	assert.Equal(t, "", chevronClass(State{}), "no selection: no accent class")
+	assert.Equal(t, "", chevronClass(State{Selected: []string{}}))
+	got := chevronClass(State{Selected: []string{"a"}})
+	assert.Contains(t, got, "text-secondary")
+	assert.Contains(t, got, "dark:text-secondary-dark")
+}
+
+func TestCombobox_LabelDisabledRootClass(t *testing.T) {
+	cfg := Config{
+		ID: "industry", Name: "industry", Mode: ModeSingle,
+		Label:     "Industry",
+		RootClass: "max-w-xs custom-root",
+		Disabled:  true,
+		Source:    Source{Static: []Option{{Value: "tech", Label: "Technology"}}},
+	}
+	html := renderHTML(t, Combobox(cfg, State{Options: cfg.Source.Static}))
+
+	// Label branch renders a <label for=...>.
+	assert.Contains(t, html, `<label for="industry-trigger"`)
+	assert.Contains(t, html, `>Industry</label>`)
+
+	// RootClass appended to the container.
+	assert.Contains(t, html, `class="relative max-w-xs custom-root"`)
+
+	// Disabled trigger button.
+	triggerIdx := strings.Index(html, `id="industry-trigger"`)
+	require.Greater(t, triggerIdx, -1)
+	end := strings.Index(html[triggerIdx:], ">") + triggerIdx
+	assert.Contains(t, html[triggerIdx:end], `disabled`, "disabled config disables the trigger button")
+}
+
+func TestCombobox_NoLabelWhenEmpty(t *testing.T) {
+	cfg := Config{
+		ID: "industry", Name: "industry", Mode: ModeSingle,
+		Source: Source{Static: []Option{{Value: "tech", Label: "Technology"}}},
+	}
+	html := renderHTML(t, Combobox(cfg, State{Options: cfg.Source.Static}))
+	assert.NotContains(t, html, `<label for="industry-trigger"`)
+}
+
+func TestTriggerLabelText_DefaultPlaceholder(t *testing.T) {
+	// No placeholder, empty selection → "Select…".
+	cfg := Config{ID: "x", Name: "x", Mode: ModeSingle,
+		Source: Source{Static: []Option{{Value: "a", Label: "A"}}}}
+	assert.Equal(t, "Select…", triggerLabelText(cfg, State{Options: cfg.Source.Static}))
+}
+
+func TestTriggerLabelText_SingleSelection_FallsBackToValue(t *testing.T) {
+	// Single mode, selected value not present in Options → falls back to value.
+	cfg := Config{ID: "x", Name: "x", Mode: ModeSingle}
+	got := triggerLabelText(cfg, State{Options: []Option{{Value: "a", Label: "A"}}, Selected: []string{"ghost"}})
+	assert.Equal(t, "ghost", got)
+}
+
+func TestTriggerLabelText_MultiSingleSelection_FallsBackToValue(t *testing.T) {
+	// Multi mode with exactly one selection not present in Options → value.
+	cfg := Config{ID: "x", Name: "x", Mode: ModeMultiple}
+	got := triggerLabelText(cfg, State{Options: []Option{{Value: "a", Label: "A"}}, Selected: []string{"ghost"}})
+	assert.Equal(t, "ghost", got)
+}
+
+func TestTriggerLabelText_MultiSingleSelection_UsesLabel(t *testing.T) {
+	cfg := Config{ID: "x", Name: "x", Mode: ModeMultiple}
+	opts := []Option{{Value: "a", Label: "Alpha"}, {Value: "b", Label: "Beta"}}
+	got := triggerLabelText(cfg, State{Options: opts, Selected: []string{"b"}})
+	assert.Equal(t, "Beta", got)
+}
+
+func TestProviderError_RendersRetryAndEscapesID(t *testing.T) {
+	cfg := Config{
+		ID: "x<script>", Name: "x",
+		OptionsEndpoint: "/api/x/options",
+	}
+	html := renderHTML(t, ProviderError(cfg))
+
+	assert.Contains(t, html, `Failed to load`)
+	assert.Contains(t, html, `hx-get="/api/x/options"`)
+	assert.Contains(t, html, `>Retry</button>`)
+	assert.Contains(t, html, `role="listbox"`)
+	// ID is escaped in HTML output.
+	assert.NotContains(t, html, `id="x<script>-options"`)
+	assert.Contains(t, html, `&lt;script&gt;`)
+}
+
+func TestClientEvent_Constant(t *testing.T) {
+	assert.Equal(t, "combobox:change", ClientEvent)
+}
+
+func TestHandler_UnsupportedRoute_Returns404(t *testing.T) {
+	resetRegistry()
+	cfg := Config{
+		ID: "u", Name: "u", Mode: ModeMultiple,
+		ToggleEndpoint: "/u/toggle", OptionsEndpoint: "/u/options", ClearEndpoint: "/u/clear",
+		Source: Source{LazyEndpoint: "/u/options"},
+	}
+	h := Handler(cfg, staticProvider(nil))
+
+	// POST to /options (only GET is supported there) → falls through to default.
+	req := httptest.NewRequest(http.MethodPost, "/u/options", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "unsupported route")
+}
+
+func TestHandler_GetToggle_WrongMethod_Returns404(t *testing.T) {
+	resetRegistry()
+	cfg := Config{
+		ID: "u", Name: "u", Mode: ModeMultiple,
+		ToggleEndpoint: "/u/toggle", OptionsEndpoint: "/u/options", ClearEndpoint: "/u/clear",
+		Source: Source{LazyEndpoint: "/u/options"},
+	}
+	h := Handler(cfg, staticProvider(nil))
+
+	// GET on the toggle path is not supported (POST only).
+	req := httptest.NewRequest(http.MethodGet, "/u/toggle", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandler_ParseFormError_Returns400(t *testing.T) {
+	resetRegistry()
+	cfg := Config{
+		ID: "u", Name: "u", Mode: ModeMultiple,
+		ToggleEndpoint: "/u/toggle", OptionsEndpoint: "/u/options", ClearEndpoint: "/u/clear",
+		Source: Source{LazyEndpoint: "/u/options"},
+	}
+	h := Handler(cfg, staticProvider(nil))
+
+	// Malformed percent-encoding in the query makes ParseForm fail.
+	req := httptest.NewRequest(http.MethodGet, "/u/options?%zz=1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestOptionsList_EmptyState_RendersNoMatches(t *testing.T) {
+	cfg := Config{ID: "x", Name: "x", Mode: ModeMultiple,
+		Source: Source{Static: []Option{{Value: "a"}}}}
+	html := renderHTML(t, OptionsList(cfg, State{Options: nil}))
+	assert.Contains(t, html, "No matches found")
+}

--- a/site/tests/e2e/combobox_coverage_test.go
+++ b/site/tests/e2e/combobox_coverage_test.go
@@ -1,0 +1,168 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestComboboxCoverage_Demo asserts the demo page renders all three combobox
+// variants and produces no console errors on first paint.
+func TestComboboxCoverage_Demo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+
+	var consoleErrors []string
+	page.On("console", func(msg playwright.ConsoleMessage) {
+		if msg.Type() == "error" {
+			consoleErrors = append(consoleErrors, msg.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/combobox", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	for _, id := range []string{"#industry-trigger", "#skills-trigger", "#users-trigger"} {
+		vis, err := page.Locator(id).First().IsVisible()
+		require.NoError(t, err)
+		assert.True(t, vis, "%s trigger should be visible", id)
+	}
+
+	main, err := page.Locator("main").First().TextContent()
+	require.NoError(t, err)
+	assert.Contains(t, main, "Combobox")
+
+	assert.Empty(t, consoleErrors, "no console errors on combobox demo (got: %v)", consoleErrors)
+}
+
+// TestComboboxCoverage_ServerLazySearchAndToggle exercises the server-mode
+// (HTMX lazy) path: opening the users combobox, searching to load options over
+// the wire, selecting one (server toggle round-trip), and verifying the OOB
+// trigger-label and hidden input reflect the new selection.
+func TestComboboxCoverage_ServerLazySearchAndToggle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+
+	var consoleErrors []string
+	page.On("console", func(msg playwright.ConsoleMessage) {
+		// htmx logs a benign warning when the search hx-include selector matches
+		// no hidden inputs (i.e. before anything is selected). That is expected
+		// component behavior, not a regression — ignore it.
+		if msg.Type() == "error" && !strings.Contains(msg.Text(), "on hx-include returned no matches") {
+			consoleErrors = append(consoleErrors, msg.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/combobox", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	trigger := page.Locator("#users-trigger").First()
+	require.NoError(t, trigger.Click())
+
+	// Dropdown opens (server mode uses the same Alpine shell).
+	_, err = page.WaitForFunction(
+		`() => document.querySelector('#users-trigger').getAttribute('aria-expanded') === 'true'`,
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)})
+	require.NoError(t, err)
+
+	// Type into the search box; HTMX issues a GET that swaps the options list.
+	search := page.Locator("#users [data-combobox-search]").First()
+	require.NoError(t, search.Fill("al"))
+
+	// Filtered options arrive over the wire: alice + albert, but not carol.
+	alice := page.Locator(`#users [data-combobox-option][data-value="alice"]`).First()
+	require.NoError(t, alice.WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+	albertCount, err := page.Locator(`#users [data-combobox-option][data-value="albert"]`).Count()
+	require.NoError(t, err)
+	assert.Equal(t, 1, albertCount, "search 'al' returns albert")
+	carolCount, err := page.Locator(`#users [data-combobox-option][data-value="carol"]`).Count()
+	require.NoError(t, err)
+	assert.Equal(t, 0, carolCount, "search 'al' filters out carol")
+
+	// Select alice — server toggle round-trip swaps the body and emits the OOB
+	// trigger label. clickUntil retries past the HTMX rebind race.
+	clickUntil(t, page, alice,
+		`() => document.querySelectorAll('#users input[type=hidden][name="users"][value="alice"]').length === 1`)
+
+	label, err := page.Locator("#users-trigger-label").TextContent()
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", label, "single selection shows the option label via OOB swap")
+
+	assert.Empty(t, consoleErrors, "no console errors during server-mode flow (got: %v)", consoleErrors)
+}
+
+// TestComboboxCoverage_KeyboardAndChevron covers the keyboard-open path
+// (openedWithKeyboard) and the chevron rotate binding, then Escape-to-close.
+func TestComboboxCoverage_KeyboardAndChevron(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/combobox", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForAlpine(page))
+
+	trigger := page.Locator("#industry-trigger").First()
+	require.NoError(t, trigger.Focus())
+
+	// ArrowDown opens the dropdown via the keyboard handler.
+	require.NoError(t, trigger.Press("ArrowDown"))
+	_, err = page.WaitForFunction(
+		`() => document.querySelector('#industry-trigger').getAttribute('aria-expanded') === 'true'`,
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)})
+	require.NoError(t, err)
+
+	// Chevron rotates while open (x-bind:class adds rotate-180).
+	_, err = page.WaitForFunction(
+		`() => { const s = document.querySelector('#industry-trigger svg'); return s && s.classList.contains('rotate-180'); }`,
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)})
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("#industry [data-combobox-body]").First().WaitFor(
+		playwright.LocatorWaitForOptions{State: playwright.WaitForSelectorStateVisible}),
+		"dropdown body visible after keyboard open")
+
+	// Escape closes and resets the rotate binding.
+	require.NoError(t, page.Keyboard().Press("Escape"))
+	_, err = page.WaitForFunction(
+		`() => { const s = document.querySelector('#industry-trigger svg'); return s && !s.classList.contains('rotate-180'); }`,
+		nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(2000)})
+	require.NoError(t, err)
+
+	expanded, err := page.Evaluate(`() => document.querySelector('#industry-trigger').getAttribute('aria-expanded')`, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "false", expanded, "Escape clears expanded state")
+}


### PR DESCRIPTION
Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 038-combobox.md
Coverage focus: components/combobox
Verification: go test ./components/combobox -count=1; go test ./site/tests/e2e/... -run 'Combobox' -timeout 5m; just coverage
Auto-merge: OK once CI is green

## What

Adds behavior-focused unit + E2E coverage for `components/combobox`. No production code or `.templ` changes.

### Unit (`components/combobox/combobox_coverage_test.go`)
- `InitialState` (was 0%): static + selection seeding, empty case
- `clientOptionLI` disabled / single-mode branch (no checkbox)
- `optionCheckbox` `checked` attribute reflects selection
- `chevronClass` selected vs empty accent
- `Combobox` Label / Disabled / RootClass branches + no-label case
- `triggerLabelText` fallbacks (default placeholder; value when label missing; multi single-selection)
- `ProviderError` direct render + ID escaping
- `ServeHTTP` unsupported-route, wrong-method, ParseForm-error branches (62.5% -> 100%)
- `ClientEvent` constant, `OptionsList` empty-state

### E2E (`site/tests/e2e/combobox_coverage_test.go`)
- demo renders all three variants, no console errors
- server-mode lazy: search loads options over HTMX, toggle round-trip updates hidden input + OOB trigger label (benign htmx hx-include no-match warning filtered)
- keyboard-open path (openedWithKeyboard), chevron rotate binding, Escape-to-close

### Result
Component unit-only coverage 71.6% -> 75.2% (ServeHTTP 62.5% -> 100%); E2E adds server-path render coverage. Full just coverage gate green (E2E suite passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)