### PR TITLE
test(head): cover render error paths and asset contract

### DIFF
--- a/components/head/head_coverage_test.go
+++ b/components/head/head_coverage_test.go
@@ -1,0 +1,172 @@
+package head
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	templruntime "github.com/a-h/templ/runtime"
+)
+
+// component is the small surface every exported head entry point satisfies.
+type component interface {
+	Render(context.Context, io.Writer) error
+}
+
+func entryPoints() []struct {
+	name string
+	comp templ.Component
+} {
+	return []struct {
+		name string
+		comp templ.Component
+	}{
+		{"Dependencies", Dependencies()},
+		{"DependenciesMinimal", DependenciesMinimal()},
+	}
+}
+
+// TestRenderCancelledContext exercises the early ctx.Err() guard at the top of
+// every generated template: a context that is already cancelled must short
+// circuit before any markup is written.
+func TestRenderCancelledContext(t *testing.T) {
+	for _, ep := range entryPoints() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var sb strings.Builder
+		err := ep.comp.Render(ctx, &sb)
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("%s: want context.Canceled, got %v", ep.name, err)
+		}
+		if sb.Len() != 0 {
+			t.Errorf("%s: cancelled render wrote %d bytes, want 0", ep.name, sb.Len())
+		}
+	}
+}
+
+// failWriter returns an error once more than failAfter bytes have been written.
+// It is paired with a 1-byte templ buffer so every generated write flushes
+// straight through to the underlying writer, letting a test drive a failure at
+// any byte offset in the rendered output.
+type failWriter struct {
+	failAfter int
+	written   int
+}
+
+func (w *failWriter) Write(p []byte) (int, error) {
+	if w.written+len(p) > w.failAfter {
+		return 0, errors.New("write failed")
+	}
+	w.written += len(p)
+	return len(p), nil
+}
+
+// tinyBuffer wraps w in a templ runtime buffer backed by a 1-byte bufio writer.
+// Because the value is already a *templruntime.Buffer, the generated GetBuffer
+// call treats it as an existing buffer (no pooled wrapper), so each WriteString
+// flushes immediately and surfaces the underlying writer's error inline.
+func tinyBuffer(w io.Writer) *templruntime.Buffer {
+	prev := templruntime.DefaultBufferSize
+	templruntime.DefaultBufferSize = 1
+	defer func() { templruntime.DefaultBufferSize = prev }()
+
+	b := &templruntime.Buffer{}
+	b.Reset(w)
+	return b
+}
+
+// TestRenderWriteErrorPropagates sweeps a forced write failure across the full
+// byte range of each template. Every generated "if err != nil { return err }"
+// branch after a write is hit at some offset, and a render that is allowed to
+// complete must succeed and emit the asset contract.
+func TestRenderWriteErrorPropagates(t *testing.T) {
+	for _, ep := range entryPoints() {
+		// Establish the full rendered length so the sweep covers every write.
+		full := renderString(t, ep.comp)
+		total := len(full)
+
+		var sawError bool
+		for failAfter := 0; failAfter < total; failAfter++ {
+			fw := &failWriter{failAfter: failAfter}
+			if err := ep.comp.Render(context.Background(), tinyBuffer(fw)); err != nil {
+				sawError = true
+			}
+		}
+		if !sawError {
+			t.Errorf("%s: forced write failures never surfaced an error", ep.name)
+		}
+
+		// A writer that never fails must render the full document successfully.
+		fw := &failWriter{failAfter: total + 1}
+		buf := tinyBuffer(fw)
+		if err := ep.comp.Render(context.Background(), buf); err != nil {
+			t.Errorf("%s: unexpected error with non-failing writer: %v", ep.name, err)
+		}
+		// The generated code leaves this caller-owned buffer unflushed; drain the
+		// final residual byte so the byte count reflects the full document.
+		if err := buf.Flush(); err != nil {
+			t.Errorf("%s: flush: %v", ep.name, err)
+		}
+		if fw.written != total {
+			t.Errorf("%s: wrote %d bytes through tiny buffer, want %d", ep.name, fw.written, total)
+		}
+	}
+}
+
+func renderString(t *testing.T, c component) string {
+	t.Helper()
+	var sb strings.Builder
+	if err := c.Render(context.Background(), &sb); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	return sb.String()
+}
+
+// TestDependenciesEmitsAllRuntimeAssets locks the exact set of script/link tags
+// each entry point emits, including the difference between the full and minimal
+// variants (collapse + focus plugins only in the full set).
+func TestDependenciesEmitsAllRuntimeAssets(t *testing.T) {
+	full := renderString(t, Dependencies())
+	minimal := renderString(t, DependenciesMinimal())
+
+	shared := []string{
+		`<link rel="stylesheet" href="/assets/styles.css">`,
+		"/assets/js/runtime/alpinejs/",
+		"/assets/js/runtime/htmx.org/",
+		`<script defer src="/assets/js/combobox.js"></script>`,
+	}
+	for _, want := range shared {
+		if !strings.Contains(full, want) {
+			t.Errorf("Dependencies() missing %q", want)
+		}
+		if !strings.Contains(minimal, want) {
+			t.Errorf("DependenciesMinimal() missing %q", want)
+		}
+	}
+
+	// Collapse + focus plugins are full-only.
+	for _, fullOnly := range []string{
+		"/assets/js/runtime/alpinejs-collapse/",
+		"/assets/js/runtime/alpinejs-focus/",
+	} {
+		if !strings.Contains(full, fullOnly) {
+			t.Errorf("Dependencies() missing full-only asset %q", fullOnly)
+		}
+		if strings.Contains(minimal, fullOnly) {
+			t.Errorf("DependenciesMinimal() must not emit %q", fullOnly)
+		}
+	}
+
+	// HTMX must load synchronously (no defer) so hx-* attributes bind on first
+	// paint; Alpine core loads deferred.
+	if !strings.Contains(full, `<script src="/assets/js/runtime/htmx.org/`) {
+		t.Errorf("Dependencies() must load HTMX without defer")
+	}
+	if !strings.Contains(full, `<script defer src="/assets/js/runtime/alpinejs/`) {
+		t.Errorf("Dependencies() must defer Alpine core")
+	}
+}

--- a/site/tests/e2e/head_coverage_test.go
+++ b/site/tests/e2e/head_coverage_test.go
@@ -1,0 +1,105 @@
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/araihu/goshtoso/components/head"
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var headAssetRefRe = regexp.MustCompile(`(?:src|href)="(/assets/[^"]+)"`)
+
+func matchAssetURLs(html string) []string {
+	seen := map[string]struct{}{}
+	var urls []string
+	for _, m := range headAssetRefRe.FindAllStringSubmatch(html, -1) {
+		if _, ok := seen[m[1]]; ok {
+			continue
+		}
+		seen[m[1]] = struct{}{}
+		urls = append(urls, m[1])
+	}
+	sort.Strings(urls)
+	return urls
+}
+
+// TestHeadAssetContractServed renders head.Dependencies and DependenciesMinimal,
+// then asserts every asset URL they reference is actually served (HTTP 200) by
+// the running server's mounted asset handler. This is the component's core
+// documented contract: the tags 404 (unstyled page / missing runtime) unless the
+// handler is mounted. The existing TestDependenciesDemoPage only checks the demo
+// code samples, not that the referenced assets resolve.
+func TestHeadAssetContractServed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+
+	var full, minimal strings.Builder
+	require.NoError(t, head.Dependencies().Render(context.Background(), &full))
+	require.NoError(t, head.DependenciesMinimal().Render(context.Background(), &minimal))
+
+	fullURLs := matchAssetURLs(full.String())
+	minimalURLs := matchAssetURLs(minimal.String())
+
+	require.NotEmpty(t, fullURLs, "Dependencies() should reference asset URLs")
+	require.NotEmpty(t, minimalURLs, "DependenciesMinimal() should reference asset URLs")
+
+	// Minimal omits the collapse/focus plugins the full set ships.
+	assert.Greater(t, len(fullURLs), len(minimalURLs),
+		"Dependencies() should reference more assets than DependenciesMinimal()")
+
+	for _, url := range fullURLs {
+		resp, err := http.Get(baseURL + url)
+		require.NoErrorf(t, err, "GET %s", url)
+		assert.Equalf(t, http.StatusOK, resp.StatusCode, "asset %s must be served", url)
+		require.NoError(t, resp.Body.Close())
+	}
+}
+
+// TestDependenciesPageNoConsoleErrors loads the dependencies demo page in a real
+// browser and asserts it boots its runtime without console errors.
+func TestDependenciesPageNoConsoleErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+
+	var consoleErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			consoleErrors = append(consoleErrors, m.Text())
+		}
+	})
+
+	_, err := page.Goto(baseURL+"/components/dependencies", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+
+	// Runtime referenced from the live <head> must initialise.
+	_, err = page.WaitForFunction("() => typeof Alpine !== 'undefined' && typeof window.htmx !== 'undefined'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("main h1").WaitFor())
+	title, err := page.Locator("main h1").TextContent()
+	require.NoError(t, err)
+	assert.Contains(t, title, "Dependencies")
+	assert.Empty(t, consoleErrors, "page should load without console errors")
+}


### PR DESCRIPTION
Raises `components/head` coverage from **75.5% → 91.8%** with behavior-focused unit and E2E tests. No production changes — no bugs surfaced.

## Unit (`components/head/head_coverage_test.go`)
- Cancelled-context guard short-circuits before any markup is written.
- Forced write failures swept across the full output via a 1-byte templ runtime `Buffer` over a failing writer, so every generated `if err != nil { return err }` branch is hit inline.
- Locks the full vs minimal asset set (collapse/focus full-only, HTMX synchronous, Alpine deferred).

## E2E (`site/tests/e2e/head_coverage_test.go`)
- Every `/assets/*` URL `Dependencies`/`DependenciesMinimal` reference is served HTTP 200 by the mounted handler (the documented 404-without-handler contract).
- Dependencies demo page boots Alpine + htmx with no console errors.

Remaining uncovered branches are unreachable: `GetChildren` never returns nil; `ResolveAttributeValue` never errors on constant string asset URLs.

---
Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 040-head.md
Coverage focus: components/head
Verification: go test ./components/head -count=1 (91.8%); go test ./site/tests/e2e -run 'Head|Dependencies'; just coverage (gate green, exit 0)
Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)