### PR TITLE
chore(site): pin library to v0.0.7

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.0.4
+	github.com/araihu/goshtoso v0.0.7
 	github.com/coder/websocket v1.8.14
 	github.com/playwright-community/playwright-go v0.5700.1
 	github.com/stretchr/testify v1.11.1

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6
 github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.0.4 h1:Ugp/BjMxo/JLTojdIdzXZXtMzVRo9m6GvQ8sVpD8dC0=
-github.com/araihu/goshtoso v0.0.4/go.mod h1:pEJfw8LGHQpyX60yGckzuxog5XwwtGfvKI7Y8f7PP24=
+github.com/araihu/goshtoso v0.0.7 h1:QS8DNRPW/USsbdrWM+0NuPy3ToAVaIm416s1/v4c8As=
+github.com/araihu/goshtoso v0.0.7/go.mod h1:pEJfw8LGHQpyX60yGckzuxog5XwwtGfvKI7Y8f7PP24=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
## Summary
- Pin the Goshtoso site module dependency to the released `github.com/araihu/goshtoso v0.0.7` tag.
- Mirror the release workflow bump that could not push directly to protected `main`.

## Test Plan
- `git diff --check`
- `GOWORK=off go test ./tests/e2e -run TestExpenseExample_FragmentNavNoErrors -count=1 -v`
- `(cd site && go test ./... -count=1 -timeout 15m)`

Note: an initial root-workspace `go test ./site/... -count=1` run hit one transient `TestExpenseExample_FragmentNavNoErrors` failure; the focused retry and full site-module rerun both passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->