### PR TITLE
fix(site): attach docs TOC rail to content

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -261,7 +261,6 @@
     --container-3xl: 48rem;
     --container-4xl: 56rem;
     --container-5xl: 64rem;
-    --container-7xl: 80rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
     --text-sm: 0.875rem;
@@ -1024,6 +1023,9 @@
   .min-h-\[50svh\] {
     min-height: 50svh;
   }
+  .min-h-full {
+    min-height: 100%;
+  }
   .min-h-screen {
     min-height: 100vh;
   }
@@ -1150,11 +1152,14 @@
   .max-w-5xl {
     max-width: var(--container-5xl);
   }
-  .max-w-7xl {
-    max-width: var(--container-7xl);
-  }
   .max-w-\[80\%\] {
     max-width: 80%;
+  }
+  .max-w-\[83rem\] {
+    max-width: 83rem;
+  }
+  .max-w-\[99rem\] {
+    max-width: 99rem;
   }
   .max-w-\[320px\] {
     max-width: 320px;
@@ -5490,6 +5495,16 @@
     @media (width >= 64rem) {
       font-size: var(--text-xl);
       line-height: var(--tw-leading, var(--text-xl--line-height));
+    }
+  }
+  .xl\:right-\[max\(0rem\,calc\(\(100vw-18rem-83rem\)\/2\)\)\] {
+    @media (width >= 80rem) {
+      right: max(0rem, calc((100vw - 18rem - 83rem) / 2));
+    }
+  }
+  .xl\:right-\[max\(0rem\,calc\(\(100vw-18rem-99rem\)\/2\)\)\] {
+    @media (width >= 80rem) {
+      right: max(0rem, calc((100vw - 18rem - 99rem) / 2));
     }
   }
   .xl\:block {

--- a/site/internal/pages/demo/layout.templ
+++ b/site/internal/pages/demo/layout.templ
@@ -108,8 +108,8 @@ templ LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compon
 						if (sidebarContent && window.htmx && htmx.process) htmx.process(sidebarContent);
 						var sb = document.querySelector('.sidebar-scroll');
 						if (sb) sb.scrollTop = __sidebarScrollTop;
-						var main = document.querySelector('main');
-						if (main) main.scrollTo({ top: 0 });
+						var pageScroll = document.getElementById('page-scroll');
+						if (pageScroll) pageScroll.scrollTo({ top: 0 });
 						if (window.buildTOC) window.buildTOC();
 					}
 				});
@@ -234,21 +234,22 @@ templ LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compon
 				></div>
 
 				<!-- Main Content -->
-				<main data-boot-anim="main" class="flex-1 overflow-y-auto p-6 lg:p-8">
-					<div id="main-content" class={ "mx-auto " + mainContentMaxWidth(activeComponent) }>
-						@content
-						@componentNavFooter(activeComponent)
-						@siteFooter()
+				<main id="page-scroll" data-boot-anim="main" class="flex-1 overflow-y-auto">
+					<div class={ "mx-auto flex min-h-full w-full " + pageFrameMaxWidth(activeComponent) }>
+						<div id="main-content" class="min-w-0 flex-1 p-6 lg:p-8">
+							@content
+							@componentNavFooter(activeComponent)
+							@siteFooter()
+						</div>
+						<!-- Right rail: "On this page" section nav, built from [data-toc-heading]. -->
+						<div id="toc-rail" data-boot-anim="main" class="hidden w-60 shrink-0 xl:block">
+							<aside class={ "fixed bottom-0 top-16 w-60 overflow-y-auto border-l border-outline px-6 py-8 dark:border-outline-dark " + tocRailRight(activeComponent) }>
+								<p class="mb-3 text-xs font-semibold uppercase tracking-wide text-on-surface-muted dark:text-on-surface-dark-muted">On this page</p>
+								<nav id="toc-list" aria-label="On this page" class="flex flex-col border-l border-outline dark:border-outline-dark"></nav>
+							</aside>
+						</div>
 					</div>
 				</main>
-
-				<!-- Right rail: "On this page" section nav, built from [data-toc-heading]. -->
-				<aside id="toc-rail" data-boot-anim="main" class="hidden xl:block w-60 shrink-0 overflow-y-auto border-l border-outline dark:border-outline-dark">
-					<div class="sticky top-0 px-6 py-8">
-						<p class="mb-3 text-xs font-semibold uppercase tracking-wide text-on-surface-muted dark:text-on-surface-dark-muted">On this page</p>
-						<nav id="toc-list" aria-label="On this page" class="flex flex-col border-l border-outline dark:border-outline-dark"></nav>
-					</div>
-				</aside>
 			</div>
 			@searchfield.SearchModal(docsSearchConfig())
 			<!-- Browser storage notice. Shows until the visitor chooses allowed or denied
@@ -310,10 +311,11 @@ templ LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compon
 					window.buildTOC = function () {
 						var rail = document.getElementById('toc-rail');
 						var nav = document.getElementById('toc-list');
-						var main = document.getElementById('main-content');
-						if (!rail || !nav || !main) return;
+						var pageScroll = document.getElementById('page-scroll');
+						var content = document.getElementById('main-content');
+						if (!rail || !nav || !pageScroll || !content) return;
 						if (spy) { spy.disconnect(); spy = null; }
-						var heads = Array.prototype.slice.call(main.querySelectorAll('[data-toc-heading]'));
+						var heads = Array.prototype.slice.call(content.querySelectorAll('[data-toc-heading]'));
 						nav.innerHTML = '';
 						// One heading (just the page title) isn't worth a rail — hide it.
 						if (heads.length < 2) { rail.style.display = 'none'; return; }
@@ -338,9 +340,11 @@ templ LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compon
 							entries.forEach(function (en) {
 								if (en.isIntersecting) setActive(nav, en.target.id);
 							});
-						}, { root: main, rootMargin: '0px 0px -75% 0px', threshold: 0 });
+						}, { root: pageScroll, rootMargin: '0px 0px -75% 0px', threshold: 0 });
 						heads.forEach(function (h) { if (h.id) spy.observe(h); });
-						setActive(nav, heads[0].id);
+						var hashId = decodeURIComponent((window.location.hash || '').replace(/^#/, ''));
+						var active = heads.find(function (h) { return h.id === hashId; }) || heads[0];
+						setActive(nav, active.id);
 					};
 					if (document.readyState === 'loading') {
 						document.addEventListener('DOMContentLoaded', window.buildTOC);
@@ -369,14 +373,23 @@ func navHxAttrs(href, label string) templ.Attributes {
 	return attrs
 }
 
-// mainContentMaxWidth picks the page-content container width per route. The
-// theme page needs the extra width to host the side-by-side controls + theme
-// showcase layout; everything else stays at the narrower docs default.
-func mainContentMaxWidth(activeComponent string) string {
+// pageFrameMaxWidth picks a docs frame width that includes content, its padding,
+// and the desktop TOC rail. The theme page needs the extra width to host the
+// side-by-side controls + theme showcase layout.
+func pageFrameMaxWidth(activeComponent string) string {
 	if activeComponent == "theme" {
-		return "max-w-7xl"
+		return "max-w-[99rem]"
 	}
-	return "max-w-5xl"
+	return "max-w-[83rem]"
+}
+
+// tocRailRight aligns the fixed desktop TOC rail with the reserved rail column
+// inside the centered docs frame. The 18rem term is the desktop sidebar width.
+func tocRailRight(activeComponent string) string {
+	if activeComponent == "theme" {
+		return "xl:right-[max(0rem,calc((100vw-18rem-99rem)/2))]"
+	}
+	return "xl:right-[max(0rem,calc((100vw-18rem-83rem)/2))]"
 }
 
 // getSidebarTopItems returns the top-level icon navigation items above the component sections

--- a/site/internal/pages/demo/layout_templ.go
+++ b/site/internal/pages/demo/layout_templ.go
@@ -356,7 +356,7 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\"></script><script>\n\t\t\t\t// Alpine nav store + htmx integration for fragment-swap sidebar navigation.\n\t\t\t\t// The store's `path` field is read inside the sidebar wrapper's x-effect so\n\t\t\t\t// the search filter re-applies after an OOB sidebar swap.\n\t\t\t\tdocument.addEventListener('alpine:init', () => {\n\t\t\t\t\tAlpine.store('nav', { path: window.location.pathname });\n\t\t\t\t});\n\t\t\t\tdocument.addEventListener('htmx:pushedIntoHistory', () => {\n\t\t\t\t\tif (window.Alpine && Alpine.store('nav')) {\n\t\t\t\t\t\tAlpine.store('nav').path = window.location.pathname;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\t// Sidebar OOB swap rebuilds the .sidebar-scroll element, so its scrollTop\n\t\t\t\t// resets. Capture before each swap and restore right after.\n\t\t\t\tvar __sidebarScrollTop = 0;\n\t\t\t\tdocument.addEventListener('htmx:beforeSwap', () => {\n\t\t\t\t\tvar el = document.querySelector('.sidebar-scroll');\n\t\t\t\t\tif (el) __sidebarScrollTop = el.scrollTop;\n\t\t\t\t});\n\t\t\t\tdocument.addEventListener('htmx:afterSwap', (e) => {\n\t\t\t\t\tif (e && e.detail && e.detail.target && window.Alpine && Alpine.initTree) {\n\t\t\t\t\t\tAlpine.initTree(e.detail.target);\n\t\t\t\t\t}\n\t\t\t\t\t// Sidebar scroll-restore and main scroll-reset apply ONLY to full\n\t\t\t\t\t// page-nav swaps (target = #main-content), where the sidebar OOB-rebuilds.\n\t\t\t\t\t// In-page swaps (accordions, tabs, table rows, the SSE log feed) must not\n\t\t\t\t\t// touch sidebar/main scroll — an ungated sidebar restore here reset the\n\t\t\t\t\t// nav to the top on every SSE log append.\n\t\t\t\t\tvar tgt = e && e.detail && e.detail.target;\n\t\t\t\t\tif (tgt && tgt.id === 'main-content') {\n\t\t\t\t\t\tvar sidebarContent = document.getElementById('sidebar-nav-content');\n\t\t\t\t\t\tif (sidebarContent && window.Alpine && Alpine.initTree) Alpine.initTree(sidebarContent);\n\t\t\t\t\t\tif (sidebarContent && window.htmx && htmx.process) htmx.process(sidebarContent);\n\t\t\t\t\t\tvar sb = document.querySelector('.sidebar-scroll');\n\t\t\t\t\t\tif (sb) sb.scrollTop = __sidebarScrollTop;\n\t\t\t\t\t\tvar main = document.querySelector('main');\n\t\t\t\t\t\tif (main) main.scrollTo({ top: 0 });\n\t\t\t\t\t\tif (window.buildTOC) window.buildTOC();\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t</script><style>\n\t\t\t\t[x-cloak] { display: none !important; }\n\t\t\t\t/* Hide scrollbar for sidebar */\n\t\t\t\t.sidebar-scroll::-webkit-scrollbar {\n\t\t\t\t\tdisplay: none;\n\t\t\t\t}\n\t\t\t\t.sidebar-scroll {\n\t\t\t\t\t-ms-overflow-style: none;\n\t\t\t\t\tscrollbar-width: none;\n\t\t\t\t}\n\t\t\t\t/* First-paint entrance animations — masks layout shift on hard reload.\n\t\t\t\t   Gated by html.boot which is stripped ~600ms after DOMContentLoaded,\n\t\t\t\t   so HTMX partial swaps do not retrigger. */\n\t\t\t\t@keyframes goshFadeIn { from { opacity: 0; } to { opacity: 1; } }\n\t\t\t\t@keyframes goshSlideDown {\n\t\t\t\t\tfrom { opacity: 0; transform: translate3d(0, -8px, 0); }\n\t\t\t\t\tto   { opacity: 1; transform: none; }\n\t\t\t\t}\n\t\t\t\t@keyframes goshSlideRight {\n\t\t\t\t\tfrom { opacity: 0; transform: translate3d(-12px, 0, 0); }\n\t\t\t\t\tto   { opacity: 1; transform: none; }\n\t\t\t\t}\n\t\t\t\thtml.boot [data-boot-anim=\"header\"]  { animation: goshSlideDown 260ms ease-out both; }\n\t\t\t\thtml.boot [data-boot-anim=\"sidebar\"] { animation: goshSlideRight 320ms ease-out 60ms both; }\n\t\t\t\thtml.boot [data-boot-anim=\"main\"]    { animation: goshFadeIn 320ms ease-out 120ms both; }\n\t\t\t\t@media (prefers-reduced-motion: reduce) {\n\t\t\t\t\thtml.boot [data-boot-anim] { animation: none; }\n\t\t\t\t}\n\t\t\t</style></head><body class=\"h-screen overflow-hidden bg-surface text-on-surface dark:bg-surface-dark dark:text-on-surface-dark theme-transition\"><!-- Header --><header data-boot-anim=\"header\" class=\"sticky top-0 z-50 border-b border-outline bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/60 dark:border-outline-dark dark:bg-surface-dark/95 dark:supports-[backdrop-filter]:bg-surface-dark/60\"><div class=\"flex h-16 items-center justify-between px-4 lg:px-8\"><div class=\"flex items-center gap-4\"><button @click=\"sidebarOpen = !sidebarOpen\" class=\"lg:hidden p-2 rounded-md hover:bg-surface-alt dark:hover:bg-surface-dark-alt\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-6 w-6\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M4 6h16M4 12h16M4 18h16\"></path></svg></button> <a href=\"/\" class=\"flex items-center gap-2\"><span class=\"text-2xl font-bold font-title\"><span class=\"text-primary dark:text-primary-dark\">Go</span>shtoso</span></a></div><!-- Right side controls --><div class=\"flex items-center gap-2\"><!-- Theme Selector --><div class=\"w-36 sm:w-44\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\"></script><script>\n\t\t\t\t// Alpine nav store + htmx integration for fragment-swap sidebar navigation.\n\t\t\t\t// The store's `path` field is read inside the sidebar wrapper's x-effect so\n\t\t\t\t// the search filter re-applies after an OOB sidebar swap.\n\t\t\t\tdocument.addEventListener('alpine:init', () => {\n\t\t\t\t\tAlpine.store('nav', { path: window.location.pathname });\n\t\t\t\t});\n\t\t\t\tdocument.addEventListener('htmx:pushedIntoHistory', () => {\n\t\t\t\t\tif (window.Alpine && Alpine.store('nav')) {\n\t\t\t\t\t\tAlpine.store('nav').path = window.location.pathname;\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t\t// Sidebar OOB swap rebuilds the .sidebar-scroll element, so its scrollTop\n\t\t\t\t// resets. Capture before each swap and restore right after.\n\t\t\t\tvar __sidebarScrollTop = 0;\n\t\t\t\tdocument.addEventListener('htmx:beforeSwap', () => {\n\t\t\t\t\tvar el = document.querySelector('.sidebar-scroll');\n\t\t\t\t\tif (el) __sidebarScrollTop = el.scrollTop;\n\t\t\t\t});\n\t\t\t\tdocument.addEventListener('htmx:afterSwap', (e) => {\n\t\t\t\t\tif (e && e.detail && e.detail.target && window.Alpine && Alpine.initTree) {\n\t\t\t\t\t\tAlpine.initTree(e.detail.target);\n\t\t\t\t\t}\n\t\t\t\t\t// Sidebar scroll-restore and main scroll-reset apply ONLY to full\n\t\t\t\t\t// page-nav swaps (target = #main-content), where the sidebar OOB-rebuilds.\n\t\t\t\t\t// In-page swaps (accordions, tabs, table rows, the SSE log feed) must not\n\t\t\t\t\t// touch sidebar/main scroll — an ungated sidebar restore here reset the\n\t\t\t\t\t// nav to the top on every SSE log append.\n\t\t\t\t\tvar tgt = e && e.detail && e.detail.target;\n\t\t\t\t\tif (tgt && tgt.id === 'main-content') {\n\t\t\t\t\t\tvar sidebarContent = document.getElementById('sidebar-nav-content');\n\t\t\t\t\t\tif (sidebarContent && window.Alpine && Alpine.initTree) Alpine.initTree(sidebarContent);\n\t\t\t\t\t\tif (sidebarContent && window.htmx && htmx.process) htmx.process(sidebarContent);\n\t\t\t\t\t\tvar sb = document.querySelector('.sidebar-scroll');\n\t\t\t\t\t\tif (sb) sb.scrollTop = __sidebarScrollTop;\n\t\t\t\t\t\tvar pageScroll = document.getElementById('page-scroll');\n\t\t\t\t\t\tif (pageScroll) pageScroll.scrollTo({ top: 0 });\n\t\t\t\t\t\tif (window.buildTOC) window.buildTOC();\n\t\t\t\t\t}\n\t\t\t\t});\n\t\t\t</script><style>\n\t\t\t\t[x-cloak] { display: none !important; }\n\t\t\t\t/* Hide scrollbar for sidebar */\n\t\t\t\t.sidebar-scroll::-webkit-scrollbar {\n\t\t\t\t\tdisplay: none;\n\t\t\t\t}\n\t\t\t\t.sidebar-scroll {\n\t\t\t\t\t-ms-overflow-style: none;\n\t\t\t\t\tscrollbar-width: none;\n\t\t\t\t}\n\t\t\t\t/* First-paint entrance animations — masks layout shift on hard reload.\n\t\t\t\t   Gated by html.boot which is stripped ~600ms after DOMContentLoaded,\n\t\t\t\t   so HTMX partial swaps do not retrigger. */\n\t\t\t\t@keyframes goshFadeIn { from { opacity: 0; } to { opacity: 1; } }\n\t\t\t\t@keyframes goshSlideDown {\n\t\t\t\t\tfrom { opacity: 0; transform: translate3d(0, -8px, 0); }\n\t\t\t\t\tto   { opacity: 1; transform: none; }\n\t\t\t\t}\n\t\t\t\t@keyframes goshSlideRight {\n\t\t\t\t\tfrom { opacity: 0; transform: translate3d(-12px, 0, 0); }\n\t\t\t\t\tto   { opacity: 1; transform: none; }\n\t\t\t\t}\n\t\t\t\thtml.boot [data-boot-anim=\"header\"]  { animation: goshSlideDown 260ms ease-out both; }\n\t\t\t\thtml.boot [data-boot-anim=\"sidebar\"] { animation: goshSlideRight 320ms ease-out 60ms both; }\n\t\t\t\thtml.boot [data-boot-anim=\"main\"]    { animation: goshFadeIn 320ms ease-out 120ms both; }\n\t\t\t\t@media (prefers-reduced-motion: reduce) {\n\t\t\t\t\thtml.boot [data-boot-anim] { animation: none; }\n\t\t\t\t}\n\t\t\t</style></head><body class=\"h-screen overflow-hidden bg-surface text-on-surface dark:bg-surface-dark dark:text-on-surface-dark theme-transition\"><!-- Header --><header data-boot-anim=\"header\" class=\"sticky top-0 z-50 border-b border-outline bg-surface/95 backdrop-blur supports-[backdrop-filter]:bg-surface/60 dark:border-outline-dark dark:bg-surface-dark/95 dark:supports-[backdrop-filter]:bg-surface-dark/60\"><div class=\"flex h-16 items-center justify-between px-4 lg:px-8\"><div class=\"flex items-center gap-4\"><button @click=\"sidebarOpen = !sidebarOpen\" class=\"lg:hidden p-2 rounded-md hover:bg-surface-alt dark:hover:bg-surface-dark-alt\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-6 w-6\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M4 6h16M4 12h16M4 18h16\"></path></svg></button> <a href=\"/\" class=\"flex items-center gap-2\"><span class=\"text-2xl font-bold font-title\"><span class=\"text-primary dark:text-primary-dark\">Go</span>shtoso</span></a></div><!-- Right side controls --><div class=\"flex items-center gap-2\"><!-- Theme Selector --><div class=\"w-36 sm:w-44\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -383,16 +383,16 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div></div></div><!-- Overlay for mobile sidebar --><div x-show=\"sidebarOpen\" @click=\"sidebarOpen = false\" class=\"fixed inset-0 z-30 bg-black/50 lg:hidden\" x-cloak></div><!-- Main Content --><main data-boot-anim=\"main\" class=\"flex-1 overflow-y-auto p-6 lg:p-8\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div></div></div><!-- Overlay for mobile sidebar --><div x-show=\"sidebarOpen\" @click=\"sidebarOpen = false\" class=\"fixed inset-0 z-30 bg-black/50 lg:hidden\" x-cloak></div><!-- Main Content --><main id=\"page-scroll\" data-boot-anim=\"main\" class=\"flex-1 overflow-y-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var22 = []any{"mx-auto " + mainContentMaxWidth(activeComponent)}
+		var templ_7745c5c3_Var22 = []any{"mx-auto flex min-h-full w-full " + pageFrameMaxWidth(activeComponent)}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var22...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<div id=\"main-content\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<div class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -405,7 +405,7 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\"><div id=\"main-content\" class=\"min-w-0 flex-1 p-6 lg:p-8\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -421,7 +421,29 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div></main><!-- Right rail: \"On this page\" section nav, built from [data-toc-heading]. --><aside id=\"toc-rail\" data-boot-anim=\"main\" class=\"hidden xl:block w-60 shrink-0 overflow-y-auto border-l border-outline dark:border-outline-dark\"><div class=\"sticky top-0 px-6 py-8\"><p class=\"mb-3 text-xs font-semibold uppercase tracking-wide text-on-surface-muted dark:text-on-surface-dark-muted\">On this page</p><nav id=\"toc-list\" aria-label=\"On this page\" class=\"flex flex-col border-l border-outline dark:border-outline-dark\"></nav></div></aside></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div><!-- Right rail: \"On this page\" section nav, built from [data-toc-heading]. --><div id=\"toc-rail\" data-boot-anim=\"main\" class=\"hidden w-60 shrink-0 xl:block\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var24 = []any{"fixed bottom-0 top-16 w-60 overflow-y-auto border-l border-outline px-6 py-8 dark:border-outline-dark " + tocRailRight(activeComponent)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var24...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<aside class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var25 string
+		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var24).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\"><p class=\"mb-3 text-xs font-semibold uppercase tracking-wide text-on-surface-muted dark:text-on-surface-dark-muted\">On this page</p><nav id=\"toc-list\" aria-label=\"On this page\" class=\"flex flex-col border-l border-outline dark:border-outline-dark\"></nav></aside></div></div></main></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -429,7 +451,7 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<!-- Browser storage notice. Shows until the visitor chooses allowed or denied\n\t\t\t     storage via the gt_storage preference cookie. Keep in lock-step with\n\t\t\t     landing.templ's cookieConsent(). --><div x-data=\"{ show: !window.goshtosoStorageConsent || window.goshtosoStorageConsent.shouldShow(), allow() { window.goshtosoStorageConsent.allow(); this.show = false }, deny() { window.goshtosoStorageConsent.deny(); this.show = false } }\" x-show=\"show\" x-cloak x-transition class=\"fixed bottom-4 left-4 right-4 sm:left-auto z-50 flex max-w-none sm:max-w-md flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark\" role=\"dialog\" aria-modal=\"false\" aria-labelledby=\"cookie-banner-title\"><div class=\"flex items-center gap-2 border-b border-outline px-4 py-3 dark:border-outline-dark\"><h3 id=\"cookie-banner-title\" class=\"font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Browser storage</h3></div><p class=\"px-4 text-sm text-on-surface dark:text-on-surface-dark\">Goshtoso can store preferences and demo state in your browser. Some examples use cookies and IndexedDB to persist local demo state. There is no analytics, advertising, or third-party tracking. You can use the site without storage, but preferences and some examples will reset or stop persisting. Details in our <a href=\"/privacy\" hx-get=\"/privacy\" hx-target=\"#main-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" @click=\"show = false\" class=\"text-primary dark:text-primary-dark underline underline-offset-2\">Privacy Policy</a>.</p><div class=\"flex flex-col-reverse gap-2 px-4 pb-4 sm:flex-row sm:justify-end\"><button @click=\"deny()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius border border-outline text-on-surface dark:border-outline-dark dark:text-on-surface-dark hover:border-primary dark:hover:border-primary-dark hover:text-primary dark:hover:text-primary-dark transition-colors\">Use without storage</button> <button @click=\"allow()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark hover:opacity-90 transition-opacity\">Allow browser storage</button></div></div><!-- Right-rail \"On this page\" TOC: built from #main-content [data-toc-heading].\n\t\t\t     Rebuilt on every main-content HTMX swap via window.buildTOC (see head script). --><script>\n\t\t\t\t(function () {\n\t\t\t\t\tvar spy = null;\n\t\t\t\t\tfunction clearActive(nav) {\n\t\t\t\t\t\tnav.querySelectorAll('[data-toc-link]').forEach(function (a) {\n\t\t\t\t\t\t\ta.classList.remove('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t\t\ta.classList.add('border-transparent');\n\t\t\t\t\t\t});\n\t\t\t\t\t}\n\t\t\t\t\tfunction setActive(nav, id) {\n\t\t\t\t\t\tvar a = nav.querySelector('[data-toc-link=\"' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '\"]');\n\t\t\t\t\t\tif (!a) return;\n\t\t\t\t\t\tclearActive(nav);\n\t\t\t\t\t\ta.classList.remove('border-transparent');\n\t\t\t\t\t\ta.classList.add('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t}\n\t\t\t\t\twindow.buildTOC = function () {\n\t\t\t\t\t\tvar rail = document.getElementById('toc-rail');\n\t\t\t\t\t\tvar nav = document.getElementById('toc-list');\n\t\t\t\t\t\tvar main = document.getElementById('main-content');\n\t\t\t\t\t\tif (!rail || !nav || !main) return;\n\t\t\t\t\t\tif (spy) { spy.disconnect(); spy = null; }\n\t\t\t\t\t\tvar heads = Array.prototype.slice.call(main.querySelectorAll('[data-toc-heading]'));\n\t\t\t\t\t\tnav.innerHTML = '';\n\t\t\t\t\t\t// One heading (just the page title) isn't worth a rail — hide it.\n\t\t\t\t\t\tif (heads.length < 2) { rail.style.display = 'none'; return; }\n\t\t\t\t\t\trail.style.display = '';\n\t\t\t\t\t\theads.forEach(function (h) {\n\t\t\t\t\t\t\tif (!h.id) return;\n\t\t\t\t\t\t\tvar a = document.createElement('a');\n\t\t\t\t\t\t\ta.href = '#' + h.id;\n\t\t\t\t\t\t\ta.textContent = (h.textContent || '').trim();\n\t\t\t\t\t\t\ta.setAttribute('data-toc-link', h.id);\n\t\t\t\t\t\t\ta.className = 'block border-l border-transparent py-1.5 pl-4 -ml-px text-sm text-on-surface-muted transition-colors hover:text-on-surface-strong dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-strong';\n\t\t\t\t\t\t\ta.addEventListener('click', function (ev) {\n\t\t\t\t\t\t\t\tev.preventDefault();\n\t\t\t\t\t\t\t\th.scrollIntoView({ behavior: 'smooth', block: 'start' });\n\t\t\t\t\t\t\t\thistory.replaceState(null, '', '#' + h.id);\n\t\t\t\t\t\t\t\tsetActive(nav, h.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t\tnav.appendChild(a);\n\t\t\t\t\t\t});\n\t\t\t\t\t\t// Scroll-spy: main is the scroll container, so it's the observer root.\n\t\t\t\t\t\tspy = new IntersectionObserver(function (entries) {\n\t\t\t\t\t\t\tentries.forEach(function (en) {\n\t\t\t\t\t\t\t\tif (en.isIntersecting) setActive(nav, en.target.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t}, { root: main, rootMargin: '0px 0px -75% 0px', threshold: 0 });\n\t\t\t\t\t\theads.forEach(function (h) { if (h.id) spy.observe(h); });\n\t\t\t\t\t\tsetActive(nav, heads[0].id);\n\t\t\t\t\t};\n\t\t\t\t\tif (document.readyState === 'loading') {\n\t\t\t\t\t\tdocument.addEventListener('DOMContentLoaded', window.buildTOC);\n\t\t\t\t\t} else {\n\t\t\t\t\t\twindow.buildTOC();\n\t\t\t\t\t}\n\t\t\t\t})();\n\t\t\t</script></body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<!-- Browser storage notice. Shows until the visitor chooses allowed or denied\n\t\t\t     storage via the gt_storage preference cookie. Keep in lock-step with\n\t\t\t     landing.templ's cookieConsent(). --><div x-data=\"{ show: !window.goshtosoStorageConsent || window.goshtosoStorageConsent.shouldShow(), allow() { window.goshtosoStorageConsent.allow(); this.show = false }, deny() { window.goshtosoStorageConsent.deny(); this.show = false } }\" x-show=\"show\" x-cloak x-transition class=\"fixed bottom-4 left-4 right-4 sm:left-auto z-50 flex max-w-none sm:max-w-md flex-col gap-4 rounded-radius border border-outline bg-surface text-on-surface shadow-lg dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark\" role=\"dialog\" aria-modal=\"false\" aria-labelledby=\"cookie-banner-title\"><div class=\"flex items-center gap-2 border-b border-outline px-4 py-3 dark:border-outline-dark\"><h3 id=\"cookie-banner-title\" class=\"font-semibold text-on-surface-strong dark:text-on-surface-dark-strong\">Browser storage</h3></div><p class=\"px-4 text-sm text-on-surface dark:text-on-surface-dark\">Goshtoso can store preferences and demo state in your browser. Some examples use cookies and IndexedDB to persist local demo state. There is no analytics, advertising, or third-party tracking. You can use the site without storage, but preferences and some examples will reset or stop persisting. Details in our <a href=\"/privacy\" hx-get=\"/privacy\" hx-target=\"#main-content\" hx-swap=\"innerHTML\" hx-push-url=\"true\" @click=\"show = false\" class=\"text-primary dark:text-primary-dark underline underline-offset-2\">Privacy Policy</a>.</p><div class=\"flex flex-col-reverse gap-2 px-4 pb-4 sm:flex-row sm:justify-end\"><button @click=\"deny()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius border border-outline text-on-surface dark:border-outline-dark dark:text-on-surface-dark hover:border-primary dark:hover:border-primary-dark hover:text-primary dark:hover:text-primary-dark transition-colors\">Use without storage</button> <button @click=\"allow()\" class=\"px-3 py-1.5 text-xs font-medium rounded-radius bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark hover:opacity-90 transition-opacity\">Allow browser storage</button></div></div><!-- Right-rail \"On this page\" TOC: built from #main-content [data-toc-heading].\n\t\t\t     Rebuilt on every main-content HTMX swap via window.buildTOC (see head script). --><script>\n\t\t\t\t(function () {\n\t\t\t\t\tvar spy = null;\n\t\t\t\t\tfunction clearActive(nav) {\n\t\t\t\t\t\tnav.querySelectorAll('[data-toc-link]').forEach(function (a) {\n\t\t\t\t\t\t\ta.classList.remove('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t\t\ta.classList.add('border-transparent');\n\t\t\t\t\t\t});\n\t\t\t\t\t}\n\t\t\t\t\tfunction setActive(nav, id) {\n\t\t\t\t\t\tvar a = nav.querySelector('[data-toc-link=\"' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '\"]');\n\t\t\t\t\t\tif (!a) return;\n\t\t\t\t\t\tclearActive(nav);\n\t\t\t\t\t\ta.classList.remove('border-transparent');\n\t\t\t\t\t\ta.classList.add('border-primary', 'dark:border-primary-dark', 'text-on-surface-strong', 'dark:text-on-surface-dark-strong', 'font-medium');\n\t\t\t\t\t}\n\t\t\t\t\twindow.buildTOC = function () {\n\t\t\t\t\t\tvar rail = document.getElementById('toc-rail');\n\t\t\t\t\t\tvar nav = document.getElementById('toc-list');\n\t\t\t\t\t\tvar pageScroll = document.getElementById('page-scroll');\n\t\t\t\t\t\tvar content = document.getElementById('main-content');\n\t\t\t\t\t\tif (!rail || !nav || !pageScroll || !content) return;\n\t\t\t\t\t\tif (spy) { spy.disconnect(); spy = null; }\n\t\t\t\t\t\tvar heads = Array.prototype.slice.call(content.querySelectorAll('[data-toc-heading]'));\n\t\t\t\t\t\tnav.innerHTML = '';\n\t\t\t\t\t\t// One heading (just the page title) isn't worth a rail — hide it.\n\t\t\t\t\t\tif (heads.length < 2) { rail.style.display = 'none'; return; }\n\t\t\t\t\t\trail.style.display = '';\n\t\t\t\t\t\theads.forEach(function (h) {\n\t\t\t\t\t\t\tif (!h.id) return;\n\t\t\t\t\t\t\tvar a = document.createElement('a');\n\t\t\t\t\t\t\ta.href = '#' + h.id;\n\t\t\t\t\t\t\ta.textContent = (h.textContent || '').trim();\n\t\t\t\t\t\t\ta.setAttribute('data-toc-link', h.id);\n\t\t\t\t\t\t\ta.className = 'block border-l border-transparent py-1.5 pl-4 -ml-px text-sm text-on-surface-muted transition-colors hover:text-on-surface-strong dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-strong';\n\t\t\t\t\t\t\ta.addEventListener('click', function (ev) {\n\t\t\t\t\t\t\t\tev.preventDefault();\n\t\t\t\t\t\t\t\th.scrollIntoView({ behavior: 'smooth', block: 'start' });\n\t\t\t\t\t\t\t\thistory.replaceState(null, '', '#' + h.id);\n\t\t\t\t\t\t\t\tsetActive(nav, h.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t\tnav.appendChild(a);\n\t\t\t\t\t\t});\n\t\t\t\t\t\t// Scroll-spy: main is the scroll container, so it's the observer root.\n\t\t\t\t\t\tspy = new IntersectionObserver(function (entries) {\n\t\t\t\t\t\t\tentries.forEach(function (en) {\n\t\t\t\t\t\t\t\tif (en.isIntersecting) setActive(nav, en.target.id);\n\t\t\t\t\t\t\t});\n\t\t\t\t\t\t}, { root: pageScroll, rootMargin: '0px 0px -75% 0px', threshold: 0 });\n\t\t\t\t\t\theads.forEach(function (h) { if (h.id) spy.observe(h); });\n\t\t\t\t\t\tvar hashId = decodeURIComponent((window.location.hash || '').replace(/^#/, ''));\n\t\t\t\t\t\tvar active = heads.find(function (h) { return h.id === hashId; }) || heads[0];\n\t\t\t\t\t\tsetActive(nav, active.id);\n\t\t\t\t\t};\n\t\t\t\t\tif (document.readyState === 'loading') {\n\t\t\t\t\t\tdocument.addEventListener('DOMContentLoaded', window.buildTOC);\n\t\t\t\t\t} else {\n\t\t\t\t\t\twindow.buildTOC();\n\t\t\t\t\t}\n\t\t\t\t})();\n\t\t\t</script></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -453,14 +475,23 @@ func navHxAttrs(href, label string) templ.Attributes {
 	return attrs
 }
 
-// mainContentMaxWidth picks the page-content container width per route. The
-// theme page needs the extra width to host the side-by-side controls + theme
-// showcase layout; everything else stays at the narrower docs default.
-func mainContentMaxWidth(activeComponent string) string {
+// pageFrameMaxWidth picks a docs frame width that includes content, its padding,
+// and the desktop TOC rail. The theme page needs the extra width to host the
+// side-by-side controls + theme showcase layout.
+func pageFrameMaxWidth(activeComponent string) string {
 	if activeComponent == "theme" {
-		return "max-w-7xl"
+		return "max-w-[99rem]"
 	}
-	return "max-w-5xl"
+	return "max-w-[83rem]"
+}
+
+// tocRailRight aligns the fixed desktop TOC rail with the reserved rail column
+// inside the centered docs frame. The 18rem term is the desktop sidebar width.
+func tocRailRight(activeComponent string) string {
+	if activeComponent == "theme" {
+		return "xl:right-[max(0rem,calc((100vw-18rem-99rem)/2))]"
+	}
+	return "xl:right-[max(0rem,calc((100vw-18rem-83rem)/2))]"
 }
 
 // getSidebarTopItems returns the top-level icon navigation items above the component sections
@@ -490,12 +521,12 @@ func sidebarSearchSlot() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var24 == nil {
-			templ_7745c5c3_Var24 = templ.NopComponent
+		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var26 == nil {
+			templ_7745c5c3_Var26 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div class=\"shrink-0 px-4 py-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div class=\"shrink-0 px-4 py-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -503,7 +534,7 @@ func sidebarSearchSlot() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -538,12 +569,12 @@ func sidebarHomeIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var25 == nil {
-			templ_7745c5c3_Var25 = templ.NopComponent
+		templ_7745c5c3_Var27 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var27 == nil {
+			templ_7745c5c3_Var27 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -567,12 +598,12 @@ func sidebarExamplesIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var26 == nil {
-			templ_7745c5c3_Var26 = templ.NopComponent
+		templ_7745c5c3_Var28 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var28 == nil {
+			templ_7745c5c3_Var28 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M3.75 6A2.25 2.25 0 016 3.75h3.75A2.25 2.25 0 0112 6v3.75A2.25 2.25 0 019.75 12H6a2.25 2.25 0 01-2.25-2.25V6ZM14.25 6A2.25 2.25 0 0116.5 3.75H18A2.25 2.25 0 0120.25 6v1.5A2.25 2.25 0 0118 9.75h-1.5a2.25 2.25 0 01-2.25-2.25V6ZM14.25 14.25A2.25 2.25 0 0116.5 12H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-1.5A2.25 2.25 0 0114.25 18v-3.75ZM3.75 16.5A2.25 2.25 0 016 14.25h3.75A2.25 2.25 0 0112 16.5V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-1.5Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M3.75 6A2.25 2.25 0 016 3.75h3.75A2.25 2.25 0 0112 6v3.75A2.25 2.25 0 019.75 12H6a2.25 2.25 0 01-2.25-2.25V6ZM14.25 6A2.25 2.25 0 0116.5 3.75H18A2.25 2.25 0 0120.25 6v1.5A2.25 2.25 0 0118 9.75h-1.5a2.25 2.25 0 01-2.25-2.25V6ZM14.25 14.25A2.25 2.25 0 0116.5 12H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-1.5A2.25 2.25 0 0114.25 18v-3.75ZM3.75 16.5A2.25 2.25 0 016 14.25h3.75A2.25 2.25 0 0112 16.5V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-1.5Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -596,12 +627,12 @@ func sidebarThemeIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var27 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var27 == nil {
-			templ_7745c5c3_Var27 = templ.NopComponent
+		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var29 == nil {
+			templ_7745c5c3_Var29 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M4.098 19.902a3.75 3.75 0 005.304 0l6.401-6.402M6.75 21A3.75 3.75 0 013 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 003.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.879 2.88M6.75 17.25h.008v.008H6.75v-.008z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M4.098 19.902a3.75 3.75 0 005.304 0l6.401-6.402M6.75 21A3.75 3.75 0 013 17.25V4.125C3 3.504 3.504 3 4.125 3h5.25c.621 0 1.125.504 1.125 1.125v4.072M6.75 21a3.75 3.75 0 003.75-3.75V8.197M6.75 21h13.125c.621 0 1.125-.504 1.125-1.125v-5.25c0-.621-.504-1.125-1.125-1.125h-4.072M10.5 8.197l2.88-2.88c.438-.439 1.15-.439 1.59 0l3.712 3.713c.44.44.44 1.152 0 1.59l-2.879 2.88M6.75 17.25h.008v.008H6.75v-.008z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -625,12 +656,12 @@ func sidebarAttributionsIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var28 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var28 == nil {
-			templ_7745c5c3_Var28 = templ.NopComponent
+		templ_7745c5c3_Var30 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var30 == nil {
+			templ_7745c5c3_Var30 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -654,12 +685,12 @@ func sidebarLicenseIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var29 == nil {
-			templ_7745c5c3_Var29 = templ.NopComponent
+		templ_7745c5c3_Var31 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var31 == nil {
+			templ_7745c5c3_Var31 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<svg xmlns=\"http://www.w3.org/2000/svg\" fill=\"none\" viewBox=\"0 0 24 24\" stroke-width=\"1.5\" stroke=\"currentColor\" class=\"w-full h-full\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 0 0 2.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 0 0-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75 2.25 2.25 0 0 0-.1-.664m-5.8 0A2.251 2.251 0 0 1 13.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -935,33 +966,33 @@ func componentNavFooter(activeComponent string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var30 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var30 == nil {
-			templ_7745c5c3_Var30 = templ.NopComponent
+		templ_7745c5c3_Var32 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var32 == nil {
+			templ_7745c5c3_Var32 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		prev, next := getComponentNav(activeComponent)
 		if prev != nil || next != nil {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<div class=\"mt-12 flex items-center justify-between border-t border-outline dark:border-outline-dark pt-6 pb-4\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<div class=\"mt-12 flex items-center justify-between border-t border-outline dark:border-outline-dark pt-6 pb-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if prev != nil {
 				prevAttrs := navHxAttrs(prev.Href, "")
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<a href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var31 templ.SafeURL
-				templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(prev.Href))
+				var templ_7745c5c3_Var33 templ.SafeURL
+				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(prev.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 699, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 712, Col: 36}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -969,45 +1000,45 @@ func componentNavFooter(activeComponent string) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, " class=\"group flex items-center gap-2 text-sm text-on-surface-muted hover:text-primary dark:text-on-surface-dark-muted dark:hover:text-primary-dark transition-colors\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"size-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M15 19l-7-7 7-7\"></path></svg> <span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, " class=\"group flex items-center gap-2 text-sm text-on-surface-muted hover:text-primary dark:text-on-surface-dark-muted dark:hover:text-primary-dark transition-colors\"><svg xmlns=\"http://www.w3.org/2000/svg\" class=\"size-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M15 19l-7-7 7-7\"></path></svg> <span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var32 string
-				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(prev.Label)
+				var templ_7745c5c3_Var34 string
+				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(prev.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 706, Col: 23}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 719, Col: 23}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</span></a> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</span></a> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if next != nil {
 				nextAttrs := navHxAttrs(next.Href, "")
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<a href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var33 templ.SafeURL
-				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(next.Href))
+				var templ_7745c5c3_Var35 templ.SafeURL
+				templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(next.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 714, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 727, Col: 36}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1015,30 +1046,30 @@ func componentNavFooter(activeComponent string) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, " class=\"group flex items-center gap-2 text-sm text-on-surface-muted hover:text-primary dark:text-on-surface-dark-muted dark:hover:text-primary-dark transition-colors\"><span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, " class=\"group flex items-center gap-2 text-sm text-on-surface-muted hover:text-primary dark:text-on-surface-dark-muted dark:hover:text-primary-dark transition-colors\"><span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var34 string
-				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(next.Label)
+				var templ_7745c5c3_Var36 string
+				templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(next.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 718, Col: 23}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 731, Col: 23}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</span> <svg xmlns=\"http://www.w3.org/2000/svg\" class=\"size-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M9 5l7 7-7 7\"></path></svg></a>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</span> <svg xmlns=\"http://www.w3.org/2000/svg\" class=\"size-4\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M9 5l7 7-7 7\"></path></svg></a>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1063,9 +1094,9 @@ func storageConsentScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var35 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var35 == nil {
-			templ_7745c5c3_Var35 = templ.NopComponent
+		templ_7745c5c3_Var37 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var37 == nil {
+			templ_7745c5c3_Var37 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = templ.Raw(`<script>(function(){if(window.goshtosoStorageConsent)return;var pref='gt_storage';var maxAge=15552000;var demoCookies=['gt_todo','gt_profile','gt_chat'];var localKeys=['theme','darkMode','themeOverrides','themeTitleFont','themeBodyFont','themeRadius','themeCssMode','themeCssFilter','cookieConsent'];function cookieValue(name){var parts=document.cookie?document.cookie.split('; '):[];for(var i=0;i<parts.length;i++){var p=parts[i];var eq=p.indexOf('=');var key=eq>=0?p.slice(0,eq):p;if(key===name)return eq>=0?decodeURIComponent(p.slice(eq+1)):'';}return '';}function setCookie(name,value,age){document.cookie=name+'='+encodeURIComponent(value)+'; Path=/; Max-Age='+age+'; SameSite=Lax';}function expireCookie(name){setCookie(name,'',0);}function clearLocalStorage(){try{localKeys.forEach(function(key){localStorage.removeItem(key);});}catch(e){}}function clearIndexedDB(){try{if(window.indexedDB&&indexedDB.deleteDatabase)indexedDB.deleteDatabase('gt_profile');}catch(e){}}window.goshtosoStorageConsent={shouldShow:function(){var v=cookieValue(pref);return v!=='allowed'&&v!=='denied';},allowed:function(){return cookieValue(pref)!=='denied';},allow:function(){setCookie(pref,'allowed',maxAge);try{localStorage.setItem('cookieConsent','v2');}catch(e){}},deny:function(){setCookie(pref,'denied',maxAge);demoCookies.forEach(expireCookie);clearLocalStorage();clearIndexedDB();}};if(cookieValue(pref)==='denied'){clearLocalStorage();clearIndexedDB();}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
@@ -1095,15 +1126,15 @@ func siteFooter() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var36 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var36 == nil {
-			templ_7745c5c3_Var36 = templ.NopComponent
+		templ_7745c5c3_Var38 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var38 == nil {
+			templ_7745c5c3_Var38 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		privacyAttrs := navHxAttrs("/privacy", "")
 		attrAttrs := navHxAttrs("/attributions", "")
 		licenseAttrs := navHxAttrs("/license", "")
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<footer class=\"mt-16 border-t border-outline dark:border-outline-dark pt-8 pb-10 text-center\"><p class=\"font-title font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">Goshtoso <span class=\"font-normal text-on-surface-muted dark:text-on-surface-dark-muted\">2026</span></p><nav class=\"mt-3 flex items-center justify-center gap-2 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\"><a href=\"/privacy\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<footer class=\"mt-16 border-t border-outline dark:border-outline-dark pt-8 pb-10 text-center\"><p class=\"font-title font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">Goshtoso <span class=\"font-normal text-on-surface-muted dark:text-on-surface-dark-muted\">2026</span></p><nav class=\"mt-3 flex items-center justify-center gap-2 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\"><a href=\"/privacy\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1111,7 +1142,7 @@ func siteFooter() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">Privacy</a> <span class=\"text-primary dark:text-primary-dark\">•</span> <a href=\"/attributions\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">Privacy</a> <span class=\"text-primary dark:text-primary-dark\">•</span> <a href=\"/attributions\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1119,7 +1150,7 @@ func siteFooter() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">Attributions</a> <span class=\"text-primary dark:text-primary-dark\">•</span> <a href=\"/license\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">Attributions</a> <span class=\"text-primary dark:text-primary-dark\">•</span> <a href=\"/license\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1127,7 +1158,7 @@ func siteFooter() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">License</a></nav><div class=\"mt-4 flex items-center justify-center gap-4\"><a href=\"https://github.com/araihu/goshtoso\" target=\"_blank\" rel=\"noopener\" aria-label=\"GitHub\" class=\"text-on-surface-muted hover:text-on-surface-strong dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-strong transition-colors\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"currentColor\" class=\"size-5\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.523 2 12 2Z\"></path></svg></a></div></footer>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, " class=\"hover:text-primary dark:hover:text-primary-dark transition-colors\">License</a></nav><div class=\"mt-4 flex items-center justify-center gap-4\"><a href=\"https://github.com/araihu/goshtoso\" target=\"_blank\" rel=\"noopener\" aria-label=\"GitHub\" class=\"text-on-surface-muted hover:text-on-surface-strong dark:text-on-surface-dark-muted dark:hover:text-on-surface-dark-strong transition-colors\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" fill=\"currentColor\" class=\"size-5\" aria-hidden=\"true\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.523 2 12 2Z\"></path></svg></a></div></footer>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1172,12 +1203,12 @@ func themeSelectIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var37 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var37 == nil {
-			templ_7745c5c3_Var37 = templ.NopComponent
+		templ_7745c5c3_Var39 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var39 == nil {
+			templ_7745c5c3_Var39 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"size-4 shrink-0\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"size-4 shrink-0\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/tests/e2e/pagination_test.go
+++ b/site/tests/e2e/pagination_test.go
@@ -94,3 +94,60 @@ func TestPagination_DocumentedHTMXVariantExposesHTMXAttributes(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "#items-tbody", hxTarget)
 }
+
+func TestPagination_DeepLinkKeepsTOCRailAttachedToContent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping E2E test in short mode")
+	}
+
+	cleanupServer := setupServer(t)
+	defer cleanupServer()
+
+	_, browser, cleanupPW := setupPlaywright(t)
+	defer cleanupPW()
+
+	page := newPage(t, browser, playwright.BrowserNewPageOptions{
+		Viewport: &playwright.Size{Width: 2048, Height: 1280},
+	})
+
+	_, err := page.Goto(baseURL+"/components/pagination#api-reference", playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, page.Locator("#api-reference").WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+	require.NoError(t, page.Locator(`#toc-list [data-toc-link="api-reference"]`).WaitFor(playwright.LocatorWaitForOptions{
+		State: playwright.WaitForSelectorStateVisible,
+	}))
+
+	gap, err := page.Evaluate(`() => {
+		const content = document.getElementById('main-content');
+		const rail = document.getElementById('toc-rail');
+		if (!content || !rail) return Number.POSITIVE_INFINITY;
+		const railStyle = getComputedStyle(rail);
+		if (railStyle.display === 'none') return Number.POSITIVE_INFINITY;
+		return rail.getBoundingClientRect().left - content.getBoundingClientRect().right;
+	}`)
+	require.NoError(t, err)
+	assert.LessOrEqual(t, jsFloat(gap), 1.0, "desktop TOC rail should sit flush with the content frame")
+
+	apiTop, err := page.Locator("#api-reference").Evaluate("el => el.getBoundingClientRect().top", nil)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, jsFloat(apiTop), 64.0, "deep-linked heading should clear the sticky header")
+	assert.Less(t, jsFloat(apiTop), 180.0, "deep-linked heading should land near the top of the scroll frame")
+}
+
+func jsFloat(v any) float64 {
+	switch n := v.(type) {
+	case float64:
+		return n
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	default:
+		return 0
+	}
+}


### PR DESCRIPTION
## Summary
- Keep the desktop docs TOC rail reserved beside the main content instead of drifting away from the content frame.
- Use the page scroll container for TOC scroll-spy and HTMX main-content scroll reset.
- Add a pagination deep-link E2E guard for the API Reference rail geometry and active TOC visibility.

## Test Plan
- `templ generate`
- `just css`
- `git diff --check`
- `go test ./... -count=1`
- `cd site && go test $(go list ./... | grep -v /tests/e2e) -count=1`
- `cd site && go test ./tests/e2e -run TestPagination -count=1 -timeout 5m`
- `GOWORK=/tmp/gs-manja-compat/go.work go test ./... -count=1` from `/Users/guilhermecastro/repos/araihu/manja`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scroll position restoration when navigating between pages
  * Improved Table of Contents rail alignment and positioning with main content
  * Enhanced deep-linking to page sections with proper scroll positioning

* **Tests**
  * Added verification for Table of Contents positioning during deep-link navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->