### PR TITLE
fix(ci): regenerate styles.css for carousel demo utilities

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -829,6 +829,9 @@
   .table {
     display: table;
   }
+  .aspect-3\/1 {
+    aspect-ratio: 3/1;
+  }
   .size-1\.5 {
     width: calc(var(--spacing) * 1.5);
     height: calc(var(--spacing) * 1.5);
@@ -937,6 +940,9 @@
   .h-16 {
     height: calc(var(--spacing) * 16);
   }
+  .h-32 {
+    height: calc(var(--spacing) * 32);
+  }
   .h-40 {
     height: calc(var(--spacing) * 40);
   }
@@ -948,6 +954,9 @@
   }
   .h-52 {
     height: calc(var(--spacing) * 52);
+  }
+  .h-64 {
+    height: calc(var(--spacing) * 64);
   }
   .h-80 {
     height: calc(var(--spacing) * 80);


### PR DESCRIPTION
Follow-up to #128. Carousel coverage (#127) merged after #128's branch point and added the `aspect-3/1`, `h-32`, `h-64` demo utilities without running `just css`, so `assets/styles.css` is stale again and the css-drift gate is red on main.

Regenerated on current `origin/main` with pinned tailwindcss **v4.3.0** (`templ generate` + `cmd/themegen` + `tailwindcss -i css/main.css -o assets/styles.css`). Only styles.css changes; gofmt / templ / themegen / go mod tidy all clean.

Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)