### PR TITLE
test(tagslist): add unit + e2e coverage

### DIFF
--- a/components/tagslist/tagslist_coverage_test.go
+++ b/components/tagslist/tagslist_coverage_test.go
@@ -1,0 +1,151 @@
+package tagslist
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func renderTagsList(t *testing.T, cfg Config) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := TagsList(cfg).Render(context.Background(), &buf); err != nil {
+		t.Fatalf("render tagslist: %v", err)
+	}
+	return buf.String()
+}
+
+func TestGetAddLabelDefaultAndCustom(t *testing.T) {
+	if got := (Config{}).GetAddLabel(); got != "Add" {
+		t.Fatalf("default add label = %q, want %q", got, "Add")
+	}
+	if got := (Config{AddActionLabel: "Append"}).GetAddLabel(); got != "Append" {
+		t.Fatalf("custom add label = %q, want %q", got, "Append")
+	}
+}
+
+func TestGetPlaceholderDefaultAndCustom(t *testing.T) {
+	if got := (Config{}).GetPlaceholder(); got != "Add a tag..." {
+		t.Fatalf("default placeholder = %q, want %q", got, "Add a tag...")
+	}
+	if got := (Config{Placeholder: "Type here"}).GetPlaceholder(); got != "Type here" {
+		t.Fatalf("custom placeholder = %q, want %q", got, "Type here")
+	}
+}
+
+func TestContainerClassesDefaultAndRootClass(t *testing.T) {
+	base := (Config{}).ContainerClasses()
+	if base != "flex flex-col gap-2" {
+		t.Fatalf("default container classes = %q", base)
+	}
+	withRoot := (Config{RootClass: "mt-4 custom"}).ContainerClasses()
+	if withRoot != "flex flex-col gap-2 mt-4 custom" {
+		t.Fatalf("rootclass container classes = %q", withRoot)
+	}
+}
+
+func TestAlpineDataEmptyValues(t *testing.T) {
+	got := (Config{Name: "tags"}).AlpineData()
+	if !strings.Contains(got, "items: []") {
+		t.Fatalf("empty values should yield empty items array: %s", got)
+	}
+	if !strings.Contains(got, "name: 'tags'") {
+		t.Fatalf("expected name in alpine data: %s", got)
+	}
+	if !strings.Contains(got, "newTag: ''") {
+		t.Fatalf("expected newTag in alpine data: %s", got)
+	}
+}
+
+func TestAlpineDataMultipleValuesCommaSeparated(t *testing.T) {
+	got := (Config{Name: "tags", Values: []string{"a", "b", "c"}}).AlpineData()
+	if !strings.Contains(got, "items: ['a','b','c']") {
+		t.Fatalf("multiple values should be comma-separated single-quoted: %s", got)
+	}
+}
+
+func TestAlpineDataEscapesBackslash(t *testing.T) {
+	got := (Config{Name: `na\me`, Values: []string{`a\b`}}).AlpineData()
+	if !strings.Contains(got, `'a\\b'`) {
+		t.Fatalf("backslash in value should be escaped: %s", got)
+	}
+	if !strings.Contains(got, `name: 'na\\me'`) {
+		t.Fatalf("backslash in name should be escaped: %s", got)
+	}
+}
+
+func TestRenderWithIDIncludesIDAttr(t *testing.T) {
+	html := renderTagsList(t, Config{ID: "mytags", Name: "tags"})
+	if !strings.Contains(html, `id="mytags"`) {
+		t.Fatalf("expected id attribute, got: %s", html)
+	}
+}
+
+func TestRenderWithoutIDOmitsIDAttr(t *testing.T) {
+	html := renderTagsList(t, Config{Name: "tags"})
+	if strings.Contains(html, "id=") {
+		t.Fatalf("expected no id attribute when ID empty, got: %s", html)
+	}
+	if !strings.Contains(html, "data-tagslist") {
+		t.Fatalf("expected data-tagslist marker, got: %s", html)
+	}
+}
+
+func TestRenderEnabledHasInputAddAndRemove(t *testing.T) {
+	html := renderTagsList(t, Config{ID: "t", Name: "tags", Values: []string{"x"}})
+	for _, want := range []string{
+		"data-tagslist-input",
+		"data-tagslist-add",
+		`aria-label="Remove tag"`,
+		"addTag()",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("enabled render missing %q in %s", want, html)
+		}
+	}
+}
+
+func TestRenderDisabledOmitsInputAddAndRemove(t *testing.T) {
+	html := renderTagsList(t, Config{
+		ID:       "t",
+		Name:     "locked",
+		Values:   []string{"locked", "readonly"},
+		Disabled: true,
+	})
+	// Chips still render.
+	if !strings.Contains(html, "data-tagslist-chips") {
+		t.Fatalf("disabled render should still include chips: %s", html)
+	}
+	for _, unwanted := range []string{
+		"data-tagslist-input",
+		"data-tagslist-add",
+		`aria-label="Remove tag"`,
+	} {
+		if strings.Contains(html, unwanted) {
+			t.Fatalf("disabled render should not include %q in %s", unwanted, html)
+		}
+	}
+}
+
+func TestRenderUsesCustomAddLabelAndPlaceholder(t *testing.T) {
+	html := renderTagsList(t, Config{
+		ID:             "t",
+		Name:           "tags",
+		AddActionLabel: "Insert",
+		Placeholder:    "New tag name",
+	})
+	if !strings.Contains(html, "Insert") {
+		t.Fatalf("expected custom add label in render: %s", html)
+	}
+	if !strings.Contains(html, `placeholder="New tag name"`) {
+		t.Fatalf("expected custom placeholder in render: %s", html)
+	}
+}
+
+func TestRenderAppliesRootClass(t *testing.T) {
+	html := renderTagsList(t, Config{Name: "tags", RootClass: "border-test"})
+	if !strings.Contains(html, "border-test") {
+		t.Fatalf("expected RootClass applied to container: %s", html)
+	}
+}

--- a/site/tests/e2e/tagslist_coverage_test.go
+++ b/site/tests/e2e/tagslist_coverage_test.go
@@ -1,0 +1,79 @@
+package e2e
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTagsList_CoverageDemoNoConsoleErrors loads the demo page, asserts every
+// variant container renders, and guards against console errors during an
+// add/remove interaction cycle.
+func TestTagsList_CoverageDemoNoConsoleErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+
+	var mu sync.Mutex
+	var consoleErrors []string
+	page.On("console", func(msg playwright.ConsoleMessage) {
+		if msg.Type() == "error" {
+			mu.Lock()
+			consoleErrors = append(consoleErrors, msg.Text())
+			mu.Unlock()
+		}
+	})
+
+	gotoTagsList(t, page)
+
+	// All three demo variant containers render.
+	for _, id := range []string{"#tagsDemo", "#labelsDemo", "#disabledTagsDemo"} {
+		require.NoError(t, page.Locator(id).WaitFor(), "variant %s should render", id)
+	}
+
+	// Add two tags to the empty list, then remove one.
+	container := page.Locator("#labelsDemo")
+	input := container.Locator("[data-tagslist-input]")
+	chips := container.Locator("[data-tagslist-chips] > span")
+
+	fillAndDispatchInput(t, input, "alpha")
+	require.NoError(t, input.Press("Enter"))
+	fillAndDispatchInput(t, input, "beta")
+	require.NoError(t, input.Press("Enter"))
+
+	// Wait for the second chip to exist before counting.
+	require.NoError(t, chips.Nth(1).WaitFor())
+	count, err := chips.Count()
+	require.NoError(t, err)
+	assert.Equal(t, 2, count, "two tags added via Enter")
+
+	// Hidden inputs use the indexed name prefix.
+	hidden := container.Locator("input[type='hidden'][name='labels[0]']")
+	val, err := hidden.GetAttribute("value")
+	require.NoError(t, err)
+	assert.Equal(t, "alpha", val)
+
+	removeBtn := container.Locator("button[aria-label='Remove tag']").First()
+	require.NoError(t, removeBtn.Click())
+	require.NoError(t, chips.Nth(1).WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateDetached,
+	}))
+	count, err = chips.Count()
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "one tag remains after remove")
+
+	mu.Lock()
+	errs := append([]string(nil), consoleErrors...)
+	mu.Unlock()
+	assert.Empty(t, errs, "no console errors expected, got: %s", strings.Join(errs, "; "))
+}


### PR DESCRIPTION
Raises `components/tagslist` component-only coverage **76.7% → 80.6%** (104/129 statements). All `types.go` helpers now 100% (`GetAddLabel`, `GetPlaceholder`, `ContainerClasses`, `AlpineData`, `jsEscapeSingle`). Remaining uncovered statements are generated templ error-path boilerplate.

- Unit tests (`components/tagslist/tagslist_coverage_test.go`): cover helper default/custom branches, RootClass, multi-value comma separation, backslash escaping, and templ Disabled / no-ID / custom-label render branches via buffer rendering.
- E2E test (`site/tests/e2e/tagslist_coverage_test.go`): asserts all three demo variant containers render, exercises add-via-Enter + remove with deterministic locator waits, and guards against console errors inline via `page.On("console", ...)`.

No production code changed; no bugs exposed. No `.templ` changes, so no regeneration needed.

Harness: Claude Code (Opus 4.8 1M, caveman)
Taken: 042-tagslist.md
Coverage focus: components/tagslist
Verification: go test ./components/tagslist -count=1; go test ./site/tests/e2e/... -run TagsList; just coverage (exit 0)
Auto-merge: OK once CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)