### PR TITLE
chore(site): pin library to v0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://github.com/araihu/goshtoso/actions/workflows/ci.yml"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/guilycst/fb3843c3a13793eb6cc0af638bc00ad4/raw/coverage.json" alt="Coverage" /></a>
   <a href="https://pkg.go.dev/github.com/araihu/goshtoso"><img src="https://pkg.go.dev/badge/github.com/araihu/goshtoso.svg" alt="Go Reference" /></a>
   <a href="https://goreportcard.com/report/github.com/araihu/goshtoso"><img src="https://goreportcard.com/badge/github.com/araihu/goshtoso" alt="Go Report Card" /></a>
-  <a href="https://github.com/araihu/goshtoso/releases"><img src="https://img.shields.io/github/v/tag/araihu/goshtoso?label=release&sort=semver" alt="Latest tag" /></a>
+  <a href="https://github.com/araihu/goshtoso/releases/tag/v0.0.4"><img src="https://img.shields.io/badge/release-v0.0.4-blue.svg" alt="Release: v0.0.4" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
 </p>
 

--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.0.3
+	github.com/araihu/goshtoso v0.0.4
 	github.com/coder/websocket v1.8.14
 	github.com/playwright-community/playwright-go v0.5700.1
 	github.com/stretchr/testify v1.11.1

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6
 github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.0.3 h1:C4UXjT2JdksjgHeOs+ti0rOszSiMGWlNF9vyHJQeQEs=
-github.com/araihu/goshtoso v0.0.3/go.mod h1:pEJfw8LGHQpyX60yGckzuxog5XwwtGfvKI7Y8f7PP24=
+github.com/araihu/goshtoso v0.0.4 h1:Ugp/BjMxo/JLTojdIdzXZXtMzVRo9m6GvQ8sVpD8dC0=
+github.com/araihu/goshtoso v0.0.4/go.mod h1:pEJfw8LGHQpyX60yGckzuxog5XwwtGfvKI7Y8f7PP24=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
## Summary
- Pin the site module to the newly released github.com/araihu/goshtoso v0.0.4 tag.
- Refresh site/go.sum for the released module checksum.
- Pin the README release badge to v0.0.4 to avoid the flaky Shields GitHub tag endpoint token-pool error.

## Verification
- templ generate
- just css
- go build -o bin/server ./site/cmd/server
- go test ./... -count=1
- cd site && go test $(go list ./... | grep -v /tests/e2e) -count=1
- git diff --check
- curl -fsSL 'https://img.shields.io/badge/release-v0.0.4-blue.svg' | rg 'release: v0\.0\.4'

## Notes
The v0.0.4 release workflow successfully created the GitHub release and uploaded CSS assets, but its final direct push to main was rejected by branch protection. This PR carries the same pin-back change through the protected-branch workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped an internal dependency to version v0.0.4.

* **Documentation**
  * Updated the project release badge to reference v0.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->