### PR TITLE
test(dropdown): add component coverage

### DIFF
--- a/components/dropdown/dropdown_coverage_test.go
+++ b/components/dropdown/dropdown_coverage_test.go
@@ -1,0 +1,110 @@
+package dropdown
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/stretchr/testify/assert"
+)
+
+func testDropdownIcon(label string) templ.Component {
+	return templ.ComponentFunc(func(ctx context.Context, w io.Writer) error {
+		_, err := io.WriteString(w, `<svg data-icon="`+label+`" aria-hidden="true"></svg>`)
+		return err
+	})
+}
+
+func TestCoverageRenderHoverDropdownWithIconOnlyTrigger(t *testing.T) {
+	rendered := renderDropdown(t, Config{
+		ID:              "hover-actions",
+		Label:           "More actions",
+		TriggerMode:     TriggerHover,
+		TriggerIcon:     testDropdownIcon("trigger"),
+		TriggerIconOnly: true,
+		MenuAlign:       AlignEnd,
+		Sections: []Section{{Items: []Item{
+			{Label: "Open", Href: "/open", Icon: testDropdownIcon("open")},
+			{Label: "Archive", Disabled: true, Tooltip: "Locked"},
+		}}},
+	})
+
+	assert.Contains(t, rendered, `id="hover-actions"`)
+	assert.Contains(t, rendered, `x-on:mouseover="isOpen = true"`)
+	assert.Contains(t, rendered, `x-on:mouseleave.prevent=`)
+	assert.Contains(t, rendered, `aria-label="More actions"`)
+	assert.Contains(t, rendered, `data-icon="trigger"`)
+	assert.Contains(t, rendered, `right-0`)
+	assert.Contains(t, rendered, `href="/open"`)
+	assert.Contains(t, rendered, `disabled`)
+	assert.Contains(t, rendered, `title="Locked"`)
+	assert.Contains(t, rendered, `opacity-50`)
+	assert.NotContains(t, rendered, `More actions<svg`)
+}
+
+func TestCoverageRenderContextDropdownItems(t *testing.T) {
+	rendered := renderDropdown(t, Config{
+		ID:          "context-actions",
+		TriggerMode: TriggerContext,
+		Sections: []Section{
+			{Items: []Item{
+				{Label: "Rename", Icon: testDropdownIcon("rename"), Shortcut: "R"},
+				{Label: "Duplicate", Icon: testDropdownIcon("duplicate"), Shortcut: "D", ShortcutIcon: testDropdownIcon("shift")},
+			}},
+			{Items: []Item{
+				{Label: "Delete", OnClick: "deleted = true", Danger: true, ID: "delete-item"},
+				{Label: "Export", Disabled: true, Tooltip: "Unavailable", ID: "export-item"},
+			}},
+		},
+	})
+
+	for _, want := range []string{
+		`id="context-actions"`,
+		`aria-label="context menu"`,
+		`x-on:contextmenu.prevent="isOpen = true"`,
+		`top-8 absolute left-0`,
+		`<ul class="flex flex-col py-1.5" role="none">`,
+		`tabindex="0"`,
+		`data-icon="rename"`,
+		`data-icon="shift"`,
+		`>R</div>`,
+		`id="delete-item"`,
+		`x-on:click="deleted = true"`,
+		`text-danger`,
+		`id="export-item"`,
+		`disabled`,
+		`title="Unavailable"`,
+	} {
+		assert.Contains(t, rendered, want)
+	}
+}
+
+func TestCoverageRenderDividersAndDefaultIconOnlyAriaLabel(t *testing.T) {
+	rendered := renderDropdown(t, Config{
+		ID:              "unnamed-actions",
+		TriggerIcon:     testDropdownIcon("overflow"),
+		TriggerIconOnly: true,
+		Sections: []Section{
+			{Items: []Item{{Label: "One", Href: "#one"}}},
+			{Items: []Item{{Label: "Two", OnClick: "two = true"}}},
+		},
+	})
+
+	assert.Contains(t, rendered, `aria-label="open menu"`)
+	assert.Contains(t, rendered, `divide-y divide-outline dark:divide-outline-dark`)
+	assert.Contains(t, rendered, `class="flex flex-col py-1.5"`)
+	assert.Contains(t, rendered, `x-on:click="two = true"`)
+	assert.Equal(t, 2, strings.Count(rendered, `role="menuitem"`))
+}
+
+func TestCoverageConfigHasShortcuts(t *testing.T) {
+	assert.False(t, Config{}.HasShortcuts())
+	assert.False(t, Config{
+		Sections: []Section{{Items: []Item{{Label: "Copy"}}}},
+	}.HasShortcuts())
+	assert.True(t, Config{
+		Sections: []Section{{Items: []Item{{Label: "Copy", Shortcut: "C"}}}},
+	}.HasShortcuts())
+}

--- a/site/tests/e2e/dropdown_coverage_test.go
+++ b/site/tests/e2e/dropdown_coverage_test.go
@@ -1,0 +1,96 @@
+package e2e
+
+import (
+	"testing"
+
+	"github.com/playwright-community/playwright-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDropdownCoverageDemo(t *testing.T) {
+	page := newPage(t, sharedBrowser)
+
+	var jsErrors []string
+	page.On("console", func(m playwright.ConsoleMessage) {
+		if m.Type() == "error" {
+			jsErrors = append(jsErrors, m.Text())
+		}
+	})
+	page.On("pageerror", func(err error) {
+		jsErrors = append(jsErrors, err.Error())
+	})
+
+	_, err := page.Goto(baseURL+"/components/dropdown", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateNetworkidle,
+	})
+	require.NoError(t, err)
+
+	_, err = page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil)
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("#dropdown-click").ScrollIntoViewIfNeeded())
+	require.NoError(t, page.Locator("main").GetByText("Dropdown").First().WaitFor())
+
+	hoverTrigger := page.Locator("#dropdown-hover button").First()
+	require.NoError(t, hoverTrigger.Hover())
+	require.NoError(t, page.Locator("#dropdown-hover [role='menu']").WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+	hoverExpanded, err := hoverTrigger.Evaluate("el => el.getAttribute('aria-expanded')", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "true", hoverExpanded)
+
+	contextTrigger := page.Locator("#dropdown-context button").First()
+	require.NoError(t, contextTrigger.Click())
+	require.NoError(t, page.Locator("#dropdown-context ul[role='none']").First().WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+	contextExpanded, err := contextTrigger.Evaluate("el => el.getAttribute('aria-expanded')", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "true", contextExpanded)
+	contextItemTag, err := page.Locator("#dropdown-context [role='menuitem']").First().Evaluate("el => el.tagName.toLowerCase()", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "li", contextItemTag)
+	require.NoError(t, page.Keyboard().Press("Escape"))
+	_, err = page.WaitForFunction(`() => document.querySelector("#dropdown-context button").getAttribute("aria-expanded") === "false"`, nil)
+	require.NoError(t, err)
+
+	actionTrigger := page.Locator("#dropdown-actions button").First()
+	require.NoError(t, actionTrigger.ScrollIntoViewIfNeeded())
+	ariaLabel, err := actionTrigger.GetAttribute("aria-label")
+	require.NoError(t, err)
+	assert.Equal(t, "cluster actions", ariaLabel)
+	svgCount, err := actionTrigger.Locator("svg").Count()
+	require.NoError(t, err)
+	assert.Equal(t, 1, svgCount)
+
+	require.NoError(t, actionTrigger.Click())
+	_, err = page.WaitForFunction(`() => document.querySelector("#dropdown-actions button").getAttribute("aria-expanded") === "true"`, nil)
+	require.NoError(t, err)
+
+	editItem := page.Locator("#dropdown-actions-edit")
+	editTag, err := editItem.Evaluate("el => el.tagName.toLowerCase()", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "button", editTag)
+	require.NoError(t, editItem.Click())
+	_, err = page.WaitForFunction(`() => {
+		const el = document.querySelector('[x-data*="editOpen"]');
+		return el && el._x_dataStack[0].editOpen === true && el._x_dataStack[0].editCount === 1;
+	}`, nil)
+	require.NoError(t, err)
+
+	archiveItem := page.Locator("#dropdown-actions-archive")
+	disabled, err := archiveItem.Evaluate("el => el.hasAttribute('disabled')", nil)
+	require.NoError(t, err)
+	assert.Equal(t, true, disabled)
+	archiveClass, err := archiveItem.GetAttribute("class")
+	require.NoError(t, err)
+	assert.Contains(t, archiveClass, "pointer-events-none")
+
+	deleteClass, err := page.Locator("#dropdown-actions-delete").GetAttribute("class")
+	require.NoError(t, err)
+	assert.Contains(t, deleteClass, "text-danger")
+
+	require.Empty(t, jsErrors, "no JS console/page errors on dropdown demo: %v", jsErrors)
+}


### PR DESCRIPTION
Harness: Codex
Taken: 013-dropdown.md
Coverage focus: components/dropdown
Verification:
- go test ./components/dropdown -count=1
- cd site && go test ./tests/e2e/... -count=1 -timeout 5m -run 'TestDropdownCoverageDemo'\n- cd site && go test ./tests/e2e/... -count=1 -timeout 5m -run 'Dropdown'\n- just coverage\nAuto-merge: OK once CI is green