### PR TITLE
feat(sidebar): support collapsible section groups

### DIFF
--- a/.agents/skills/using-goshtoso/references/components-reference.md
+++ b/.agents/skills/using-goshtoso/references/components-reference.md
@@ -1309,7 +1309,7 @@ import "github.com/araihu/goshtoso/components/sidebar"  // package sidebar
 |-------|------|-------------|
 | `Title` | `string` | Title is the section header |
 | `Items` | `[]Item` | Items are the navigation items in this section |
-| `Collapsible` | `bool` | Collapsible enables collapse/expand with Alpine.js |
+| `Collapsible` | `bool` | Collapsible renders direct child groups behind independent disclosure controls. |
 
 ## spinner
 

--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -1309,7 +1309,7 @@ import "github.com/araihu/goshtoso/components/sidebar"  // package sidebar
 |-------|------|-------------|
 | `Title` | `string` | Title is the section header |
 | `Items` | `[]Item` | Items are the navigation items in this section |
-| `Collapsible` | `bool` | Collapsible enables collapse/expand with Alpine.js |
+| `Collapsible` | `bool` | Collapsible renders direct child groups behind independent disclosure controls. |
 
 ## spinner
 

--- a/components/sidebar/sidebar.templ
+++ b/components/sidebar/sidebar.templ
@@ -145,15 +145,15 @@ templ sidebarSection(section Section, index int) {
 		}
 		<div class="flex flex-col">
 			for _, item := range section.Items {
-				@sidebarSectionItem(item)
+				@sidebarSectionItem(item, section.Collapsible)
 			}
 		</div>
 	</div>
 }
 
 // sidebarSectionItem renders an item with left border line (PenguinUI sidebar style)
-templ sidebarSectionItem(item Item) {
-	if item.Collapsible && len(item.Items) > 0 {
+templ sidebarSectionItem(item Item, collapseChildGroups bool) {
+	if (item.Collapsible || collapseChildGroups) && len(item.Items) > 0 {
 		@sidebarCollapsibleSectionItem(item)
 	} else if item.Disabled {
 		<span class="flex items-center border-l border-outline py-2.5 pl-4 text-sm font-medium text-on-surface-muted cursor-not-allowed dark:border-outline-dark dark:text-on-surface-dark-muted">
@@ -195,10 +195,10 @@ templ sidebarSectionItem(item Item) {
 		</a>
 	}
 
-	if len(item.Items) > 0 && !item.Collapsible {
+	if len(item.Items) > 0 && !item.Collapsible && !collapseChildGroups {
 		<div class="ml-4 flex flex-col">
 			for _, child := range item.Items {
-				@sidebarSectionItem(child)
+				@sidebarSectionItem(child, false)
 			}
 		</div>
 	}
@@ -222,9 +222,9 @@ templ sidebarCollapsibleSectionItem(item Item) {
 				<path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"></path>
 			</svg>
 		</a>
-		<div id={ sidebarChildrenID(item) } x-show="open" class="ml-4 flex flex-col">
+		<div id={ sidebarChildrenID(item) } x-show="open" { sidebarChildrenAttrs(item.Open)... } class="ml-4 flex flex-col">
 			for _, child := range item.Items {
-				@sidebarSectionItem(child)
+				@sidebarSectionItem(child, false)
 			}
 		</div>
 	</div>

--- a/components/sidebar/sidebar_coverage_test.go
+++ b/components/sidebar/sidebar_coverage_test.go
@@ -311,8 +311,59 @@ func TestSectionItemsWithChildrenCanCollapse(t *testing.T) {
 		`id="tag-pets-children"`,
 		`<span class="min-w-0 flex-1 truncate">Pets</span>`,
 	)
+	if strings.Contains(html, `id="tag-pets-children" x-show="open" style="display: none;"`) {
+		t.Fatalf("open collapsible child groups should render visible before Alpine initializes: %s", html)
+	}
 	if count := strings.Count(html, `href="#operation-get-pets"`); count != 1 {
 		t.Fatalf("collapsible children rendered %d links, want 1: %s", count, html)
+	}
+}
+
+func TestCollapsibleSectionCollapsesChildGroupsByDefault(t *testing.T) {
+	html := renderSidebar(t, Config{
+		Sections: []Section{
+			{
+				Title:       "Operations",
+				Collapsible: true,
+				Items: []Item{
+					{
+						ID:    "tag-pets",
+						Label: "Pets",
+						Href:  "#tag-pets",
+						Items: []Item{
+							{ID: "get-pets", Label: "GET /pets", Href: "#operation-get-pets"},
+						},
+					},
+					{
+						ID:    "tag-stores",
+						Label: "Stores",
+						Href:  "#tag-stores",
+						Items: []Item{
+							{ID: "get-stores", Label: "GET /stores", Href: "#operation-get-stores"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	assertContainsAll(t, html,
+		`aria-controls="tag-pets-children"`,
+		`aria-controls="tag-stores-children"`,
+		`id="tag-pets-children"`,
+		`id="tag-stores-children"`,
+		`x-on:click.prevent="open = !open"`,
+		`x-show="open"`,
+		`style="display: none;"`,
+		`href="#operation-get-pets"`,
+		`href="#operation-get-stores"`,
+	)
+
+	if count := strings.Count(html, `x-data="{ open: false }"`); count != 2 {
+		t.Fatalf("collapsible section should render each child group closed with independent state, got %d scopes: %s", count, html)
+	}
+	if strings.Contains(html, `x-data="{ open: true }"`) {
+		t.Fatalf("collapsible section child groups should default closed: %s", html)
 	}
 }
 

--- a/components/sidebar/sidebar_templ.go
+++ b/components/sidebar/sidebar_templ.go
@@ -558,7 +558,7 @@ func sidebarSection(section Section, index int) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		for _, item := range section.Items {
-			templ_7745c5c3_Err = sidebarSectionItem(item).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = sidebarSectionItem(item, section.Collapsible).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -572,7 +572,7 @@ func sidebarSection(section Section, index int) templ.Component {
 }
 
 // sidebarSectionItem renders an item with left border line (PenguinUI sidebar style)
-func sidebarSectionItem(item Item) templ.Component {
+func sidebarSectionItem(item Item, collapseChildGroups bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -593,7 +593,7 @@ func sidebarSectionItem(item Item) templ.Component {
 			templ_7745c5c3_Var22 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		if item.Collapsible && len(item.Items) > 0 {
+		if (item.Collapsible || collapseChildGroups) && len(item.Items) > 0 {
 			templ_7745c5c3_Err = sidebarCollapsibleSectionItem(item).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -857,13 +857,13 @@ func sidebarSectionItem(item Item) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		if len(item.Items) > 0 && !item.Collapsible {
+		if len(item.Items) > 0 && !item.Collapsible && !collapseChildGroups {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "<div class=\"ml-4 flex flex-col\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, child := range item.Items {
-				templ_7745c5c3_Err = sidebarSectionItem(child).Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = sidebarSectionItem(child, false).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1012,17 +1012,25 @@ func sidebarCollapsibleSectionItem(item Item) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "\" x-show=\"open\" class=\"ml-4 flex flex-col\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "\" x-show=\"open\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, sidebarChildrenAttrs(item.Open))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, " class=\"ml-4 flex flex-col\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, child := range item.Items {
-			templ_7745c5c3_Err = sidebarSectionItem(child).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = sidebarSectionItem(child, false).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/sidebar/types.go
+++ b/components/sidebar/types.go
@@ -78,7 +78,8 @@ type Section struct {
 	Title string
 	// Items are the navigation items in this section
 	Items []Item
-	// Collapsible enables collapse/expand with Alpine.js
+	// Collapsible renders direct child groups behind independent disclosure controls.
+	// Each group starts closed unless the parent Item sets Open.
 	Collapsible bool
 }
 
@@ -138,6 +139,13 @@ func sidebarDisclosureData(open bool) string {
 		return "{ open: true }"
 	}
 	return "{ open: false }"
+}
+
+func sidebarChildrenAttrs(open bool) templ.Attributes {
+	if open {
+		return nil
+	}
+	return templ.Attributes{"style": "display: none;"}
 }
 
 func sidebarChildrenID(item Item) string {

--- a/site/internal/pages/demo/components/sidebar.templ
+++ b/site/internal/pages/demo/components/sidebar.templ
@@ -183,7 +183,8 @@ templ sidebarSubItemsPreview() {
 							},
 						},
 						{
-							Title: "Endpoints",
+							Title:       "Endpoints",
+							Collapsible: true,
 							Items: []sidebar.Item{
 								{ID: "ep-users", Label: "Users", Href: "#", Icon: usersIcon(), Items: []sidebar.Item{
 									{ID: "ep-create-user", Label: "Create User", Href: "#", Badge: "POST"},

--- a/site/internal/pages/demo/components/sidebar_templ.go
+++ b/site/internal/pages/demo/components/sidebar_templ.go
@@ -343,7 +343,8 @@ func sidebarSubItemsPreview() templ.Component {
 					},
 				},
 				{
-					Title: "Endpoints",
+					Title:       "Endpoints",
+					Collapsible: true,
 					Items: []sidebar.Item{
 						{ID: "ep-users", Label: "Users", Href: "#", Icon: usersIcon(), Items: []sidebar.Item{
 							{ID: "ep-create-user", Label: "Create User", Href: "#", Badge: "POST"},
@@ -493,7 +494,7 @@ func collapsibleItem(label string, active bool) templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/sidebar.templ`, Line: 309, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/sidebar.templ`, Line: 310, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
@@ -511,7 +512,7 @@ func collapsibleItem(label string, active bool) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/sidebar.templ`, Line: 313, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/sidebar.templ`, Line: 314, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {

--- a/site/tests/e2e/sidebar_coverage_test.go
+++ b/site/tests/e2e/sidebar_coverage_test.go
@@ -52,9 +52,18 @@ func TestSidebarCoverageDemo(t *testing.T) {
 		subItems := page.Locator("#sidebar-sub-items")
 		require.NoError(t, subItems.ScrollIntoViewIfNeeded())
 
-		for _, label := range []string{"Create User", "Get User", "Update User", "Delete User", "List Products", "Create Product"} {
-			require.NoError(t, subItems.Locator("a").Filter(playwright.LocatorFilterOptions{HasText: label}).WaitFor())
-		}
+		require.False(t, sidebarLinkVisibleContaining(t, page, "#sidebar-sub-items", "Create User"))
+		require.False(t, sidebarLinkVisibleContaining(t, page, "#sidebar-sub-items", "List Products"))
+
+		users := subItems.Locator("a[aria-controls='ep-users-children']")
+		products := subItems.Locator("a[aria-controls='ep-products-children']")
+		require.NoError(t, users.Click())
+		waitForSidebarLinkVisibleContaining(t, page, "#sidebar-sub-items", "Create User")
+
+		require.NoError(t, products.Click())
+		waitForSidebarLinkVisibleContaining(t, page, "#sidebar-sub-items", "Create User")
+		waitForSidebarLinkVisibleContaining(t, page, "#sidebar-sub-items", "List Products")
+
 		for _, badge := range []string{"POST", "GET", "PUT", "DEL"} {
 			require.NoError(t, subItems.Locator("sup").Filter(playwright.LocatorFilterOptions{HasText: badge}).First().WaitFor())
 		}
@@ -110,4 +119,24 @@ func sidebarVisible(t *testing.T, page playwright.Page, scope string, text strin
 	require.NoError(t, err)
 
 	return result.(bool)
+}
+
+func sidebarLinkVisibleContaining(t *testing.T, page playwright.Page, scope string, text string) bool {
+	t.Helper()
+
+	result, err := page.Evaluate(`([scope, text]) => Array.from(document.querySelectorAll(scope + " a")).some((el) => el.textContent.includes(text) && el.offsetParent !== null)`, []string{scope, text})
+	require.NoError(t, err)
+
+	return result.(bool)
+}
+
+func waitForSidebarLinkVisibleContaining(t *testing.T, page playwright.Page, scope string, text string) {
+	t.Helper()
+
+	_, err := page.WaitForFunction(
+		`([scope, text]) => Array.from(document.querySelectorAll(scope + " a")).some((el) => el.textContent.includes(text) && el.offsetParent !== null)`,
+		[]string{scope, text},
+		playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)},
+	)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
- Allow sidebar sections to render child groups as independent collapsible controls
- Keep collapsible children hidden on first render unless the parent item is explicitly open
- Update sidebar docs/demo coverage for multiple groups open at once

## Test Plan
- go test ./... -count=1
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sidebar sections now support collapsible child groups with independent disclosure controls for expanding and collapsing each group.

* **Documentation**
  * Updated sidebar component documentation to reflect new collapsible child group behavior.

* **Tests**
  * Enhanced test coverage for collapsible sidebar functionality and expand/collapse interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->