### PR TITLE
ci: refresh coverage badge to 68.0%

### DIFF
--- a/badges/coverage.svg
+++ b/badges/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 39.6%">
-  <title>coverage: 39.6%</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="106" height="20" role="img" aria-label="coverage: 68.0%">
+  <title>coverage: 68.0%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -11,13 +11,13 @@
   </clipPath>
   <g clip-path="url(#r)">
     <rect width="59" height="20" fill="#555"/>
-    <rect x="59" width="47" height="20" fill="#e05d44"/>
+    <rect x="59" width="47" height="20" fill="#97ca00"/>
     <rect width="106" height="20" fill="url(#s)"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
     <text x="30" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="30" y="14">coverage</text>
-    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">39.6%</text>
-    <text x="81.5" y="14">39.6%</text>
+    <text x="81.5" y="15" fill="#010101" fill-opacity=".3">68.0%</text>
+    <text x="81.5" y="14">68.0%</text>
   </g>
 </svg>


### PR DESCRIPTION
## What

Regenerate `badges/coverage.svg`: **39.6% → 68.0%**.

## Why

Coverage PRs #89–#133 raised real component coverage but the badge stayed frozen at 39.6%:

1. **Badge is a drift-check, not an auto-writer.** `ci.yml` only does `git diff --exit-code -- badges/coverage.svg`; it never commits. Authors must run `just coverage` and commit the SVG. None of the coverage PRs did.
2. **Coverage job rarely completes on main.** The `coverage`/`deploy` jobs are push-only; the concurrency group `ci-CI-refs/heads/main` cancels superseded main-push runs. Rapid merges cancelled them before they finished — last successful main run was #88.
3. **`main` is not branch-protected**, so red PRs (and missing badge bumps) merged unblocked.

This PR fixes the symptom (stale badge). Follow-ups worth doing separately:
- Scope concurrency so main-push runs don't cancel each other (use `run_id` in group for push).
- Add required status checks on `main`.
- Optionally make the badge self-updating on main-push instead of drift-checked.

## Verification

`just coverage` (unit + e2e):
```text
total: (statements) 68.0%
```
Only `badges/coverage.svg` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)