### PR TITLE
fix(ci): repair main — css drift + gofmt

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -751,6 +751,9 @@
   .mt-auto {
     margin-top: auto;
   }
+  .mr-1 {
+    margin-right: calc(var(--spacing) * 1);
+  }
   .mr-2 {
     margin-right: calc(var(--spacing) * 2);
   }
@@ -3313,6 +3316,10 @@
   .opacity-100 {
     opacity: 100%;
   }
+  .shadow {
+    --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
   .shadow-2xl {
     --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, rgb(0 0 0 / 0.25));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -3383,6 +3390,10 @@
   }
   .outline-primary {
     outline-color: var(--color-primary);
+  }
+  .blur {
+    --tw-blur: blur(8px);
+    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
   .grayscale {
     --tw-grayscale: grayscale(100%);
@@ -4933,6 +4944,12 @@
   .data-\[mine\=true\]\:justify-end {
     &[data-mine="true"] {
       justify-content: flex-end;
+    }
+  }
+  .data-\[state\=open\]\:ring-2 {
+    &[data-state="open"] {
+      --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
   }
   .supports-\[backdrop-filter\]\:bg-surface\/60 {

--- a/site/tests/e2e/palette_coverage_test.go
+++ b/site/tests/e2e/palette_coverage_test.go
@@ -22,7 +22,7 @@ func gotoPalette(t *testing.T, page playwright.Page) {
 
 // TestPalette_ResetClearsModel picks a swatch, then clicks Reset and asserts the
 // bound model returns to the empty placeholder ("—"). Covers the Reset
-// pick('', null) branch.
+// pick(empty, null) branch.
 func TestPalette_ResetClearsModel(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping E2E test in short mode")


### PR DESCRIPTION
Main was red on two `lint-build` gates after a batch of parallel coverage merges. This restores green.

## Breakages found (reproduced locally against `origin/main`)
1. **css-drift** (runs first): `assets/styles.css` was stale — a merged demo/component introduced the `mr-1`, `shadow`, `blur`, and `data-[state=open]:ring-2` utilities without running `just css`. Regenerated with the pinned tailwindcss **v4.3.0** (`go run ./cmd/themegen` + `tailwindcss -i css/main.css -o assets/styles.css`). Idempotent.
2. **gofmt**: `site/tests/e2e/palette_coverage_test.go` failed `gofmt -l` — a doc comment read `pick('', null)`, which gofmt's doc-comment formatter rewrites to a curly quote. Reworded to `pick(empty, null)` so it is gofmt-stable and keeps its meaning.

## Verification (in isolated worktree on origin/main)
- `gofmt -l .` → clean tree-wide
- drift checks clean: `templ generate`, `cmd/themegen`, `cmd/skillgen`, `cmd/vendorgen -check`, `go mod tidy`
- `go vet ./...` + root unit tests pass; `site/tests/e2e` package compiles (`go vet`)
- `tailwindcss` re-run produces no further diff (idempotent)

## Notes
- Not a coverage-plan task — this is a direct main-fix. No CLAIMS.md row.
- The cancelled CI runs on main were queue/runner cancellations (zero jobs started), not the failure source; the failure is the two gates above.

Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)