### PR TITLE
test: fix staticcheck failures blocking main

### DIFF
--- a/components/link/link_coverage_test.go
+++ b/components/link/link_coverage_test.go
@@ -127,7 +127,7 @@ func TestIconLeadingPlacement(t *testing.T) {
 	// Leading icon should appear before the closing tag content marker; assert
 	// it precedes any trailing position by checking it renders right after <a>.
 	openIdx := strings.Index(html, ">")
-	if !(openIdx < iconIdx && iconIdx < textIdx) {
+	if openIdx >= iconIdx || iconIdx >= textIdx {
 		t.Fatalf("expected leading icon between open tag and close: %s", html)
 	}
 }

--- a/components/textarea/textarea_coverage_test.go
+++ b/components/textarea/textarea_coverage_test.go
@@ -149,10 +149,8 @@ func TestCoverageRenderWithActions(t *testing.T) {
 
 func TestCoverageWithActionsNoRootClass(t *testing.T) {
 	html := render(t, TextareaWithActions(Config{ID: "a"}))
-	// condClass("") returns "" → container class ends at base without trailing space class.
-	if strings.Contains(html, "dark:text-on-surface-dark ") {
-		// acceptable; just ensure no stray duplicate; primary assertion is render succeeded
-	}
+	// condClass("") returns "" → container class ends at base without a trailing
+	// space class; the primary assertion is simply that the render succeeded.
 	if !strings.Contains(html, "<textarea") {
 		t.Fatalf("expected textarea: %s", html)
 	}


### PR DESCRIPTION
## Problem

main's required check `Lint, drift checks, build` is **red** — two staticcheck issues from recent coverage PRs are failing `golangci-lint`, which (with the new branch protection) blocks every merge to main:

```
components/link/link_coverage_test.go:130:5: QF1001: could apply De Morgan's law
components/textarea/textarea_coverage_test.go:153:2: SA9003: empty branch
```

## Fix

- **link**: rewrite `if !(openIdx < iconIdx && iconIdx < textIdx)` → `if openIdx >= iconIdx || iconIdx >= textIdx`.
- **textarea**: drop the empty `if strings.Contains(...) {}` branch (asserted nothing); keep the real render-succeeded check.

Two files, behaviour-equivalent. `golangci-lint run` on both packages locally: `0 issues`.

This unblocks main for all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test assertions and comments for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->