### PR TITLE
feat(search): support client-loaded results

### DIFF
--- a/.agents/skills/using-goshtoso/references/components-reference.md
+++ b/.agents/skills/using-goshtoso/references/components-reference.md
@@ -1191,6 +1191,7 @@ import "github.com/araihu/goshtoso/components/search"  // package search
 | `GlobalShortcut` | `bool` | GlobalShortcut enables Cmd/Ctrl+K window handling for this instance. |
 | `EscapeText` | `string` | EscapeText is rendered in the dialog close KBD hint. Defaults to "Esc". |
 | `Items` | `[]Item` | Items are the caller-provided result records. |
+| `ItemsURL` | `string` | ItemsURL is an optional JSON endpoint for client-side result records. |
 | `MaxResults` | `int` | MaxResults limits the visible matches. Defaults to 4. |
 | `DescriptionMaxLength` | `int` | DescriptionMaxLength truncates result descriptions. Defaults to 120. |
 | `EmptyText` | `string` | EmptyText appears when no result matches the query. |

--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -1191,6 +1191,7 @@ import "github.com/araihu/goshtoso/components/search"  // package search
 | `GlobalShortcut` | `bool` | GlobalShortcut enables Cmd/Ctrl+K window handling for this instance. |
 | `EscapeText` | `string` | EscapeText is rendered in the dialog close KBD hint. Defaults to "Esc". |
 | `Items` | `[]Item` | Items are the caller-provided result records. |
+| `ItemsURL` | `string` | ItemsURL is an optional JSON endpoint for client-side result records. |
 | `MaxResults` | `int` | MaxResults limits the visible matches. Defaults to 4. |
 | `DescriptionMaxLength` | `int` | DescriptionMaxLength truncates result descriptions. Defaults to 120. |
 | `EmptyText` | `string` | EmptyText appears when no result matches the query. |

--- a/components/search/search.templ
+++ b/components/search/search.templ
@@ -64,6 +64,9 @@ templ SearchModal(cfg Config) {
 		aria-modal="true"
 		aria-labelledby={ id + "-label" }
 		id={ id + "-dialog" }
+		if cfg.ItemsURL != "" {
+			data-search-source-url={ cfg.ItemsURL }
+		}
 	>
 		<div
 			class={ cfg.DialogClasses() }
@@ -102,8 +105,12 @@ templ SearchModal(cfg Config) {
 				role="listbox"
 				aria-label={ cfg.GetLabel() + " results" }
 			>
-				for i, item := range cfg.Items {
-					@resultItem(item, i)
+				if cfg.ItemsURL != "" {
+					@clientResultItems()
+				} else {
+					for i, item := range cfg.Items {
+						@resultItem(item, i)
+					}
 				}
 				<p
 					x-show="query.trim().length > 0 && visibleResults().length === 0"
@@ -154,6 +161,37 @@ templ resultItem(item Item, index int) {
 	</button>
 }
 
+templ clientResultItems() {
+	<template x-for="(item, index) in visibleResults()" x-bind:key="item.key">
+		<button
+			type="button"
+			data-search-result
+			x-bind:id="item.id || null"
+			x-bind:data-search-title="item.title"
+			x-bind:data-search-description="item.description"
+			x-bind:data-search-section="item.section || null"
+			x-bind:data-search-href="item.href || null"
+			x-bind:data-search-text="item.searchText"
+			x-bind:data-result-index="item.index"
+			x-bind:class="isActiveIndex(index) ? 'bg-surface-alt text-on-surface-strong shadow-[inset_2px_0_0_var(--color-outline-strong)] dark:bg-surface-dark dark:text-on-surface-dark-strong dark:shadow-[inset_2px_0_0_var(--color-outline-dark-strong)]' : 'text-on-surface hover:bg-surface-alt hover:text-on-surface-strong focus:bg-surface-alt focus:text-on-surface-strong dark:text-on-surface-dark dark:hover:bg-surface-dark dark:hover:text-on-surface-dark-strong dark:focus:bg-surface-dark dark:focus:text-on-surface-dark-strong'"
+			x-on:mouseenter="setActiveIndex(index)"
+			x-on:click="selectResult(item)"
+			class="flex w-full flex-col gap-2 p-4 text-left transition focus:outline-none"
+			role="option"
+		>
+			<div class="flex items-start justify-between gap-3">
+				<strong class="min-w-0 text-base font-semibold" x-html="highlight(item.title)"></strong>
+				<template x-if="item.section">
+					<span class="shrink-0 rounded-radius border border-outline px-2 py-0.5 text-xs font-medium text-on-surface-muted dark:border-outline-dark dark:text-on-surface-dark-muted" x-text="item.section"></span>
+				</template>
+			</div>
+			<template x-if="item.description">
+				<p class="text-sm leading-6 text-on-surface-muted dark:text-on-surface-dark-muted" x-html="highlight(truncate(item.description))"></p>
+			</template>
+		</button>
+	</template>
+}
+
 templ searchIcon(classes string) {
 	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor" fill="none" stroke-width="2" class={ classes } aria-hidden="true">
 		<path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"></path>
@@ -188,9 +226,19 @@ templ searchScript() {
 			activeIndex: 0,
 			maxResults: maxResults || 4,
 			descriptionMaxLength: descriptionMaxLength || 120,
+			cachedAllResults: null,
+			cachedDOMTerm: null,
+			cachedDOMResults: [],
+			clientItems: [],
+			clientItemsLoaded: false,
+			clientItemsLoading: false,
+			cachedClientTerm: null,
+			cachedClientResults: [],
 			openSearch: function () {
 				this.open = true;
 				this.activeIndex = 0;
+				if (!this.usesClientSource()) this.resetDOMCache();
+				this.ensureClientItems();
 				this.$nextTick(() => {
 					if (this.$refs.input) this.$refs.input.focus();
 				});
@@ -212,12 +260,93 @@ templ searchScript() {
 				if (!term) return false;
 				return (el.dataset.searchText || '').toLowerCase().indexOf(term) !== -1;
 			},
-			allResults: function () {
-				return Array.prototype.slice.call(this.$root.querySelectorAll('[data-search-result]'));
+			sourceURL: function () {
+				return (this.$root && this.$root.dataset.searchSourceUrl) || '';
 			},
-			matchedResults: function () {
+			usesClientSource: function () {
+				return this.sourceURL() !== '';
+			},
+			resetClientCache: function () {
+				this.cachedClientTerm = null;
+				this.cachedClientResults = [];
+			},
+			resetDOMCache: function () {
+				this.cachedAllResults = null;
+				this.cachedDOMTerm = null;
+				this.cachedDOMResults = [];
+			},
+			stringValue: function (value) {
+				if (value === null || value === undefined) return '';
+				return String(value);
+			},
+			searchTextForItem: function (item) {
+				return [item.title, item.description, item.section].concat(item.keywords || []).filter(Boolean).join(' ');
+			},
+			safeHref: function (value) {
+				var href = this.stringValue(value).trim();
+				if (!href) return '';
+				try {
+					var parsed = new URL(href, window.location.href);
+					var protocol = parsed.protocol.toLowerCase();
+					if (protocol === 'http:' || protocol === 'https:' || protocol === 'mailto:' || protocol === 'tel:') return href;
+				} catch (e) {
+					return '';
+				}
+				return '';
+			},
+			normalizeItems: function (payload) {
+				var values = Array.isArray(payload) ? payload : (Array.isArray(payload && payload.items) ? payload.items : []);
+				var self = this;
+				return values.map(function (raw, index) {
+					raw = raw || {};
+					var keywords = raw.keywords !== undefined ? raw.keywords : raw.Keywords;
+					if (!Array.isArray(keywords)) keywords = [];
+					var item = {
+						id: self.stringValue(raw.id !== undefined ? raw.id : raw.ID),
+						title: self.stringValue(raw.title !== undefined ? raw.title : raw.Title),
+						description: self.stringValue(raw.description !== undefined ? raw.description : raw.Description),
+						href: self.safeHref(raw.href !== undefined ? raw.href : raw.Href),
+						section: self.stringValue(raw.section !== undefined ? raw.section : raw.Section),
+						keywords: keywords.map(function (keyword) { return self.stringValue(keyword); }),
+						index: index
+					};
+					item.key = item.id || item.href || item.title || String(index);
+					item.searchText = self.searchTextForItem(item);
+					return item;
+				});
+			},
+			ensureClientItems: function () {
+				if (!this.usesClientSource() || this.clientItemsLoaded || this.clientItemsLoading) return;
+				this.clientItemsLoading = true;
+				fetch(this.sourceURL(), { headers: { 'Accept': 'application/json' } })
+					.then(function (response) {
+						if (!response.ok) throw new Error('Search items request failed');
+						return response.json();
+					})
+					.then((payload) => {
+						this.clientItems = this.normalizeItems(payload);
+						this.clientItemsLoaded = true;
+						this.resetClientCache();
+					})
+					.catch(() => {
+						this.clientItems = [];
+						this.clientItemsLoaded = true;
+						this.resetClientCache();
+					})
+					.finally(() => {
+						this.clientItemsLoading = false;
+					});
+			},
+			allResults: function () {
+				if (!this.cachedAllResults) {
+					this.cachedAllResults = Array.prototype.slice.call(this.$root.querySelectorAll('[data-search-result]'));
+				}
+				return this.cachedAllResults;
+			},
+			matchedDOMResults: function () {
 				var term = this.query.trim().toLowerCase();
 				if (!term) return [];
+				if (term === this.cachedDOMTerm) return this.cachedDOMResults;
 				var titleMatches = [];
 				var nonTitleMatches = [];
 				this.allResults().forEach(function (el) {
@@ -226,7 +355,29 @@ templ searchScript() {
 					if (title.indexOf(term) !== -1) titleMatches.push(el);
 					else if (text.indexOf(term) !== -1) nonTitleMatches.push(el);
 				});
-				return titleMatches.concat(nonTitleMatches).slice(0, this.maxResults);
+				this.cachedDOMTerm = term;
+				this.cachedDOMResults = titleMatches.concat(nonTitleMatches).slice(0, this.maxResults);
+				return this.cachedDOMResults;
+			},
+			matchedClientResults: function () {
+				var term = this.query.trim().toLowerCase();
+				if (!term) return [];
+				if (term === this.cachedClientTerm) return this.cachedClientResults;
+				var titleMatches = [];
+				var nonTitleMatches = [];
+				this.clientItems.forEach(function (item) {
+					var title = (item.title || '').toLowerCase();
+					var text = (item.searchText || '').toLowerCase();
+					if (title.indexOf(term) !== -1) titleMatches.push(item);
+					else if (text.indexOf(term) !== -1) nonTitleMatches.push(item);
+				});
+				this.cachedClientTerm = term;
+				this.cachedClientResults = titleMatches.concat(nonTitleMatches).slice(0, this.maxResults);
+				return this.cachedClientResults;
+			},
+			matchedResults: function () {
+				if (this.usesClientSource()) return this.matchedClientResults();
+				return this.matchedDOMResults();
 			},
 			visibleResults: function () {
 				return this.matchedResults();
@@ -242,12 +393,21 @@ templ searchScript() {
 				var results = this.visibleResults();
 				if (!results.length) return;
 				this.activeIndex = (this.activeIndex + delta + results.length) % results.length;
-				results[this.activeIndex].scrollIntoView({ block: 'nearest' });
+				this.$nextTick(() => {
+					var el = this.usesClientSource() ? this.$root.querySelectorAll('[data-search-result]')[this.activeIndex] : results[this.activeIndex];
+					if (el) el.scrollIntoView({ block: 'nearest' });
+				});
 			},
 			setActive: function (el) {
 				var results = this.visibleResults();
 				var index = results.indexOf(el);
 				if (index >= 0) this.activeIndex = index;
+			},
+			setActiveIndex: function (index) {
+				this.activeIndex = index;
+			},
+			isActiveIndex: function (index) {
+				return index === this.activeIndex;
 			},
 			isActive: function (el) {
 				return this.visibleResults().indexOf(el) === this.activeIndex;
@@ -255,12 +415,20 @@ templ searchScript() {
 			choose: function () {
 				var results = this.visibleResults();
 				if (!results.length) return;
-				results[this.activeIndex].click();
+				if (this.usesClientSource()) this.selectResult(results[this.activeIndex]);
+				else results[this.activeIndex].click();
 			},
-			selectResult: function (el) {
+			selectResult: function (result) {
 				this.closeSearch();
-				if (!el.hasAttribute('hx-get') && !el.hasAttribute('hx-post') && el.dataset.searchHref) {
-					window.location.href = el.dataset.searchHref;
+				if (!result) return;
+				if (result.dataset) {
+					if (!result.hasAttribute('hx-get') && !result.hasAttribute('hx-post') && result.dataset.searchHref) {
+						window.location.href = result.dataset.searchHref;
+					}
+					return;
+				}
+				if (result.href) {
+					window.location.href = result.href;
 				}
 			},
 			truncate: function (value) {

--- a/components/search/search_templ.go
+++ b/components/search/search_templ.go
@@ -282,29 +282,52 @@ func SearchModal(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var15 = []any{cfg.DialogClasses()}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var15...)
+		if cfg.ItemsURL != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, " data-search-source-url=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var15 string
+			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ItemsURL)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 68, Col: 40}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var15)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div class=\"")
+		var templ_7745c5c3_Var16 = []any{cfg.DialogClasses()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var16...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var16 string
-		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var15).String())
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<div class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var17 string
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var16).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var17)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\" x-show=\"open\" x-transition:enter=\"transition ease-out duration-150\" x-transition:enter-start=\"opacity-0 translate-y-1\" x-transition:enter-end=\"opacity-100 translate-y-0\"><div class=\"relative flex items-center gap-3 border border-outline bg-surface px-4 py-3 dark:border-outline-dark dark:bg-surface-dark-alt\" x-bind:class=\"query.trim().length > 0 ? 'rounded-t-radius border-b-0' : 'rounded-radius'\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\" x-show=\"open\" x-transition:enter=\"transition ease-out duration-150\" x-transition:enter-start=\"opacity-0 translate-y-1\" x-transition:enter-end=\"opacity-100 translate-y-0\"><div class=\"relative flex items-center gap-3 border border-outline bg-surface px-4 py-3 dark:border-outline-dark dark:bg-surface-dark-alt\" x-bind:class=\"query.trim().length > 0 ? 'rounded-t-radius border-b-0' : 'rounded-radius'\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -312,72 +335,72 @@ func SearchModal(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<label id=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var17 string
-		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-label")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 80, Col: 29}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var17)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\" class=\"sr-only\" for=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<label id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var18 string
-		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-input")
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-label")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 80, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 83, Col: 29}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" class=\"sr-only\" for=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var19 string
-		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.GetLabel())
+		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-input")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 80, Col: 86}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 83, Col: 67}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</label> <input x-ref=\"input\" x-model=\"query\" x-on:input=\"activeIndex = 0\" x-on:keydown.down.prevent=\"move(1)\" x-on:keydown.up.prevent=\"move(-1)\" x-on:keydown.enter.prevent=\"choose()\" x-on:keydown.escape.prevent=\"closeSearch()\" id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var20 string
-		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-input")
+		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.GetLabel())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 89, Col: 23}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 83, Col: 86}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" type=\"search\" class=\"min-w-0 flex-1 bg-transparent py-1 text-base text-on-surface-strong placeholder:text-on-surface-muted focus:outline-none dark:text-on-surface-dark-strong dark:placeholder:text-on-surface-dark-muted\" placeholder=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</label> <input x-ref=\"input\" x-model=\"query\" x-on:input=\"activeIndex = 0\" x-on:keydown.down.prevent=\"move(1)\" x-on:keydown.up.prevent=\"move(-1)\" x-on:keydown.enter.prevent=\"choose()\" x-on:keydown.escape.prevent=\"closeSearch()\" id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var21 string
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.GetPlaceholder())
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-input")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 92, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 92, Col: 23}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" autocomplete=\"off\" spellcheck=\"false\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" type=\"search\" class=\"min-w-0 flex-1 bg-transparent py-1 text-base text-on-surface-strong placeholder:text-on-surface-muted focus:outline-none dark:text-on-surface-dark-strong dark:placeholder:text-on-surface-dark-muted\" placeholder=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var22 string
+		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.GetPlaceholder())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 95, Col: 39}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" autocomplete=\"off\" spellcheck=\"false\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -385,7 +408,7 @@ func SearchModal(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, ">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -393,43 +416,50 @@ func SearchModal(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div><div x-show=\"query.trim().length > 0\" class=\"flex max-h-[min(28rem,calc(100vh-12rem))] flex-col divide-y divide-outline overflow-hidden overflow-y-auto rounded-b-radius border border-outline bg-surface text-sm font-light dark:divide-outline-dark dark:border-outline-dark dark:bg-surface-dark-alt\" role=\"listbox\" aria-label=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var22 string
-		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.GetLabel() + " results")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 103, Col: 44}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		for i, item := range cfg.Items {
-			templ_7745c5c3_Err = resultItem(item, i).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<p x-show=\"query.trim().length > 0 && visibleResults().length === 0\" class=\"px-4 py-4 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div><div x-show=\"query.trim().length > 0\" class=\"flex max-h-[min(28rem,calc(100vh-12rem))] flex-col divide-y divide-outline overflow-hidden overflow-y-auto rounded-b-radius border border-outline bg-surface text-sm font-light dark:divide-outline-dark dark:border-outline-dark dark:bg-surface-dark-alt\" role=\"listbox\" aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var23 string
-		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.GetEmptyText())
+		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.GetLabel() + " results")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 112, Col: 25}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 106, Col: 44}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var23)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</p></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if cfg.ItemsURL != "" {
+			templ_7745c5c3_Err = clientResultItems().Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else {
+			for i, item := range cfg.Items {
+				templ_7745c5c3_Err = resultItem(item, i).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<p x-show=\"query.trim().length > 0 && visibleResults().length === 0\" class=\"px-4 py-4 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var24 string
+		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.GetEmptyText())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 119, Col: 25}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</p></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -453,129 +483,129 @@ func resultItem(item Item, index int) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var24 == nil {
-			templ_7745c5c3_Var24 = templ.NopComponent
+		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var25 == nil {
+			templ_7745c5c3_Var25 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<button type=\"button\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<button type=\"button\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if item.ID != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, " id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var25 string
-			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.ID)
+			var templ_7745c5c3_Var26 string
+			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 123, Col: 15}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 130, Col: 15}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var26)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " data-search-result data-search-title=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var26 string
-		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 126, Col: 32}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var26)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\" data-search-description=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, " data-search-result data-search-title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var27 string
-		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Description)
+		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 127, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 133, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\" data-search-description=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var28 string
+		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Description)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 134, Col: 44}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var28)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if item.Section != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, " data-search-section=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var28 string
-			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Section)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 129, Col: 37}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var28)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		if item.SafeHref() != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, " data-search-href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, " data-search-section=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var29 string
-			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.SafeHref())
+			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Section)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 132, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 136, Col: 37}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var29)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, " data-search-text=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
+		if item.SafeHref() != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, " data-search-href=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var30 string
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.SafeHref())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 139, Col: 37}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		var templ_7745c5c3_Var30 string
-		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.SearchText())
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 134, Col: 38}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\" data-result-index=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, " data-search-text=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var31 string
-		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprint(index))
+		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.SearchText())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 135, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 141, Col: 38}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var31)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\" x-bind:hidden=\"!isResultVisible($el)\" x-bind:style=\"'order: ' + resultOrder($el)\" x-bind:class=\"isActive($el) ? 'bg-surface-alt text-on-surface-strong shadow-[inset_2px_0_0_var(--color-outline-strong)] dark:bg-surface-dark dark:text-on-surface-dark-strong dark:shadow-[inset_2px_0_0_var(--color-outline-dark-strong)]' : 'text-on-surface hover:bg-surface-alt hover:text-on-surface-strong focus:bg-surface-alt focus:text-on-surface-strong dark:text-on-surface-dark dark:hover:bg-surface-dark dark:hover:text-on-surface-dark-strong dark:focus:bg-surface-dark dark:focus:text-on-surface-dark-strong'\" x-on:mouseenter=\"setActive($el)\" x-on:click=\"selectResult($el)\" class=\"flex w-full flex-col gap-2 p-4 text-left transition focus:outline-none\" role=\"option\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "\" data-result-index=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var32 string
+		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprint(index))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 142, Col: 39}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\" x-bind:hidden=\"!isResultVisible($el)\" x-bind:style=\"'order: ' + resultOrder($el)\" x-bind:class=\"isActive($el) ? 'bg-surface-alt text-on-surface-strong shadow-[inset_2px_0_0_var(--color-outline-strong)] dark:bg-surface-dark dark:text-on-surface-dark-strong dark:shadow-[inset_2px_0_0_var(--color-outline-dark-strong)]' : 'text-on-surface hover:bg-surface-alt hover:text-on-surface-strong focus:bg-surface-alt focus:text-on-surface-strong dark:text-on-surface-dark dark:hover:bg-surface-dark dark:hover:text-on-surface-dark-strong dark:focus:bg-surface-dark dark:focus:text-on-surface-dark-strong'\" x-on:mouseenter=\"setActive($el)\" x-on:click=\"selectResult($el)\" class=\"flex w-full flex-col gap-2 p-4 text-left transition focus:outline-none\" role=\"option\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -583,66 +613,95 @@ func resultItem(item Item, index int) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "><div class=\"flex items-start justify-between gap-3\"><strong class=\"min-w-0 text-base font-semibold\" x-html=\"highlight($el.closest('[data-search-result]').dataset.searchTitle)\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "><div class=\"flex items-start justify-between gap-3\"><strong class=\"min-w-0 text-base font-semibold\" x-html=\"highlight($el.closest('[data-search-result]').dataset.searchTitle)\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var32 string
-		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(item.Title)
+		var templ_7745c5c3_Var33 string
+		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(item.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 146, Col: 139}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 153, Col: 139}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</strong> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</strong> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if item.Section != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<span class=\"shrink-0 rounded-radius border border-outline px-2 py-0.5 text-xs font-medium text-on-surface-muted dark:border-outline-dark dark:text-on-surface-dark-muted\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var33 string
-			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(item.Section)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 148, Col: 189}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</span>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</div>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if item.Description != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<p class=\"text-sm leading-6 text-on-surface-muted dark:text-on-surface-dark-muted\" x-html=\"highlight(truncate($el.closest('[data-search-result]').dataset.searchDescription))\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<span class=\"shrink-0 rounded-radius border border-outline px-2 py-0.5 text-xs font-medium text-on-surface-muted dark:border-outline-dark dark:text-on-surface-dark-muted\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var34 string
-			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(item.Description)
+			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(item.Section)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 152, Col: 196}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 155, Col: 189}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if item.Description != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<p class=\"text-sm leading-6 text-on-surface-muted dark:text-on-surface-dark-muted\" x-html=\"highlight(truncate($el.closest('[data-search-result]').dataset.searchDescription))\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var35 string
+			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(item.Description)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 159, Col: 196}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</button>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func clientResultItems() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var36 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var36 == nil {
+			templ_7745c5c3_Var36 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<template x-for=\"(item, index) in visibleResults()\" x-bind:key=\"item.key\"><button type=\"button\" data-search-result x-bind:id=\"item.id || null\" x-bind:data-search-title=\"item.title\" x-bind:data-search-description=\"item.description\" x-bind:data-search-section=\"item.section || null\" x-bind:data-search-href=\"item.href || null\" x-bind:data-search-text=\"item.searchText\" x-bind:data-result-index=\"item.index\" x-bind:class=\"isActiveIndex(index) ? 'bg-surface-alt text-on-surface-strong shadow-[inset_2px_0_0_var(--color-outline-strong)] dark:bg-surface-dark dark:text-on-surface-dark-strong dark:shadow-[inset_2px_0_0_var(--color-outline-dark-strong)]' : 'text-on-surface hover:bg-surface-alt hover:text-on-surface-strong focus:bg-surface-alt focus:text-on-surface-strong dark:text-on-surface-dark dark:hover:bg-surface-dark dark:hover:text-on-surface-dark-strong dark:focus:bg-surface-dark dark:focus:text-on-surface-dark-strong'\" x-on:mouseenter=\"setActiveIndex(index)\" x-on:click=\"selectResult(item)\" class=\"flex w-full flex-col gap-2 p-4 text-left transition focus:outline-none\" role=\"option\"><div class=\"flex items-start justify-between gap-3\"><strong class=\"min-w-0 text-base font-semibold\" x-html=\"highlight(item.title)\"></strong><template x-if=\"item.section\"><span class=\"shrink-0 rounded-radius border border-outline px-2 py-0.5 text-xs font-medium text-on-surface-muted dark:border-outline-dark dark:text-on-surface-dark-muted\" x-text=\"item.section\"></span></template></div><template x-if=\"item.description\"><p class=\"text-sm leading-6 text-on-surface-muted dark:text-on-surface-dark-muted\" x-html=\"highlight(truncate(item.description))\"></p></template></button></template>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -666,30 +725,30 @@ func searchIcon(classes string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var35 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var35 == nil {
-			templ_7745c5c3_Var35 = templ.NopComponent
+		templ_7745c5c3_Var37 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var37 == nil {
+			templ_7745c5c3_Var37 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var36 = []any{classes}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var36...)
+		var templ_7745c5c3_Var38 = []any{classes}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var38...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" fill=\"none\" stroke-width=\"2\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" fill=\"none\" stroke-width=\"2\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var37 string
-		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var36).String())
+		var templ_7745c5c3_Var39 string
+		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var38).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var37)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var39)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -713,9 +772,9 @@ func searchScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var38 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var38 == nil {
-			templ_7745c5c3_Var38 = templ.NopComponent
+		templ_7745c5c3_Var40 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var40 == nil {
+			templ_7745c5c3_Var40 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = templ.Raw(`<script>
@@ -745,9 +804,19 @@ func searchScript() templ.Component {
 			activeIndex: 0,
 			maxResults: maxResults || 4,
 			descriptionMaxLength: descriptionMaxLength || 120,
+			cachedAllResults: null,
+			cachedDOMTerm: null,
+			cachedDOMResults: [],
+			clientItems: [],
+			clientItemsLoaded: false,
+			clientItemsLoading: false,
+			cachedClientTerm: null,
+			cachedClientResults: [],
 			openSearch: function () {
 				this.open = true;
 				this.activeIndex = 0;
+				if (!this.usesClientSource()) this.resetDOMCache();
+				this.ensureClientItems();
 				this.$nextTick(() => {
 					if (this.$refs.input) this.$refs.input.focus();
 				});
@@ -769,12 +838,93 @@ func searchScript() templ.Component {
 				if (!term) return false;
 				return (el.dataset.searchText || '').toLowerCase().indexOf(term) !== -1;
 			},
-			allResults: function () {
-				return Array.prototype.slice.call(this.$root.querySelectorAll('[data-search-result]'));
+			sourceURL: function () {
+				return (this.$root && this.$root.dataset.searchSourceUrl) || '';
 			},
-			matchedResults: function () {
+			usesClientSource: function () {
+				return this.sourceURL() !== '';
+			},
+			resetClientCache: function () {
+				this.cachedClientTerm = null;
+				this.cachedClientResults = [];
+			},
+			resetDOMCache: function () {
+				this.cachedAllResults = null;
+				this.cachedDOMTerm = null;
+				this.cachedDOMResults = [];
+			},
+			stringValue: function (value) {
+				if (value === null || value === undefined) return '';
+				return String(value);
+			},
+			searchTextForItem: function (item) {
+				return [item.title, item.description, item.section].concat(item.keywords || []).filter(Boolean).join(' ');
+			},
+			safeHref: function (value) {
+				var href = this.stringValue(value).trim();
+				if (!href) return '';
+				try {
+					var parsed = new URL(href, window.location.href);
+					var protocol = parsed.protocol.toLowerCase();
+					if (protocol === 'http:' || protocol === 'https:' || protocol === 'mailto:' || protocol === 'tel:') return href;
+				} catch (e) {
+					return '';
+				}
+				return '';
+			},
+			normalizeItems: function (payload) {
+				var values = Array.isArray(payload) ? payload : (Array.isArray(payload && payload.items) ? payload.items : []);
+				var self = this;
+				return values.map(function (raw, index) {
+					raw = raw || {};
+					var keywords = raw.keywords !== undefined ? raw.keywords : raw.Keywords;
+					if (!Array.isArray(keywords)) keywords = [];
+					var item = {
+						id: self.stringValue(raw.id !== undefined ? raw.id : raw.ID),
+						title: self.stringValue(raw.title !== undefined ? raw.title : raw.Title),
+						description: self.stringValue(raw.description !== undefined ? raw.description : raw.Description),
+						href: self.safeHref(raw.href !== undefined ? raw.href : raw.Href),
+						section: self.stringValue(raw.section !== undefined ? raw.section : raw.Section),
+						keywords: keywords.map(function (keyword) { return self.stringValue(keyword); }),
+						index: index
+					};
+					item.key = item.id || item.href || item.title || String(index);
+					item.searchText = self.searchTextForItem(item);
+					return item;
+				});
+			},
+			ensureClientItems: function () {
+				if (!this.usesClientSource() || this.clientItemsLoaded || this.clientItemsLoading) return;
+				this.clientItemsLoading = true;
+				fetch(this.sourceURL(), { headers: { 'Accept': 'application/json' } })
+					.then(function (response) {
+						if (!response.ok) throw new Error('Search items request failed');
+						return response.json();
+					})
+					.then((payload) => {
+						this.clientItems = this.normalizeItems(payload);
+						this.clientItemsLoaded = true;
+						this.resetClientCache();
+					})
+					.catch(() => {
+						this.clientItems = [];
+						this.clientItemsLoaded = true;
+						this.resetClientCache();
+					})
+					.finally(() => {
+						this.clientItemsLoading = false;
+					});
+			},
+			allResults: function () {
+				if (!this.cachedAllResults) {
+					this.cachedAllResults = Array.prototype.slice.call(this.$root.querySelectorAll('[data-search-result]'));
+				}
+				return this.cachedAllResults;
+			},
+			matchedDOMResults: function () {
 				var term = this.query.trim().toLowerCase();
 				if (!term) return [];
+				if (term === this.cachedDOMTerm) return this.cachedDOMResults;
 				var titleMatches = [];
 				var nonTitleMatches = [];
 				this.allResults().forEach(function (el) {
@@ -783,7 +933,29 @@ func searchScript() templ.Component {
 					if (title.indexOf(term) !== -1) titleMatches.push(el);
 					else if (text.indexOf(term) !== -1) nonTitleMatches.push(el);
 				});
-				return titleMatches.concat(nonTitleMatches).slice(0, this.maxResults);
+				this.cachedDOMTerm = term;
+				this.cachedDOMResults = titleMatches.concat(nonTitleMatches).slice(0, this.maxResults);
+				return this.cachedDOMResults;
+			},
+			matchedClientResults: function () {
+				var term = this.query.trim().toLowerCase();
+				if (!term) return [];
+				if (term === this.cachedClientTerm) return this.cachedClientResults;
+				var titleMatches = [];
+				var nonTitleMatches = [];
+				this.clientItems.forEach(function (item) {
+					var title = (item.title || '').toLowerCase();
+					var text = (item.searchText || '').toLowerCase();
+					if (title.indexOf(term) !== -1) titleMatches.push(item);
+					else if (text.indexOf(term) !== -1) nonTitleMatches.push(item);
+				});
+				this.cachedClientTerm = term;
+				this.cachedClientResults = titleMatches.concat(nonTitleMatches).slice(0, this.maxResults);
+				return this.cachedClientResults;
+			},
+			matchedResults: function () {
+				if (this.usesClientSource()) return this.matchedClientResults();
+				return this.matchedDOMResults();
 			},
 			visibleResults: function () {
 				return this.matchedResults();
@@ -799,12 +971,21 @@ func searchScript() templ.Component {
 				var results = this.visibleResults();
 				if (!results.length) return;
 				this.activeIndex = (this.activeIndex + delta + results.length) % results.length;
-				results[this.activeIndex].scrollIntoView({ block: 'nearest' });
+				this.$nextTick(() => {
+					var el = this.usesClientSource() ? this.$root.querySelectorAll('[data-search-result]')[this.activeIndex] : results[this.activeIndex];
+					if (el) el.scrollIntoView({ block: 'nearest' });
+				});
 			},
 			setActive: function (el) {
 				var results = this.visibleResults();
 				var index = results.indexOf(el);
 				if (index >= 0) this.activeIndex = index;
+			},
+			setActiveIndex: function (index) {
+				this.activeIndex = index;
+			},
+			isActiveIndex: function (index) {
+				return index === this.activeIndex;
 			},
 			isActive: function (el) {
 				return this.visibleResults().indexOf(el) === this.activeIndex;
@@ -812,12 +993,20 @@ func searchScript() templ.Component {
 			choose: function () {
 				var results = this.visibleResults();
 				if (!results.length) return;
-				results[this.activeIndex].click();
+				if (this.usesClientSource()) this.selectResult(results[this.activeIndex]);
+				else results[this.activeIndex].click();
 			},
-			selectResult: function (el) {
+			selectResult: function (result) {
 				this.closeSearch();
-				if (!el.hasAttribute('hx-get') && !el.hasAttribute('hx-post') && el.dataset.searchHref) {
-					window.location.href = el.dataset.searchHref;
+				if (!result) return;
+				if (result.dataset) {
+					if (!result.hasAttribute('hx-get') && !result.hasAttribute('hx-post') && result.dataset.searchHref) {
+						window.location.href = result.dataset.searchHref;
+					}
+					return;
+				}
+				if (result.href) {
+					window.location.href = result.href;
 				}
 			},
 			truncate: function (value) {

--- a/components/search/search_test.go
+++ b/components/search/search_test.go
@@ -60,6 +60,46 @@ func TestSearchRendersGlobalShortcutWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestSearchModalCanLoadResultsFromItemsURL(t *testing.T) {
+	html := renderHTML(t, SearchModal(Config{
+		ID:       "remote-search",
+		ItemsURL: "/search.json",
+		Items: []Item{{
+			ID:    "static-result",
+			Title: "Static result that should not render",
+		}},
+	}))
+
+	for _, want := range []string{
+		`data-search-source-url="/search.json"`,
+		`<template x-for="(item, index) in visibleResults()"`,
+		`x-bind:id="item.id || null"`,
+		`x-on:click="selectResult(item)"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("SearchModal with ItemsURL missing %q in\n%s", want, html)
+		}
+	}
+	if strings.Contains(html, "Static result that should not render") || strings.Contains(html, `id="static-result"`) {
+		t.Fatalf("ItemsURL mode should not pre-render result records:\n%s", html)
+	}
+}
+
+func TestSearchScriptCachesDOMResultMatches(t *testing.T) {
+	html := renderHTML(t, SearchModal(Config{ID: "docs-search"}))
+
+	for _, want := range []string{
+		`cachedDOMTerm: null`,
+		`cachedDOMResults: []`,
+		`if (term === this.cachedDOMTerm) return this.cachedDOMResults;`,
+		`cachedAllResults`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("SearchModal script missing DOM match cache %q in\n%s", want, html)
+		}
+	}
+}
+
 func TestSearchEscapesResultPayloadsBeforeHighlighting(t *testing.T) {
 	payload := `<img src=x onerror=alert(1)>`
 	var buf bytes.Buffer

--- a/components/search/types.go
+++ b/components/search/types.go
@@ -48,6 +48,10 @@ type Config struct {
 	EscapeText string
 	// Items are the caller-provided result records.
 	Items []Item
+	// ItemsURL is an optional JSON endpoint for client-side result records.
+	// When set, results are fetched and rendered in the browser instead of
+	// pre-rendering every Item as a hidden DOM node.
+	ItemsURL string
 	// MaxResults limits the visible matches. Defaults to 4.
 	MaxResults int
 	// DescriptionMaxLength truncates result descriptions. Defaults to 120.

--- a/site/internal/pages/demo/components/search.templ
+++ b/site/internal/pages/demo/components/search.templ
@@ -46,6 +46,20 @@ templ searchDemoContent() {
     },
 })`,
 		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Remote Results",
+				Description: "Load result records from a JSON endpoint, then filter and navigate in the browser.",
+			},
+			searchRemotePreview(),
+			`@search.Search(search.Config{
+    ID:          "remote-search",
+    Label:       "Remote search",
+    Placeholder: "Search fetched results",
+    ItemsURL:    "/api/components/search/items",
+})`,
+		)
 	</div>
 	@demo.APIReference([]demo.PropDoc{
 		{Name: "ID", Type: "string", Default: `"search"`, Description: "Unique id used for the root, dialog, input, and label relationships."},
@@ -55,6 +69,7 @@ templ searchDemoContent() {
 		{Name: "GlobalShortcut", Type: "bool", Default: "false", Description: "When true, Cmd/Ctrl+K opens this search instance."},
 		{Name: "EscapeText", Type: "string", Default: `"Esc"`, Description: "Keyboard hint rendered beside the dialog input."},
 		{Name: "Items", Type: "[]Item", Default: "nil", Description: "Caller-provided result records. The component only filters and displays them."},
+		{Name: "ItemsURL", Type: "string", Default: `""`, Description: "JSON endpoint for client-loaded result records. When set, records are fetched and only visible matches are rendered."},
 		{Name: "MaxResults", Type: "int", Default: "4", Description: "Maximum number of visible matches."},
 		{Name: "DescriptionMaxLength", Type: "int", Default: "120", Description: "Maximum visible description length before truncation."},
 		{Name: "EmptyText", Type: "string", Default: `"No results found."`, Description: "Message shown when the current query has no matches."},
@@ -77,6 +92,17 @@ templ searchDefaultPreview() {
 				{ID: "search-demo-kbd", Title: "KBD", Description: "Semantic keyboard shortcut hints.", Href: "/components/kbd", Section: "Display", Keywords: []string{"shortcut key"}},
 				{ID: "search-demo-text-input", Title: "Text Input", Description: "Inputs with search, password, masks, and validation states.", Href: "/components/text-input", Section: "Form", Keywords: []string{"field"}},
 			},
+		})
+	</div>
+}
+
+templ searchRemotePreview() {
+	<div id="search-remote" class="mx-auto w-full max-w-sm">
+		@search.Search(search.Config{
+			ID:          "remote-search",
+			Label:       "Remote search",
+			Placeholder: "Search fetched results",
+			ItemsURL:    "/api/components/search/items",
 		})
 	</div>
 }

--- a/site/internal/pages/demo/components/search_templ.go
+++ b/site/internal/pages/demo/components/search_templ.go
@@ -107,6 +107,22 @@ func searchDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Remote Results",
+				Description: "Load result records from a JSON endpoint, then filter and navigate in the browser.",
+			},
+			searchRemotePreview(),
+			`@search.Search(search.Config{
+    ID:          "remote-search",
+    Label:       "Remote search",
+    Placeholder: "Search fetched results",
+    ItemsURL:    "/api/components/search/items",
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -119,6 +135,7 @@ func searchDemoContent() templ.Component {
 			{Name: "GlobalShortcut", Type: "bool", Default: "false", Description: "When true, Cmd/Ctrl+K opens this search instance."},
 			{Name: "EscapeText", Type: "string", Default: `"Esc"`, Description: "Keyboard hint rendered beside the dialog input."},
 			{Name: "Items", Type: "[]Item", Default: "nil", Description: "Caller-provided result records. The component only filters and displays them."},
+			{Name: "ItemsURL", Type: "string", Default: `""`, Description: "JSON endpoint for client-loaded result records. When set, records are fetched and only visible matches are rendered."},
 			{Name: "MaxResults", Type: "int", Default: "4", Description: "Maximum number of visible matches."},
 			{Name: "DescriptionMaxLength", Type: "int", Default: "120", Description: "Maximum visible description length before truncation."},
 			{Name: "EmptyText", Type: "string", Default: `"No results found."`, Description: "Message shown when the current query has no matches."},
@@ -181,7 +198,7 @@ func searchDefaultPreview() templ.Component {
 	})
 }
 
-func searchCustomPreview() templ.Component {
+func searchRemotePreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -202,7 +219,49 @@ func searchCustomPreview() templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"search-custom\" class=\"mx-auto w-full max-w-sm\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"search-remote\" class=\"mx-auto w-full max-w-sm\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = search.Search(search.Config{
+			ID:          "remote-search",
+			Label:       "Remote search",
+			Placeholder: "Search fetched results",
+			ItemsURL:    "/api/components/search/items",
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func searchCustomPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"search-custom\" class=\"mx-auto w-full max-w-sm\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -221,7 +280,7 @@ func searchCustomPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/server/search_handler.go
+++ b/site/internal/server/search_handler.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type searchItemResponse struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Href        string   `json:"href,omitempty"`
+	Section     string   `json:"section,omitempty"`
+	Keywords    []string `json:"keywords,omitempty"`
+}
+
+func (s *Server) handleSearchItems(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/api/components/search/items" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	_ = json.NewEncoder(w).Encode([]searchItemResponse{
+		{
+			ID:          "search-remote-table",
+			Title:       "Fetched table",
+			Description: "Loaded from a JSON endpoint and filtered in the browser.",
+			Href:        "/components/table",
+			Section:     "Remote",
+			Keywords:    []string{"fetched remote json"},
+		},
+		{
+			ID:          "search-remote-combobox",
+			Title:       "Remote combobox",
+			Description: "Another result from the same client-side item source.",
+			Href:        "/components/combobox",
+			Section:     "Remote",
+			Keywords:    []string{"async source"},
+		},
+	})
+}

--- a/site/internal/server/server.go
+++ b/site/internal/server/server.go
@@ -102,6 +102,7 @@ func (s *Server) setupRoutes() {
 	s.mux.HandleFunc("/api/components/form-validation", s.handleFormValidation)
 	s.mux.HandleFunc("/api/components/steps/demo", s.handleStepsDemo)
 	s.mux.HandleFunc("/api/components/radio/echo", s.handleRadioEcho)
+	s.mux.HandleFunc("/api/components/search/items", s.handleSearchItems)
 	s.registerGettingStartedRoutes()
 
 	// Combobox users demo runs server-mode lazy search.

--- a/site/tests/e2e/search_test.go
+++ b/site/tests/e2e/search_test.go
@@ -55,6 +55,40 @@ func TestSearch_PageLoadsAndFilters(t *testing.T) {
 	assert.NoError(t, page.Locator("#component-search-dialog p", playwright.PageLocatorOptions{HasText: "No results found."}).WaitFor())
 }
 
+func TestSearch_ItemsURLFetchesAndFilters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser)
+
+	_, err := page.Goto(baseURL+"/components/search", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+
+	trigger := page.Locator("#remote-search button[aria-haspopup='dialog']")
+	require.NoError(t, trigger.Click())
+
+	input := page.Locator("#remote-search-input")
+	require.NoError(t, input.WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+
+	require.NoError(t, input.Fill("fetched"))
+	require.NoError(t, page.Locator("#search-remote-table:visible").WaitFor())
+
+	visible, err := page.Locator("#remote-search-dialog [data-search-result]:visible").Count()
+	require.NoError(t, err)
+	assert.Equal(t, 1, visible)
+}
+
 func TestSidebarSearch_UsesKbdAndNavigates(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping E2E test in short mode")


### PR DESCRIPTION
## Summary
- Add `search.Config.ItemsURL` so search results can be fetched and rendered client-side.
- Keep existing SSR/static `Items` behavior, with cached DOM matching to avoid repeated full scans.
- Add a remote-results demo endpoint and E2E coverage for JSON-backed search.

## Test Plan
- `git diff --check`
- `go run ./cmd/skillgen`
- `templ generate`
- `go test ./... -count=1`
- `cd site && go test $(go list ./... | grep -v /tests/e2e) -count=1`
- `go test ./site/tests/e2e -run 'TestSearch_|TestSidebarSearch_|TestSearchCoverage' -count=1 -timeout 5m -v`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search component now supports loading results from a remote JSON endpoint via the `ItemsURL` configuration option, enabling client-side fetching and rendering of results

* **Documentation**
  * Added "Remote Results" demo section showing how to use remote-loaded search results
  * Updated component documentation with `ItemsURL` field details

* **Tests**
  * Added test coverage for remote results functionality and client-side result matching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->