### PR TITLE
test(carousel): add unit + e2e coverage (4% → ~74%)

### DIFF
--- a/components/carousel/carousel_coverage_test.go
+++ b/components/carousel/carousel_coverage_test.go
@@ -1,0 +1,238 @@
+package carousel
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestCoverageCarouselConfigHelpers(t *testing.T) {
+	if !hasOverlay(WithText) || !hasOverlay(WithCTA) {
+		t.Fatal("text and CTA variants should render overlays")
+	}
+	if hasOverlay(Default) || hasOverlay(OnCard) {
+		t.Fatal("default and card variants should not render overlays")
+	}
+
+	helperCases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"default transition", transitionAttr(Config{}), "1000ms"},
+		{"touch transition", transitionAttr(Config{Touch: true}), "700ms"},
+		{"card transition", transitionAttr(Config{Variant: OnCard, Touch: true}), "300ms"},
+		{"root class", containerClasses(Config{RootClass: "custom-root"}), "relative w-full overflow-hidden custom-root"},
+		{"default slides classes", slidesContainerClasses(Config{}), "relative min-h-[50svh] w-full"},
+		{"height slides classes", slidesContainerClasses(Config{Height: "h-32"}), "relative h-32 w-full"},
+		{"aspect slides classes", slidesContainerClasses(Config{AspectRatio: "3/1"}), "aspect-3/1 relative w-full"},
+		{"nav button classes", navButtonClasses(), "absolute top-1/2 z-20 flex rounded-full -translate-y-1/2 items-center justify-center bg-surface/40 p-2 text-on-surface transition hover:bg-surface/60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary active:outline-offset-0 dark:bg-surface-dark/40 dark:text-on-surface-dark dark:hover:bg-surface-dark/60 dark:focus-visible:outline-primary-dark"},
+		{"default indicators", indicatorContainerClasses(Config{}), "absolute rounded-radius bottom-3 md:bottom-5 left-1/2 z-20 flex -translate-x-1/2 gap-4 md:gap-3 px-1.5 py-1 md:px-2 bg-surface/75 dark:bg-surface-dark/75"},
+		{"overlay indicators", indicatorContainerClasses(Config{Variant: WithText}), "absolute rounded-radius bottom-3 md:bottom-5 left-1/2 z-20 flex -translate-x-1/2 gap-4 md:gap-3 px-1.5 py-1 md:px-2"},
+		{"default active indicator", indicatorActiveClasses(Config{}), "bg-on-surface dark:bg-on-surface-dark"},
+		{"autoplay active indicator", indicatorActiveClasses(Config{Autoplay: &AutoplayConfig{}}), "bg-on-surface-dark"},
+		{"default inactive indicator", indicatorInactiveClasses(Config{}), "bg-on-surface/50 dark:bg-on-surface-dark/50"},
+		{"overlay inactive indicator", indicatorInactiveClasses(Config{Variant: WithCTA}), "bg-on-surface-dark/50"},
+		{"card container", cardContainerClasses(), "group flex max-w-sm flex-col overflow-hidden rounded-radius border border-outline bg-surface-alt text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark"},
+	}
+	for _, tc := range helperCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Fatalf("got %q, want %q", tc.got, tc.want)
+			}
+		})
+	}
+
+	attrs := transitionAttrs("700ms")
+	if got := attrs["x-transition.opacity.duration.700ms"]; got != true {
+		t.Fatalf("transitionAttrs missing boolean Alpine transition attribute: %#v", attrs)
+	}
+}
+
+func TestCoverageGenerateAlpineDataIncludesOptionalBehavior(t *testing.T) {
+	data := generateAlpineData(Config{
+		Slides: []Slide{{ImgSrc: "/one.webp", ImgAlt: "One"}},
+		Autoplay: &AutoplayConfig{
+			Interval: 0,
+		},
+		Touch: true,
+	})
+
+	for _, want := range []string{
+		"slides:[{imgSrc:'/one.webp',imgAlt:'One'}]",
+		"currentSlideIndex:1",
+		"previous:function()",
+		"next:function()",
+		"autoplayIntervalTime:4000",
+		"isPaused:false",
+		"setAutoplayInterval:function(t)",
+		"touchStartX:null",
+		"handleTouchStart:function(e)",
+		"handleTouchEnd:function()",
+	} {
+		if !strings.Contains(data, want) {
+			t.Fatalf("Alpine data missing %q in:\n%s", want, data)
+		}
+	}
+}
+
+func TestCoverageRenderDefaultCarousel(t *testing.T) {
+	html := renderCoverageCarousel(t, Config{
+		ID:          "coverage-default",
+		Slides:      coverageSlides(),
+		Touch:       true,
+		AspectRatio: "3/1",
+		RootClass:   "coverage-root",
+	})
+
+	for _, want := range []string{
+		`id="coverage-default"`,
+		`x-data=`,
+		`coverage-root`,
+		`aspect-3/1 relative w-full`,
+		`x-on:touchstart="handleTouchStart($event)"`,
+		`aria-label="previous slide"`,
+		`aria-label="next slide"`,
+		`role="group"`,
+		`aria-label="slides"`,
+		`x-transition.opacity.duration.700ms`,
+		`x-bind:class="[currentSlideIndex === index + 1 ? &#39;bg-on-surface dark:bg-on-surface-dark&#39; : &#39;bg-on-surface/50 dark:bg-on-surface-dark/50&#39;]"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("default carousel render missing %q in:\n%s", want, html)
+		}
+	}
+}
+
+func TestCoverageRenderTextAndCTACarousels(t *testing.T) {
+	textHTML := renderCoverageCarousel(t, Config{
+		ID:      "coverage-text",
+		Variant: WithText,
+		Slides:  coverageSlides(),
+		Height:  "h-64",
+	})
+	for _, want := range []string{
+		`id="coverage-text"`,
+		`relative h-64 w-full`,
+		`x-transition.opacity.duration.1000ms`,
+		`x-text="slide.title"`,
+		`x-text="slide.description"`,
+		`bg-linear-to-t from-surface-dark/85`,
+		`x-bind:class="[currentSlideIndex === index + 1 ? &#39;bg-on-surface-dark&#39; : &#39;bg-on-surface-dark/50&#39;]"`,
+	} {
+		if !strings.Contains(textHTML, want) {
+			t.Fatalf("text carousel render missing %q in:\n%s", want, textHTML)
+		}
+	}
+	if strings.Contains(textHTML, `x-bind:href="slide.ctaUrl"`) {
+		t.Fatalf("text carousel should not render CTA link:\n%s", textHTML)
+	}
+
+	ctaHTML := renderCoverageCarousel(t, Config{
+		ID:      "coverage-cta",
+		Variant: WithCTA,
+		Slides:  coverageSlides(),
+	})
+	for _, want := range []string{
+		`id="coverage-cta"`,
+		`x-bind:href="slide.ctaUrl"`,
+		`x-text="slide.ctaText"`,
+	} {
+		if !strings.Contains(ctaHTML, want) {
+			t.Fatalf("CTA carousel render missing %q in:\n%s", want, ctaHTML)
+		}
+	}
+}
+
+func TestCoverageRenderAutoplayCardAndHTMXCarousels(t *testing.T) {
+	autoplayHTML := renderCoverageCarousel(t, Config{
+		ID:       "coverage-autoplay",
+		Slides:   coverageSlides(),
+		Autoplay: &AutoplayConfig{Interval: 2500},
+	})
+	for _, want := range []string{
+		`id="coverage-autoplay"`,
+		`x-init="autoplay"`,
+		`autoplayIntervalTime:2500`,
+		`aria-label="pause carousel"`,
+		`x-bind:aria-pressed="isPaused"`,
+		`setAutoplayInterval(autoplayIntervalTime)`,
+	} {
+		if !strings.Contains(autoplayHTML, want) {
+			t.Fatalf("autoplay carousel render missing %q in:\n%s", want, autoplayHTML)
+		}
+	}
+
+	cardHTML := renderCoverageCarousel(t, Config{
+		ID:      "coverage-card",
+		Variant: OnCard,
+		Slides:  coverageSlides(),
+	})
+	for _, want := range []string{
+		`<article`,
+		`id="coverage-card"`,
+		`style="-webkit-mask-image: -webkit-radial-gradient(white, black)"`,
+		`relative h-48 lg:h-64 w-full`,
+		`x-transition.opacity.duration.300ms`,
+		`x-text="slides[currentSlideIndex - 1]?.title || ''"`,
+		`x-text="slides[currentSlideIndex - 1]?.description || ''"`,
+	} {
+		if !strings.Contains(cardHTML, want) {
+			t.Fatalf("card carousel render missing %q in:\n%s", want, cardHTML)
+		}
+	}
+
+	htmxHTML := renderCoverageCarousel(t, Config{
+		ID:        "coverage-htmx",
+		RootClass: "coverage-loader",
+		HTMX: &HTMXConfig{
+			Get:       "/api/carousel",
+			Indicator: "#loading",
+		},
+	})
+	for _, want := range []string{
+		`id="coverage-htmx"`,
+		`coverage-loader min-h-[50svh] flex items-center justify-center`,
+		`hx-get="/api/carousel"`,
+		`hx-trigger="load"`,
+		`hx-swap="innerHTML"`,
+		`hx-indicator="#loading"`,
+		`Loading carousel...`,
+	} {
+		if !strings.Contains(htmxHTML, want) {
+			t.Fatalf("HTMX carousel render missing %q in:\n%s", want, htmxHTML)
+		}
+	}
+}
+
+func renderCoverageCarousel(t *testing.T, cfg Config) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := Carousel(cfg).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("render carousel: %v", err)
+	}
+	return buf.String()
+}
+
+func coverageSlides() []Slide {
+	return []Slide{
+		{
+			ImgSrc:      "/assets/one.webp",
+			ImgAlt:      "Slide one",
+			Title:       "First slide",
+			Description: "First description",
+			CTAHref:     "/first",
+			CTALabel:    "Open first",
+		},
+		{
+			ImgSrc:      "/assets/two.webp",
+			ImgAlt:      "Slide two",
+			Title:       "Second slide",
+			Description: "Second description",
+			CTAHref:     "/second",
+			CTALabel:    "Open second",
+		},
+	}
+}

--- a/site/tests/e2e/carousel_coverage_test.go
+++ b/site/tests/e2e/carousel_coverage_test.go
@@ -1,0 +1,92 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCarouselCoverageDemoVariants(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	page := newPage(t, sharedBrowser)
+	var jsErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			jsErrors = append(jsErrors, m.Text())
+		}
+	})
+	page.On("pageerror", func(err error) {
+		jsErrors = append(jsErrors, err.Error())
+	})
+
+	_, err := page.Goto(baseURL+"/components/carousel", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+	_, err = page.WaitForFunction(`() => typeof Alpine !== 'undefined'`, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, page.GetByRole("heading", playwright.PageGetByRoleOptions{
+		Name:  "Carousel",
+		Exact: playwright.Bool(true),
+	}).WaitFor())
+	for _, selector := range []string{
+		"#carousel-default-c",
+		"#carousel-text-c",
+		"#carousel-cta-c",
+		"#carousel-autoplay-c",
+		"#carousel-aspect-c",
+		"#carousel-touch-c",
+		"#carousel-card-c",
+		"#carousel-htmx",
+	} {
+		require.NoErrorf(t, page.Locator(selector).WaitFor(playwright.LocatorWaitForOptions{
+			State: playwright.WaitForSelectorStateAttached,
+		}), "carousel variant %s should be attached", selector)
+	}
+
+	require.NoError(t, page.Locator("#carousel-text-c").GetByText("Front end developers", playwright.LocatorGetByTextOptions{
+		Exact: playwright.Bool(true),
+	}).WaitFor())
+	require.NoError(t, page.GetByRole("link", playwright.PageGetByRoleOptions{
+		Name: "Get Started",
+	}).WaitFor())
+
+	aspectClass, err := page.Locator("#carousel-aspect-c > div").First().GetAttribute("class")
+	require.NoError(t, err)
+	assert.Contains(t, aspectClass, "aspect-3/1")
+
+	require.NoError(t, waitForCarouselIndex(page, "#carousel-touch-c", 1))
+	indexAfterSwipe, err := page.Locator("#carousel-touch-c").Evaluate(`el => {
+		const data = Alpine.$data(el);
+		data.handleTouchStart({touches: [{clientX: 240}]});
+		data.handleTouchMove({touches: [{clientX: 120}]});
+		data.handleTouchEnd();
+		return data.currentSlideIndex;
+	}`, nil)
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, indexAfterSwipe)
+
+	require.NoError(t, page.Locator("#carousel-card-c").GetByText("Abstract Blue Series", playwright.LocatorGetByTextOptions{
+		Exact: playwright.Bool(true),
+	}).WaitFor())
+	require.NoError(t, page.Locator("#carousel-card-c button[aria-label='next slide']").Click())
+	require.NoError(t, page.Locator("#carousel-card-c").GetByText("Sunset Collection", playwright.LocatorGetByTextOptions{
+		Exact: playwright.Bool(true),
+	}).WaitFor())
+
+	loadedTitle := page.Locator("#carousel-htmx h3").Filter(playwright.LocatorFilterOptions{
+		HasText: "Loaded via HTMX",
+	})
+	require.NoError(t, loadedTitle.WaitFor(playwright.LocatorWaitForOptions{
+		State:   playwright.WaitForSelectorStateVisible,
+		Timeout: playwright.Float(5000),
+	}))
+
+	require.Empty(t, jsErrors, "no JS console/page errors on carousel demo: %v", jsErrors)
+}


### PR DESCRIPTION
Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 009-carousel.md
Coverage focus: components/carousel
Verification: go test ./components/carousel -count=1; go test ./site/tests/e2e -run TestCarouselCoverageDemoVariants; just coverage (total 67.6%, carousel 4% → ~74%)
Auto-merge: OK once CI is green

## What

Adds behavior-focused unit + E2E coverage for `components/carousel`, raising
component coverage from 4.0% (25/629) to ~74%.

- Unit (`components/carousel/carousel_coverage_test.go`): all config helpers in
  `types.go` to 100% (hasOverlay, transition attrs, class builders,
  generateAlpineData, slidesToJSON, jsEscape); render assertions for default,
  text, CTA, autoplay, card, and HTMX variants covering ARIA labels, Alpine
  bindings, HTMX attrs, and overlay branches.
- E2E (`site/tests/e2e/carousel_coverage_test.go`): drives `/components/carousel`
  variant containers, aspect-ratio class, touch-swipe index via Alpine `$data`,
  card next-slide nav, and HTMX slide load — with inline console/pageerror
  capture and deterministic locator waits (no sleeps).

No production changes — tests passed against current source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)