### PR TITLE
test: raise component coverage for uncovered paths

### DIFF
--- a/components/chatbubble/chatbubble_coverage_test.go
+++ b/components/chatbubble/chatbubble_coverage_test.go
@@ -1,0 +1,110 @@
+package chatbubble
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func render(t *testing.T, c templ.Component) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, c.Render(context.Background(), &buf))
+	return buf.String()
+}
+
+func TestCoverageConfigHelpers(t *testing.T) {
+	sent := Config{Side: Sent, RootClass: "extra-row"}
+	assert.True(t, sent.IsMine())
+	assert.Equal(t, "true", sent.DataMine())
+	assert.Contains(t, sent.RowClasses(), "mt-4")
+	assert.Contains(t, sent.RowClasses(), "extra-row")
+	assert.Contains(t, sent.BubbleClasses(), "group-data-[mine=true]:bg-primary")
+
+	received := Config{Side: Received, Grouped: true}
+	assert.False(t, received.IsMine())
+	assert.Equal(t, "false", received.DataMine())
+	assert.Contains(t, received.RowClasses(), "mt-0.5")
+
+	assert.True(t, Config{ShowAvatar: true}.HasAvatar())
+	assert.False(t, Config{ShowAvatar: true, Grouped: true}.HasAvatar())
+	assert.True(t, Config{SenderName: "Ada"}.HasHeader())
+	assert.False(t, Config{SenderName: "Ada", Grouped: true}.HasHeader())
+}
+
+func TestCoverageChatBubbleRendersAutoSenderRootAttrsAndEscapedMessage(t *testing.T) {
+	html := render(t, ChatBubble(Config{
+		Side:           Auto,
+		Sender:         "ada@example",
+		SenderName:     "Ada",
+		Message:        `<script>alert("x")</script>`,
+		Timestamp:      "11:32",
+		AvatarInitials: "AL",
+		AvatarVariant:  "info",
+		ShowAvatar:     true,
+		IsBot:          true,
+		RootClass:      "audit-row",
+		RootAttrs: templ.Attributes{
+			"data-testid": "bubble",
+		},
+	}))
+
+	assert.Contains(t, html, `data-mine="false"`)
+	assert.Contains(t, html, `data-sender="ada@example"`)
+	assert.Contains(t, html, `data-testid="bubble"`)
+	assert.Contains(t, html, "audit-row")
+	assert.Contains(t, html, "Ada")
+	assert.Contains(t, html, "11:32")
+	assert.Contains(t, html, "BOT")
+	assert.Contains(t, html, "AL")
+	assert.Contains(t, html, `&lt;script&gt;alert(&#34;x&#34;)&lt;/script&gt;`)
+	assert.NotContains(t, html, `<script>alert`)
+}
+
+func TestCoverageChatBubbleSentStatusAndGroupedSuppressions(t *testing.T) {
+	sent := render(t, ChatBubble(Config{
+		Side:       Sent,
+		SenderName: "Me",
+		Message:    "On my way",
+		Status:     StatusSeen,
+	}))
+
+	assert.Contains(t, sent, `data-mine="true"`)
+	assert.Contains(t, sent, "On my way")
+	assert.Contains(t, sent, "Seen")
+	assert.Contains(t, sent, "group-data-[mine=true]:hidden")
+
+	grouped := render(t, ChatBubble(Config{
+		Side:           Received,
+		SenderName:     "Ada",
+		Message:        "Follow-up",
+		ShowAvatar:     true,
+		AvatarInitials: "AL",
+		Grouped:        true,
+	}))
+
+	assert.Contains(t, grouped, "Follow-up")
+	assert.NotContains(t, grouped, ">Ada<")
+	assert.NotContains(t, grouped, ">AL<")
+}
+
+func TestCoverageTypingIndicator(t *testing.T) {
+	html := render(t, TypingIndicator(Config{
+		ShowAvatar:     true,
+		AvatarInitials: "AL",
+		AvatarVariant:  "info",
+		RootClass:      "typing-row",
+	}))
+
+	assert.Contains(t, html, `aria-label="typing"`)
+	assert.Contains(t, html, `aria-live="polite"`)
+	assert.Contains(t, html, `data-mine="false"`)
+	assert.Contains(t, html, "typing-row")
+	assert.Equal(t, 3, strings.Count(html, "animate-bounce"))
+	assert.Contains(t, html, "AL")
+}

--- a/components/dropdown/dropdown_coverage_test.go
+++ b/components/dropdown/dropdown_coverage_test.go
@@ -2,11 +2,13 @@ package dropdown
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/a-h/templ"
+	templruntime "github.com/a-h/templ/runtime"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,6 +17,35 @@ func testDropdownIcon(label string) templ.Component {
 		_, err := io.WriteString(w, `<svg data-icon="`+label+`" aria-hidden="true"></svg>`)
 		return err
 	})
+}
+
+func failingDropdownIcon(err error) templ.Component {
+	return templ.ComponentFunc(func(ctx context.Context, w io.Writer) error {
+		return err
+	})
+}
+
+type failingDropdownWriter struct {
+	failAfter int
+	written   int
+}
+
+func (w *failingDropdownWriter) Write(p []byte) (int, error) {
+	if w.written+len(p) > w.failAfter {
+		return 0, errors.New("dropdown write failed")
+	}
+	w.written += len(p)
+	return len(p), nil
+}
+
+func tinyDropdownBuffer(w io.Writer) *templruntime.Buffer {
+	previousSize := templruntime.DefaultBufferSize
+	templruntime.DefaultBufferSize = 1
+	defer func() { templruntime.DefaultBufferSize = previousSize }()
+
+	buf := &templruntime.Buffer{}
+	buf.Reset(w)
+	return buf
 }
 
 func TestCoverageRenderHoverDropdownWithIconOnlyTrigger(t *testing.T) {
@@ -107,4 +138,228 @@ func TestCoverageConfigHasShortcuts(t *testing.T) {
 	assert.True(t, Config{
 		Sections: []Section{{Items: []Item{{Label: "Copy", Shortcut: "C"}}}},
 	}.HasShortcuts())
+}
+
+func TestCoverageDropdownRenderPropagatesNestedIconErrors(t *testing.T) {
+	renderErr := errors.New("dropdown icon render failed")
+	icon := failingDropdownIcon(renderErr)
+
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "click icon only trigger",
+			cfg: Config{
+				TriggerIcon:     icon,
+				TriggerIconOnly: true,
+				Sections:        []Section{{Items: []Item{{Label: "Open", Href: "/open"}}}},
+			},
+		},
+		{
+			name: "hover icon only trigger",
+			cfg: Config{
+				TriggerMode:     TriggerHover,
+				TriggerIcon:     icon,
+				TriggerIconOnly: true,
+				Sections:        []Section{{Items: []Item{{Label: "Open", Href: "/open"}}}},
+			},
+		},
+		{
+			name: "context trigger icon",
+			cfg: Config{
+				TriggerMode: TriggerContext,
+				TriggerIcon: icon,
+				Sections:    []Section{{Items: []Item{{Label: "Open", Href: "/open"}}}},
+			},
+		},
+		{
+			name: "link item icon",
+			cfg: Config{
+				Sections: []Section{{Items: []Item{{Label: "Open", Href: "/open", Icon: icon}}}},
+			},
+		},
+		{
+			name: "button item icon",
+			cfg: Config{
+				Sections: []Section{{Items: []Item{{Label: "Run", OnClick: "run()", Icon: icon}}}},
+			},
+		},
+		{
+			name: "context item icon",
+			cfg: Config{
+				TriggerMode: TriggerContext,
+				Sections:    []Section{{Items: []Item{{Label: "Open", Href: "/open", Icon: icon}}}},
+			},
+		},
+		{
+			name: "context shortcut icon",
+			cfg: Config{
+				TriggerMode: TriggerContext,
+				Sections: []Section{{Items: []Item{{
+					Label:        "Open",
+					Href:         "/open",
+					Shortcut:     "O",
+					ShortcutIcon: icon,
+				}}}},
+			},
+		},
+		{
+			name: "context button item icon",
+			cfg: Config{
+				TriggerMode: TriggerContext,
+				Sections:    []Section{{Items: []Item{{Label: "Run", OnClick: "run()", Icon: icon}}}},
+			},
+		},
+		{
+			name: "context button shortcut icon",
+			cfg: Config{
+				TriggerMode: TriggerContext,
+				Sections: []Section{{Items: []Item{{
+					Label:        "Run",
+					OnClick:      "run()",
+					Shortcut:     "R",
+					ShortcutIcon: icon,
+				}}}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rendered strings.Builder
+			err := Dropdown(tt.cfg).Render(context.Background(), &rendered)
+			assert.ErrorIs(t, err, renderErr)
+		})
+	}
+}
+
+func TestCoverageDropdownHelpersPropagateCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cfg := Config{
+		Label: "Actions",
+		Sections: []Section{{Items: []Item{{
+			Label:    "Open",
+			Href:     "/open",
+			Shortcut: "O",
+		}}}},
+	}
+	item := cfg.Sections[0].Items[0]
+
+	tests := []struct {
+		name      string
+		component templ.Component
+	}{
+		{name: "dropdown", component: Dropdown(cfg)},
+		{name: "click dropdown", component: clickDropdown(cfg)},
+		{name: "hover dropdown", component: hoverDropdown(cfg)},
+		{name: "context dropdown", component: contextDropdown(cfg)},
+		{name: "trigger button", component: triggerButton(cfg)},
+		{name: "hover trigger button", component: hoverTriggerButton(cfg)},
+		{name: "context trigger button", component: contextTriggerButton(cfg)},
+		{name: "dropdown menu", component: dropdownMenu(cfg)},
+		{name: "context dropdown menu", component: contextDropdownMenu(cfg)},
+		{name: "menu item", component: menuItem(cfg, item)},
+		{name: "menu item link", component: menuItemLink(cfg, item)},
+		{name: "menu item button", component: menuItemButton(cfg, Item{Label: "Run", OnClick: "run()"})},
+		{name: "context menu item", component: contextMenuItem(cfg, item)},
+		{name: "context menu item plain", component: contextMenuItemPlain(cfg, item)},
+		{name: "context menu item button", component: contextMenuItemButton(cfg, Item{Label: "Run", OnClick: "run()"})},
+		{name: "chevron icon", component: chevronIcon()},
+		{name: "dots icon", component: dotsIcon()},
+		{name: "cmd icon", component: cmdIcon()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rendered strings.Builder
+			err := tt.component.Render(ctx, &rendered)
+			assert.ErrorIs(t, err, context.Canceled)
+			assert.Empty(t, rendered.String())
+		})
+	}
+}
+
+func TestCoverageDropdownRenderPropagatesWriteErrors(t *testing.T) {
+	configs := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "click",
+			cfg: Config{
+				ID:              "click-actions",
+				Label:           "Actions",
+				TriggerIcon:     testDropdownIcon("trigger"),
+				TriggerIconOnly: true,
+				MenuAlign:       AlignEnd,
+				Sections: []Section{
+					{Items: []Item{
+						{Label: "Open", Href: "/open", Icon: testDropdownIcon("open"), Tooltip: "Open file", ID: "open-item"},
+						{Label: "Archive", OnClick: "archive()", Icon: testDropdownIcon("archive")},
+					}},
+					{Items: []Item{
+						{Label: "Delete", OnClick: "deleteItem()", Danger: true, Disabled: true, Tooltip: "Locked"},
+					}},
+				},
+			},
+		},
+		{
+			name: "hover",
+			cfg: Config{
+				ID:              "hover-actions",
+				Label:           "More actions",
+				TriggerMode:     TriggerHover,
+				TriggerIcon:     testDropdownIcon("trigger"),
+				TriggerIconOnly: true,
+				Sections: []Section{{Items: []Item{
+					{Label: "Open", Href: "/open", Icon: testDropdownIcon("open"), Tooltip: "Open file", ID: "hover-open"},
+					{Label: "Run", OnClick: "run()", Icon: testDropdownIcon("run"), Tooltip: "Run task", ID: "hover-run"},
+				}}},
+			},
+		},
+		{
+			name: "context",
+			cfg: Config{
+				ID:          "context-actions",
+				Label:       "Context actions",
+				TriggerMode: TriggerContext,
+				TriggerIcon: testDropdownIcon("trigger"),
+				Sections: []Section{
+					{Items: []Item{
+						{Label: "Rename", Href: "/rename", Icon: testDropdownIcon("rename"), Shortcut: "R", Tooltip: "Rename item", ID: "rename-item"},
+						{Label: "Duplicate", Href: "/duplicate", Icon: testDropdownIcon("duplicate"), Shortcut: "D", ShortcutIcon: testDropdownIcon("shift")},
+					}},
+					{Items: []Item{
+						{Label: "Delete", OnClick: "deleteItem()", Icon: testDropdownIcon("delete"), Shortcut: "X", Danger: true},
+						{Label: "Export", OnClick: "exportItem()", Shortcut: "E", ShortcutIcon: testDropdownIcon("cmd"), Disabled: true, Tooltip: "Unavailable"},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range configs {
+		t.Run(tt.name, func(t *testing.T) {
+			rendered := renderDropdown(t, tt.cfg)
+
+			var sawError bool
+			for failAfter := 0; failAfter < len(rendered); failAfter++ {
+				writer := &failingDropdownWriter{failAfter: failAfter}
+				err := Dropdown(tt.cfg).Render(context.Background(), tinyDropdownBuffer(writer))
+				if err != nil {
+					sawError = true
+				}
+			}
+			assert.True(t, sawError)
+
+			writer := &failingDropdownWriter{failAfter: len(rendered) + 1}
+			buf := tinyDropdownBuffer(writer)
+			assert.NoError(t, Dropdown(tt.cfg).Render(context.Background(), buf))
+			assert.NoError(t, buf.Flush())
+			assert.Equal(t, len(rendered), writer.written)
+		})
+	}
 }

--- a/components/radio/radio_coverage_test.go
+++ b/components/radio/radio_coverage_test.go
@@ -182,6 +182,56 @@ func TestCoverageSegmentedHTMXAndAlpine(t *testing.T) {
 	assert.NotContains(t, html, " else")
 }
 
+// TestCoverageSegmentedAllInteractionAttributes drives the full segmentedInput
+// attribute surface, which is separate from the standard radioInput template.
+func TestCoverageSegmentedAllInteractionAttributes(t *testing.T) {
+	html := render(t, Radio(Config{
+		ID:        "segfull",
+		Name:      "mode",
+		Value:     "full",
+		Label:     "Full",
+		Segmented: true,
+		Checked:   true,
+		Disabled:  true,
+		HTMX: &HTMXConfig{
+			Get:       "/get",
+			Post:      "/post",
+			Put:       "/put",
+			Delete:    "/delete",
+			Patch:     "/patch",
+			Target:    "#target",
+			Swap:      "outerHTML",
+			Trigger:   "click",
+			Indicator: "#busy",
+			PushURL:   true,
+			Confirm:   "Continue?",
+			Vals:      `{"mode":"full"}`,
+			Include:   "#form",
+		},
+		Alpine: &AlpineConfig{
+			Data:         "{selected:'full'}",
+			Model:        "selected",
+			OnChange:     "track()",
+			BindChecked:  "selected === 'full'",
+			BindDisabled: "locked",
+		},
+		InputAttrs: templ.Attributes{"data-test": "segmented-full"},
+	}))
+
+	for _, want := range []string{
+		`id="segfull"`, `name="mode"`, `value="full"`, `class="sr-only"`,
+		"checked", "disabled", `hx-get="/get"`, `hx-post="/post"`,
+		`hx-put="/put"`, `hx-delete="/delete"`, `hx-patch="/patch"`,
+		`hx-target="#target"`, `hx-swap="outerHTML"`, `hx-trigger="click"`,
+		`hx-indicator="#busy"`, `hx-push-url="true"`, `hx-confirm="Continue?"`,
+		`hx-include="#form"`, "hx-vals=", "x-data=", "x-model=", "x-on:change=",
+		"x-bind:checked=", "x-bind:disabled=", `data-test="segmented-full"`,
+	} {
+		assert.Contains(t, html, want, "missing %s", want)
+	}
+	assert.NotContains(t, html, `hx-trigger="change"`)
+}
+
 // TestCoverageInputAttrsEscapeHatch covers the trailing cfg.InputAttrs spread.
 func TestCoverageInputAttrsEscapeHatch(t *testing.T) {
 	html := render(t, Radio(Config{
@@ -320,4 +370,31 @@ func TestCoveragePredicates(t *testing.T) {
 	assert.Equal(t, "click", (&HTMXConfig{Post: "/p", Trigger: "click"}).EffectiveTrigger())
 	assert.Equal(t, "change", (&HTMXConfig{Post: "/p"}).EffectiveTrigger())
 	assert.Equal(t, "", (&HTMXConfig{}).EffectiveTrigger())
+}
+
+// TestCoverageCanceledContextPropagates covers the generated template
+// cancellation guards without needing to force writer failures.
+func TestCoverageCanceledContextPropagates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cases := map[string]templ.Component{
+		"Radio":                         Radio(Config{}),
+		"radioSegmented":                radioSegmented(Config{}),
+		"segmentedInput":                segmentedInput(Config{}),
+		"RadioBar":                      RadioBar(),
+		"standardRadio":                 standardRadio(Config{}),
+		"radioWithDescription":          radioWithDescription(Config{}),
+		"radioWithContainer":            radioWithContainer(Config{}),
+		"radioInput":                    radioInput(Config{}),
+		"RadioGroup":                    RadioGroup(GroupConfig{}),
+		"groupRadioItem":                groupRadioItem(Config{}),
+		"groupRadioItemWithDescription": groupRadioItemWithDescription(Config{}),
+	}
+	for name, component := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			assert.ErrorIs(t, component.Render(ctx, &buf), context.Canceled)
+		})
+	}
 }

--- a/components/textinput/textinput_coverage_test.go
+++ b/components/textinput/textinput_coverage_test.go
@@ -1,12 +1,24 @@
 package textinput
 
 import (
+	"context"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/a-h/templ"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+var errCoverageWriter = errors.New("coverage writer failure")
+
+type failingCoverageWriter struct{}
+
+func (failingCoverageWriter) Write([]byte) (int, error) {
+	return 0, errCoverageWriter
+}
 
 // TestCoverageRenderDefault exercises the default input branch with the full
 // set of optional attributes so each conditional in defaultInput is rendered.
@@ -204,4 +216,89 @@ func TestCoverageDefaultNoLabelNoHelper(t *testing.T) {
 	assert.NotContains(t, html, "<label")
 	assert.NotContains(t, html, "<small")
 	assert.True(t, strings.Contains(html, "<input"))
+}
+
+// TestCoverageDirectTemplatesUseNonBufferWriters covers generated rendering
+// branches that are skipped when tests render only through bytes.Buffer.
+func TestCoverageDirectTemplatesUseNonBufferWriters(t *testing.T) {
+	ctx := templ.WithChildren(context.Background(), templ.Raw("ignored"))
+
+	cases := []struct {
+		name      string
+		component templ.Component
+	}{
+		{"textInputDefault", TextInput(Config{Name: "default"})},
+		{"textInputPassword", TextInput(Config{Type: TypePassword, Name: "password"})},
+		{"textInputSearch", TextInput(Config{Type: TypeSearch, Name: "search"})},
+		{"defaultInputBare", defaultInput(Config{Name: "bare"})},
+		{"defaultInputMaskedFull", defaultInput(Config{
+			ID:           "masked",
+			Name:         "masked",
+			Type:         TypeTel,
+			Mask:         "999-999",
+			Disabled:     true,
+			Required:     true,
+			Readonly:     true,
+			Autocomplete: "tel",
+			Pattern:      "[0-9-]+",
+			MaxLength:    7,
+			InputAttrs:   templ.Attributes{"data-mask": "phone"},
+		})},
+		{"passwordInputBare", passwordInput(Config{Name: "password"})},
+		{"searchInputBare", searchInput(Config{Name: "search"})},
+		{"inputLabelDefault", inputLabel(Config{ID: "field", Label: "Field"})},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, tc.component.Render(ctx, io.Discard))
+		})
+	}
+}
+
+// TestCoverageTemplatesPropagateCanceledContext covers each generated
+// component's early context error return.
+func TestCoverageTemplatesPropagateCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cases := []struct {
+		name      string
+		component templ.Component
+	}{
+		{"textInput", TextInput(Config{})},
+		{"defaultInput", defaultInput(Config{})},
+		{"passwordInput", passwordInput(Config{})},
+		{"searchInput", searchInput(Config{})},
+		{"inputLabel", inputLabel(Config{})},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.component.Render(ctx, io.Discard)
+			require.ErrorIs(t, err, context.Canceled)
+		})
+	}
+}
+
+// TestCoverageTemplatesPropagateWriterErrors covers the generated buffer
+// release path when rendering to a non-buffer writer fails.
+func TestCoverageTemplatesPropagateWriterErrors(t *testing.T) {
+	cases := []struct {
+		name      string
+		component templ.Component
+	}{
+		{"textInput", TextInput(Config{Name: "default"})},
+		{"defaultInput", defaultInput(Config{Name: "default"})},
+		{"passwordInput", passwordInput(Config{Name: "password"})},
+		{"searchInput", searchInput(Config{Name: "search"})},
+		{"inputLabel", inputLabel(Config{ID: "field", Label: "Field"})},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.component.Render(context.Background(), failingCoverageWriter{})
+			require.ErrorIs(t, err, errCoverageWriter)
+		})
+	}
 }

--- a/components/tooltip/tooltip_coverage_test.go
+++ b/components/tooltip/tooltip_coverage_test.go
@@ -3,6 +3,7 @@ package tooltip
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -168,6 +169,52 @@ func TestTooltipCoverageRenderDefaultRichClickAndCustomTrigger(t *testing.T) {
 				if !strings.Contains(html, want) {
 					t.Fatalf("Tooltip render missing %q in %s", want, html)
 				}
+			}
+		})
+	}
+}
+
+func TestTooltipCoverageCustomTriggerRenderErrors(t *testing.T) {
+	errTrigger := errors.New("trigger render failed")
+	failingTrigger := templ.ComponentFunc(func(ctx context.Context, w io.Writer) error {
+		return errTrigger
+	})
+
+	tests := []struct {
+		name string
+		cfg  Config
+	}{
+		{
+			name: "default",
+			cfg: Config{
+				Label:   "Default tooltip",
+				Trigger: failingTrigger,
+			},
+		},
+		{
+			name: "rich",
+			cfg: Config{
+				Label:       "Rich tooltip",
+				Description: "Trigger should fail before details render",
+				Trigger:     failingTrigger,
+			},
+		},
+		{
+			name: "click",
+			cfg: Config{
+				Label:       "Click tooltip",
+				TriggerMode: Click,
+				Trigger:     failingTrigger,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := Tooltip(tt.cfg).Render(context.Background(), &buf)
+			if !errors.Is(err, errTrigger) {
+				t.Fatalf("Tooltip render error = %v, want %v", err, errTrigger)
 			}
 		})
 	}

--- a/justfile
+++ b/justfile
@@ -71,8 +71,8 @@ coverage:
     go tool covdata merge \
       -i=.coverage/unit-root,.coverage/unit-site,.coverage/e2e \
       -o=.coverage/merged
-    go tool covdata percent -i=.coverage/merged > .coverage/coverage-percent.txt
-    go tool covdata textfmt -i=.coverage/merged -o=.coverage/coverage.out
+    go tool covdata percent -i=.coverage/merged -pkg="$component_coverpkg" > .coverage/coverage-percent.txt
+    go tool covdata textfmt -i=.coverage/merged -pkg="$component_coverpkg" -o=.coverage/coverage.out
     go tool cover -func=.coverage/coverage.out > .coverage/coverage-func.txt
     go tool cover -html=.coverage/coverage.out -o .coverage/coverage.html
 

--- a/site/cmd/server/e2e_shutdown_test.go
+++ b/site/cmd/server/e2e_shutdown_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2EShutdownWrapperDisabledWithoutToken(t *testing.T) {
+	called := false
+	handler := e2eShutdownWrapper(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	}), "", func() {})
+
+	req := httptest.NewRequest(http.MethodPost, "/__e2e/shutdown", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.True(t, called)
+	require.Equal(t, http.StatusTeapot, rec.Code)
+}
+
+func TestE2EShutdownWrapperRequiresPostAndToken(t *testing.T) {
+	shutdowns := 0
+	handler := e2eShutdownWrapper(http.NotFoundHandler(), "secret", func() {
+		shutdowns++
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/__e2e/shutdown?token=secret", nil))
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	require.Equal(t, 0, shutdowns)
+
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/__e2e/shutdown?token=wrong", nil))
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Equal(t, 0, shutdowns)
+}
+
+func TestE2EShutdownWrapperCallsShutdown(t *testing.T) {
+	shutdowns := 0
+	handler := e2eShutdownWrapper(http.NotFoundHandler(), "secret", func() {
+		shutdowns++
+	})
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/__e2e/shutdown?token=secret", nil))
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, 1, shutdowns)
+}

--- a/site/cmd/server/main.go
+++ b/site/cmd/server/main.go
@@ -34,6 +34,15 @@ func main() {
 		Addr:    addr,
 		Handler: srv,
 	}
+	httpServer.Handler = e2eShutdownWrapper(httpServer.Handler, os.Getenv("GOSHTOSO_E2E_SHUTDOWN_TOKEN"), func() {
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := httpServer.Shutdown(ctx); err != nil {
+				log.Printf("Server shutdown error: %v", err)
+			}
+		}()
+	})
 
 	errs := make(chan error, 1)
 	go func() {
@@ -58,6 +67,28 @@ func main() {
 		}
 		log.Fatalf("Server error: %v", err)
 	}
+}
+
+func e2eShutdownWrapper(next http.Handler, token string, shutdown func()) http.Handler {
+	if token == "" {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/__e2e/shutdown" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Query().Get("token") != token {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		shutdown()
+	})
 }
 
 func resolveProjectRoot() string {

--- a/site/tests/e2e/e2e_shutdown_test.go
+++ b/site/tests/e2e/e2e_shutdown_test.go
@@ -1,0 +1,36 @@
+package e2e
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopServerUsesShutdownEndpointWhenConfigured(t *testing.T) {
+	var requested bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = true
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/__e2e/shutdown", r.URL.Path)
+		require.Equal(t, "secret", r.URL.Query().Get("token"))
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	err := stopServer(&exec.Cmd{}, srv.URL, "secret")
+
+	require.NoError(t, err)
+	require.True(t, requested)
+}
+
+func TestE2ECoverPkgIncludesServerMainPackage(t *testing.T) {
+	got := e2eCoverPkg("github.com/araihu/goshtoso/components/button,github.com/araihu/goshtoso/components/table")
+
+	require.Equal(t,
+		"github.com/araihu/goshtoso/site/cmd/server,github.com/araihu/goshtoso/components/button,github.com/araihu/goshtoso/components/table",
+		got,
+	)
+}

--- a/site/tests/e2e/e2e_test.go
+++ b/site/tests/e2e/e2e_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"net/http"
@@ -25,6 +27,7 @@ var (
 	sharedPW      *playwright.Playwright
 	sharedBrowser playwright.Browser
 	serverCmd     *exec.Cmd
+	shutdownToken string
 )
 
 // freePort finds an available TCP port
@@ -45,7 +48,7 @@ func TestMain(m *testing.M) {
 	if coverDir := os.Getenv("GOSHTOSO_E2E_COVERDIR"); coverDir != "" {
 		buildArgs = append(buildArgs, "-cover")
 		if coverPkg := os.Getenv("GOSHTOSO_E2E_COVERPKG"); coverPkg != "" {
-			buildArgs = append(buildArgs, "-coverpkg="+coverPkg)
+			buildArgs = append(buildArgs, "-coverpkg="+e2eCoverPkg(coverPkg))
 		}
 	}
 	buildArgs = append(buildArgs, "./cmd/server")
@@ -73,7 +76,11 @@ func TestMain(m *testing.M) {
 			fmt.Fprintf(os.Stderr, "failed to create coverage dir: %v\n", err)
 			os.Exit(1)
 		}
-		serverCmd.Env = append(os.Environ(), "GOCOVERDIR="+coverDir)
+		shutdownToken = randomToken()
+		serverCmd.Env = append(os.Environ(),
+			"GOCOVERDIR="+coverDir,
+			"GOSHTOSO_E2E_SHUTDOWN_TOKEN="+shutdownToken,
+		)
 	}
 	serverCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := serverCmd.Start(); err != nil {
@@ -114,12 +121,59 @@ func TestMain(m *testing.M) {
 	// Cleanup
 	_ = browser.Close()
 	_ = pw.Stop()
-	if serverCmd != nil && serverCmd.Process != nil {
-		_ = syscall.Kill(-serverCmd.Process.Pid, syscall.SIGTERM)
-		_ = serverCmd.Wait()
+	if err := stopServer(serverCmd, baseURL, shutdownToken); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stop server: %v\n", err)
 	}
 
 	os.Exit(code)
+}
+
+func stopServer(cmd *exec.Cmd, url, token string) error {
+	if cmd == nil || cmd.Process == nil {
+		if token == "" {
+			return nil
+		}
+		return postShutdown(url, token)
+	}
+	if token != "" {
+		if err := postShutdown(url, token); err == nil {
+			return cmd.Wait()
+		}
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM); err != nil {
+		return err
+	}
+	return cmd.Wait()
+}
+
+func postShutdown(url, token string) error {
+	req, err := http.NewRequest(http.MethodPost, url+"/__e2e/shutdown?token="+token, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("shutdown returned %s", resp.Status)
+	}
+	return nil
+}
+
+func randomToken() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+func e2eCoverPkg(coverPkg string) string {
+	return "github.com/araihu/goshtoso/site/cmd/server," + coverPkg
 }
 
 // setupServer is now a no-op since TestMain handles it.


### PR DESCRIPTION
## Summary
- add focused component coverage for chatbubble, tooltip, dropdown, radio, and textinput render/config paths
- make E2E coverage runs shut down the covered demo server cleanly so browser-driven component coverage is flushed
- keep coverage artifacts filtered to component packages only

## Test Plan
- [x] just coverage
- [x] verified coverage reports contain no site/ rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage tests for chat bubble, dropdown, radio, text input, and tooltip components (rendering paths, error propagation, canceled contexts, writer failures, accessibility/ARIA, and grouped/sent state behavior).
  * Added server-side and end-to-end shutdown tests and e2e lifecycle updates to support token-based shutdown during test runs.

* **Chores**
  * Scoped coverage reporting to component packages in the coverage task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->