### PR TITLE
fix(site): shrink theme page payload

### DIFF
--- a/components/palette/palette.templ
+++ b/components/palette/palette.templ
@@ -2,92 +2,7 @@ package palette
 
 templ Palette(cfg Config) {
 	<div
-		x-data="{
-			hovered: '',
-			selectedHex: '#000000',
-			hexInput: '',
-			hexInvalid: false,
-			pick(value, el) {
-				this.syncHex(value, el)
-				this.$dispatch('select-close', value)
-			},
-			commitHex(value) {
-				const hex = this.normalizeHex(value)
-				if (!hex) {
-					this.hexInvalid = true
-					return
-				}
-				this.hexInvalid = false
-				this.selectedHex = hex
-				this.hexInput = hex
-				this.$dispatch('select-close', hex)
-			},
-			previewHex(value) {
-				this.hexInput = value
-				const hex = this.normalizeHex(value)
-				this.hexInvalid = this.hexInput !== '' && !hex
-				if (hex) {
-					this.selectedHex = hex
-					this.hexInput = hex
-					this.$dispatch('select-close', hex)
-				}
-			},
-			syncHex(value, el) {
-				this.hexInvalid = false
-				if (!value) {
-					this.selectedHex = '#000000'
-					this.hexInput = ''
-					return
-				}
-				if (value[0] === '#') {
-					const hex = this.normalizeHex(value)
-					if (hex) {
-						this.selectedHex = hex
-						this.hexInput = hex
-					}
-					return
-				}
-				if (value === 'white') {
-					this.selectedHex = '#ffffff'
-					this.hexInput = '#ffffff'
-					return
-				}
-				if (value === 'black') {
-					this.selectedHex = '#000000'
-					this.hexInput = '#000000'
-					return
-				}
-				if (el) {
-					const hex = this.colorToHex(getComputedStyle(el).backgroundColor)
-					this.selectedHex = hex
-					this.hexInput = hex
-				}
-			},
-			normalizeHex(value) {
-				const raw = (value || '').trim()
-				const short = raw.match(/^#([0-9a-fA-F]{3})$/)
-				if (short) {
-					return '#' + short[1].split('').map(ch => ch + ch).join('').toLowerCase()
-				}
-				const full = raw.match(/^#([0-9a-fA-F]{6})$/)
-				return full ? '#' + full[1].toLowerCase() : ''
-			},
-			colorToHex(color) {
-				if (!this._ctx) {
-					const canvas = document.createElement('canvas')
-					canvas.width = 1
-					canvas.height = 1
-					this._ctx = canvas.getContext('2d', { willReadFrequently: true })
-				}
-				const ctx = this._ctx
-				ctx.clearRect(0, 0, 1, 1)
-				ctx.fillStyle = '#000000'
-				ctx.fillStyle = color
-				ctx.fillRect(0, 0, 1, 1)
-				const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data
-				return '#' + [r, g, b].map(n => n.toString(16).padStart(2, '0')).join('')
-			},
-		}"
+		x-data={ cfg.alpineData() }
 		data-palette
 		id={ cfg.ID }
 		class={ cfg.ContainerClasses() }
@@ -109,7 +24,16 @@ templ Palette(cfg Config) {
 		}
 		if cfg.LazyWhen != "" {
 			<template x-if={ cfg.LazyWhen }>
-				@swatchGrid(cfg)
+				<div
+					class="grid w-full gap-1 max-h-44 overflow-y-auto pr-1"
+					style="grid-template-columns: repeat(11, minmax(0, 1fr));"
+					x-html="swatchGridHTML()"
+					@click="handleSwatchEvent($event, 'pick')"
+					@mouseover="handleSwatchEvent($event, 'hover')"
+					@focusin="handleSwatchEvent($event, 'hover')"
+					@mouseleave="hovered = ''"
+					@focusout="if (!$event.currentTarget.contains($event.relatedTarget)) hovered = ''"
+				></div>
 			</template>
 		} else {
 			@swatchGrid(cfg)

--- a/components/palette/palette_coverage_test.go
+++ b/components/palette/palette_coverage_test.go
@@ -16,7 +16,7 @@ func TestPalette_CustomHuesShades(t *testing.T) {
 		Shades: []string{"100", "500"},
 	})
 	// 2 hues × 2 shades = 4 grid swatches, plus white/black neutrals.
-	assert.Equal(t, 4, strings.Count(html, "background-color: var(--color-"))
+	assert.Equal(t, 4, strings.Count(html, `style="background-color: var(--color-`))
 	assert.Contains(t, html, `data-cls="red-100"`)
 	assert.Contains(t, html, `data-cls="red-500"`)
 	assert.Contains(t, html, `data-cls="blue-100"`)
@@ -50,13 +50,15 @@ func TestPalette_RootClassRendered(t *testing.T) {
 	assert.Contains(t, html, `class="p-2 space-y-2 w-64 shadow"`)
 }
 
-// TestPalette_LazyWhen wraps the swatch grid in <template x-if> so the grid
-// mounts lazily; covers the LazyWhen branch in Palette.
+// TestPalette_LazyWhen keeps the full swatch grid out of the initial HTML so
+// pages with many palettes do not ship thousands of inert template buttons.
 func TestPalette_LazyWhen(t *testing.T) {
 	html := render(t, Config{ID: "p", LazyWhen: "open"})
 	assert.Contains(t, html, `<template x-if="open">`)
-	// Grid still rendered inside the template.
-	assert.Contains(t, html, `data-cls="blue-700"`)
+	assert.Contains(t, html, `x-html="swatchGridHTML()"`)
+	assert.Contains(t, html, `@click="handleSwatchEvent($event, 'pick')"`)
+	assert.NotContains(t, html, `data-cls="blue-700"`)
+	assert.NotContains(t, html, `background-color: var(--color-blue-700)`)
 
 	// Without LazyWhen, no x-if template wraps the grid.
 	plain := render(t, Config{ID: "p"})

--- a/components/palette/palette_templ.go
+++ b/components/palette/palette_templ.go
@@ -34,98 +34,103 @@ func Palette(cfg Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div x-data=\"{\n\t\t\thovered: '',\n\t\t\tselectedHex: '#000000',\n\t\t\thexInput: '',\n\t\t\thexInvalid: false,\n\t\t\tpick(value, el) {\n\t\t\t\tthis.syncHex(value, el)\n\t\t\t\tthis.$dispatch('select-close', value)\n\t\t\t},\n\t\t\tcommitHex(value) {\n\t\t\t\tconst hex = this.normalizeHex(value)\n\t\t\t\tif (!hex) {\n\t\t\t\t\tthis.hexInvalid = true\n\t\t\t\t\treturn\n\t\t\t\t}\n\t\t\t\tthis.hexInvalid = false\n\t\t\t\tthis.selectedHex = hex\n\t\t\t\tthis.hexInput = hex\n\t\t\t\tthis.$dispatch('select-close', hex)\n\t\t\t},\n\t\t\tpreviewHex(value) {\n\t\t\t\tthis.hexInput = value\n\t\t\t\tconst hex = this.normalizeHex(value)\n\t\t\t\tthis.hexInvalid = this.hexInput !== '' && !hex\n\t\t\t\tif (hex) {\n\t\t\t\t\tthis.selectedHex = hex\n\t\t\t\t\tthis.hexInput = hex\n\t\t\t\t\tthis.$dispatch('select-close', hex)\n\t\t\t\t}\n\t\t\t},\n\t\t\tsyncHex(value, el) {\n\t\t\t\tthis.hexInvalid = false\n\t\t\t\tif (!value) {\n\t\t\t\t\tthis.selectedHex = '#000000'\n\t\t\t\t\tthis.hexInput = ''\n\t\t\t\t\treturn\n\t\t\t\t}\n\t\t\t\tif (value[0] === '#') {\n\t\t\t\t\tconst hex = this.normalizeHex(value)\n\t\t\t\t\tif (hex) {\n\t\t\t\t\t\tthis.selectedHex = hex\n\t\t\t\t\t\tthis.hexInput = hex\n\t\t\t\t\t}\n\t\t\t\t\treturn\n\t\t\t\t}\n\t\t\t\tif (value === 'white') {\n\t\t\t\t\tthis.selectedHex = '#ffffff'\n\t\t\t\t\tthis.hexInput = '#ffffff'\n\t\t\t\t\treturn\n\t\t\t\t}\n\t\t\t\tif (value === 'black') {\n\t\t\t\t\tthis.selectedHex = '#000000'\n\t\t\t\t\tthis.hexInput = '#000000'\n\t\t\t\t\treturn\n\t\t\t\t}\n\t\t\t\tif (el) {\n\t\t\t\t\tconst hex = this.colorToHex(getComputedStyle(el).backgroundColor)\n\t\t\t\t\tthis.selectedHex = hex\n\t\t\t\t\tthis.hexInput = hex\n\t\t\t\t}\n\t\t\t},\n\t\t\tnormalizeHex(value) {\n\t\t\t\tconst raw = (value || '').trim()\n\t\t\t\tconst short = raw.match(/^#([0-9a-fA-F]{3})$/)\n\t\t\t\tif (short) {\n\t\t\t\t\treturn '#' + short[1].split('').map(ch => ch + ch).join('').toLowerCase()\n\t\t\t\t}\n\t\t\t\tconst full = raw.match(/^#([0-9a-fA-F]{6})$/)\n\t\t\t\treturn full ? '#' + full[1].toLowerCase() : ''\n\t\t\t},\n\t\t\tcolorToHex(color) {\n\t\t\t\tif (!this._ctx) {\n\t\t\t\t\tconst canvas = document.createElement('canvas')\n\t\t\t\t\tcanvas.width = 1\n\t\t\t\t\tcanvas.height = 1\n\t\t\t\t\tthis._ctx = canvas.getContext('2d', { willReadFrequently: true })\n\t\t\t\t}\n\t\t\t\tconst ctx = this._ctx\n\t\t\t\tctx.clearRect(0, 0, 1, 1)\n\t\t\t\tctx.fillStyle = '#000000'\n\t\t\t\tctx.fillStyle = color\n\t\t\t\tctx.fillRect(0, 0, 1, 1)\n\t\t\t\tconst [r, g, b] = ctx.getImageData(0, 0, 1, 1).data\n\t\t\t\treturn '#' + [r, g, b].map(n => n.toString(16).padStart(2, '0')).join('')\n\t\t\t},\n\t\t}\" data-palette id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div x-data=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID)
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.alpineData())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 92, Col: 13}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 5, Col: 27}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" data-palette id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var2).String())
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 1, Col: 0}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 7, Col: 13}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var5 string
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var2).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if cfg.modelAssignExpr() != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " x-on:select-close=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var5 string
-			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.modelAssignExpr())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 95, Col: 44}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, ">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if !cfg.HideReset {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"flex items-center gap-2\"><span class=\"text-[11px] font-mono text-on-surface-muted dark:text-on-surface-dark-muted truncate\" x-text=\"hovered || 'Pick a color'\"></span> ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if !cfg.HideReset {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<button type=\"button\" @click=\"pick('', null)\" class=\"ml-auto text-[10px] font-medium text-on-surface-muted dark:text-on-surface-dark-muted hover:text-primary dark:hover:text-primary-dark\">Reset</button>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		if cfg.LazyWhen != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<template x-if=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, " x-on:select-close=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.LazyWhen)
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.modelAssignExpr())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 111, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 10, Col: 44}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = swatchGrid(cfg).Render(ctx, templ_7745c5c3_Buffer)
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, ">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if !cfg.HideReset {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"flex items-center gap-2\"><span class=\"text-[11px] font-mono text-on-surface-muted dark:text-on-surface-dark-muted truncate\" x-text=\"hovered || 'Pick a color'\"></span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</template>")
+			if !cfg.HideReset {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<button type=\"button\" @click=\"pick('', null)\" class=\"ml-auto text-[10px] font-medium text-on-surface-muted dark:text-on-surface-dark-muted hover:text-primary dark:hover:text-primary-dark\">Reset</button>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if cfg.LazyWhen != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<template x-if=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var7 string
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.LazyWhen)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 26, Col: 32}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var7)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\"><div class=\"grid w-full gap-1 max-h-44 overflow-y-auto pr-1\" style=\"grid-template-columns: repeat(11, minmax(0, 1fr));\" x-html=\"swatchGridHTML()\" @click=\"handleSwatchEvent($event, 'pick')\" @mouseover=\"handleSwatchEvent($event, 'hover')\" @focusin=\"handleSwatchEvent($event, 'hover')\" @mouseleave=\"hovered = ''\" @focusout=\"if (!$event.currentTarget.contains($event.relatedTarget)) hovered = ''\"></div></template>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -165,9 +170,9 @@ func swatchGrid(cfg Config) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div class=\"grid w-full gap-1 max-h-44 overflow-y-auto pr-1\" style=\"grid-template-columns: repeat(11, minmax(0, 1fr));\">")
@@ -186,12 +191,12 @@ func swatchGrid(cfg Config) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var8 string
-				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(hue + "-" + shade)
+				var templ_7745c5c3_Var9 string
+				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(hue + "-" + shade)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 181, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 105, Col: 33}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -207,12 +212,12 @@ func swatchGrid(cfg Config) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var9 string
-				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(hue + "-" + shade)
+				var templ_7745c5c3_Var10 string
+				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.ResolveAttributeValue(hue + "-" + shade)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 189, Col: 30}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/palette/palette.templ`, Line: 113, Col: 30}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var10)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}

--- a/components/palette/palette_test.go
+++ b/components/palette/palette_test.go
@@ -20,7 +20,7 @@ func render(t *testing.T, cfg Config) string {
 func TestPalette_GridAndStaticDispatch(t *testing.T) {
 	html := render(t, Config{ID: "palette-surface"})
 	want := len(DefaultHues) * len(DefaultShades)
-	assert.Equal(t, want, strings.Count(html, "background-color: var(--color-"), "one grid button per hue×shade")
+	assert.Equal(t, want, strings.Count(html, `style="background-color: var(--color-`), "one grid button per hue×shade")
 	assert.Contains(t, html, `data-cls="blue-700"`)
 	assert.Contains(t, html, `style="background-color: var(--color-blue-700)"`)
 	assert.Contains(t, html, `@click="pick($el.dataset.cls, $el)"`)

--- a/components/palette/types.go
+++ b/components/palette/types.go
@@ -10,7 +10,12 @@
 // assigns it from $event.detail.
 package palette
 
-import "github.com/a-h/templ"
+import (
+	"strconv"
+	"strings"
+
+	"github.com/a-h/templ"
+)
 
 // DefaultHues lists Tailwind v4's named hue families in display order.
 var DefaultHues = []string{
@@ -47,9 +52,9 @@ type Config struct {
 	// RootClass appends classes to the wrapper.
 	RootClass string
 	// LazyWhen is an Alpine expression; when non-empty, the swatch grid is
-	// wrapped in <template x-if=...> so it mounts only when the expression is
-	// truthy (e.g. inside a Select dropdown, pass the dropdown's open
-	// expression). Keeps the initial DOM light.
+	// generated inside <template x-if=...> only when the expression is truthy
+	// (e.g. inside a Select dropdown, pass the dropdown's open expression).
+	// This keeps both the initial DOM and the initial HTML payload light.
 	LazyWhen string
 }
 
@@ -92,4 +97,153 @@ func (c Config) modelAssignExpr() string {
 		return ""
 	}
 	return c.Alpine.Model + " = $event.detail"
+}
+
+func (c Config) alpineData() string {
+	var sb strings.Builder
+	sb.WriteString(`{
+			hovered: '',
+			selectedHex: '#000000',
+			hexInput: '',
+			hexInvalid: false,
+			swatchHues: `)
+	sb.WriteString(jsStringArray(c.hues()))
+	sb.WriteString(`,
+			swatchShades: `)
+	sb.WriteString(jsStringArray(c.shades()))
+	sb.WriteString(`,
+			hideNeutral: `)
+	if c.HideNeutral {
+		sb.WriteString("true")
+	} else {
+		sb.WriteString("false")
+	}
+	sb.WriteString(`,
+			pick(value, el) {
+				this.syncHex(value, el)
+				this.$dispatch('select-close', value)
+			},
+			commitHex(value) {
+				const hex = this.normalizeHex(value)
+				if (!hex) {
+					this.hexInvalid = true
+					return
+				}
+				this.hexInvalid = false
+				this.selectedHex = hex
+				this.hexInput = hex
+				this.$dispatch('select-close', hex)
+			},
+			previewHex(value) {
+				this.hexInput = value
+				const hex = this.normalizeHex(value)
+				this.hexInvalid = this.hexInput !== '' && !hex
+				if (hex) {
+					this.selectedHex = hex
+					this.hexInput = hex
+					this.$dispatch('select-close', hex)
+				}
+			},
+			syncHex(value, el) {
+				this.hexInvalid = false
+				if (!value) {
+					this.selectedHex = '#000000'
+					this.hexInput = ''
+					return
+				}
+				if (value[0] === '#') {
+					const hex = this.normalizeHex(value)
+					if (hex) {
+						this.selectedHex = hex
+						this.hexInput = hex
+					}
+					return
+				}
+				if (value === 'white') {
+					this.selectedHex = '#ffffff'
+					this.hexInput = '#ffffff'
+					return
+				}
+				if (value === 'black') {
+					this.selectedHex = '#000000'
+					this.hexInput = '#000000'
+					return
+				}
+				if (el) {
+					const hex = this.colorToHex(getComputedStyle(el).backgroundColor)
+					this.selectedHex = hex
+					this.hexInput = hex
+				}
+			},
+			normalizeHex(value) {
+				const raw = (value || '').trim()
+				const short = raw.match(/^#([0-9a-fA-F]{3})$/)
+				if (short) {
+					return '#' + short[1].split('').map(ch => ch + ch).join('').toLowerCase()
+				}
+				const full = raw.match(/^#([0-9a-fA-F]{6})$/)
+				return full ? '#' + full[1].toLowerCase() : ''
+			},
+			colorToHex(color) {
+				if (!this._ctx) {
+					const canvas = document.createElement('canvas')
+					canvas.width = 1
+					canvas.height = 1
+					this._ctx = canvas.getContext('2d', { willReadFrequently: true })
+				}
+				const ctx = this._ctx
+				ctx.clearRect(0, 0, 1, 1)
+				ctx.fillStyle = '#000000'
+				ctx.fillStyle = color
+				ctx.fillRect(0, 0, 1, 1)
+				const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data
+				return '#' + [r, g, b].map(n => n.toString(16).padStart(2, '0')).join('')
+			},
+			escapeAttr(value) {
+				return String(value)
+					.replace(/&/g, '&amp;')
+					.replace(/"/g, '&quot;')
+					.replace(/</g, '&lt;')
+					.replace(/>/g, '&gt;')
+			},
+			swatchButton(cls, classes, style) {
+				const safeCls = this.escapeAttr(cls)
+				const styleAttr = style ? ' style="' + this.escapeAttr(style) + '"' : ''
+				return '<button type="button" data-cls="' + safeCls + '" class="' + classes + '"' + styleAttr + ' title="' + safeCls + '"></button>'
+			},
+			swatchGridHTML() {
+				const standard = 'h-5 w-full rounded-sm border border-outline/30 dark:border-outline-dark/30 transition-transform hover:scale-125 hover:ring-2 hover:ring-primary focus:scale-125 dark:hover:ring-primary-dark'
+				const neutral = 'h-5 w-full rounded-sm border border-outline/60 transition-transform hover:scale-125 hover:ring-2 hover:ring-primary focus:scale-125 dark:border-outline-dark/60 dark:hover:ring-primary-dark'
+				let html = ''
+				if (!this.hideNeutral) {
+					html += this.swatchButton('white', neutral + ' bg-white', '')
+					html += this.swatchButton('black', neutral + ' bg-black', '')
+				}
+				this.swatchHues.forEach(hue => {
+					this.swatchShades.forEach(shade => {
+						const cls = hue + '-' + shade
+						html += this.swatchButton(cls, standard, 'background-color: var(--color-' + cls + ')')
+					})
+				})
+				return html
+			},
+			handleSwatchEvent(event, action) {
+				const button = event.target.closest('button[data-cls]')
+				if (!button || !event.currentTarget.contains(button)) return
+				if (action === 'pick') {
+					this.pick(button.dataset.cls, button)
+					return
+				}
+				this.hovered = button.dataset.cls
+			},
+		}`)
+	return sb.String()
+}
+
+func jsStringArray(values []string) string {
+	quoted := make([]string, len(values))
+	for i, value := range values {
+		quoted[i] = strconv.Quote(value)
+	}
+	return "[" + strings.Join(quoted, ",") + "]"
 }

--- a/site/internal/pages/demo/components/theme.templ
+++ b/site/internal/pages/demo/components/theme.templ
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/araihu/goshtoso/components/codeblock"
 	palettecomp "github.com/araihu/goshtoso/components/palette"
 	selectfield "github.com/araihu/goshtoso/components/select"
 	"github.com/araihu/goshtoso/site/internal/pages/demo"
@@ -834,6 +833,15 @@ func themePageScript() string {
 	}
 	sb.WriteString("],\n")
 
+	sb.WriteString("    themeLabels: {")
+	for i, info := range infos {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(fmt.Sprintf("'%s':'%s'", info.Key, info.Label))
+	}
+	sb.WriteString("},\n")
+
 	// themeClassMap: nested object themeKey -> token -> tailwind class.
 	// Used by the palette UI to show the "default" class for the active
 	// theme when the user has not overridden a token.
@@ -1026,6 +1034,11 @@ func themePageScript() string {
       const keys = (filterKey === 'all') ? order : [filterKey];
       const inner = keys.map(k => '    ' + (this.blocks[k] || '').split('\n').join('\n    ')).join('\n\n');
       return '@layer base {\n' + inner + '\n}\n';
+    },
+    cssExportLabel() {
+      const filterKey = this.cssFilter === 'current' ? (this.theme || 'goshtoso') : this.cssFilter;
+      const label = filterKey === 'all' ? 'All themes' : (this.themeLabels[filterKey] || filterKey);
+      return label + (this.cssMode === 'single' ? ' — single' : ' — @layer base');
     },
     copyCSS() {
       navigator.clipboard.writeText(this.cssCode()).then(() => {
@@ -1735,7 +1748,6 @@ templ themeContrastSection() {
 }
 
 templ themeCSSSection() {
-	{{ blocks := getThemeCSSBlocks() }}
 	<div>
 		<h2 class="text-2xl font-bold font-title text-on-surface-strong dark:text-on-surface-dark-strong mb-2">Get CSS Code</h2>
 		<p class="text-sm text-on-surface dark:text-on-surface-dark mb-4">
@@ -1764,48 +1776,26 @@ templ themeCSSSection() {
 				>Multiple Themes</button>
 			</div>
 		</div>
-		<div class="space-y-3">
-			<!-- Single mode, per-theme blocks (and "all" concatenated). -->
-			for _, k := range themeCSSOrder {
-				<div x-show={ fmt.Sprintf("cssMode === 'single' && ((cssFilter === 'current' && (theme || 'goshtoso') === '%s') || cssFilter === '%s')", k, k) }>
-					@codeblock.CodeBlock(codeblock.Config{
-						Language:  "css",
-						Label:     themeLabel(k) + " — single",
-						Code:      blocks[k],
-						MaxHeight: "24rem",
-						ID:        "theme-css-single-" + k,
-					})
-				</div>
-			}
-			<div x-show="cssMode === 'single' && cssFilter === 'all'">
-				@codeblock.CodeBlock(codeblock.Config{
-					Language:  "css",
-					Label:     "All themes — single",
-					Code:      concatThemes(),
-					MaxHeight: "24rem",
-					ID:        "theme-css-single-all",
-				})
+		<div class="rounded-radius border border-outline dark:border-outline-dark overflow-hidden">
+			<div class="flex items-center justify-between gap-3 px-4 py-2 bg-surface-alt dark:bg-surface-dark-alt border-b border-outline dark:border-outline-dark">
+				<span class="truncate text-xs font-medium text-on-surface dark:text-on-surface-dark" x-text="cssExportLabel()">Theme CSS</span>
+				<button
+					type="button"
+					@click="copyCSS()"
+					aria-label="Copy theme CSS code"
+					class="flex items-center gap-1 text-xs text-on-surface-muted hover:text-primary transition-colors dark:text-on-surface-dark-muted dark:hover:text-primary-dark"
+				>
+					<svg x-show="!copied" xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+					</svg>
+					<svg x-show="copied" x-cloak xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+					</svg>
+					<span x-text="copied ? 'Copied!' : 'Copy'">Copy</span>
+				</button>
 			</div>
-			<!-- Multi mode, per-theme wrapped in @layer base. -->
-			for _, k := range themeCSSOrder {
-				<div x-show={ fmt.Sprintf("cssMode === 'multiple' && ((cssFilter === 'current' && (theme || 'goshtoso') === '%s') || cssFilter === '%s')", k, k) }>
-					@codeblock.CodeBlock(codeblock.Config{
-						Language:  "css",
-						Label:     themeLabel(k) + " — @layer base",
-						Code:      wrapSingleTheme(k),
-						MaxHeight: "24rem",
-						ID:        "theme-css-multi-" + k,
-					})
-				</div>
-			}
-			<div x-show="cssMode === 'multiple' && cssFilter === 'all'">
-				@codeblock.CodeBlock(codeblock.Config{
-					Language:  "css",
-					Label:     "All themes — @layer base",
-					Code:      allThemesWrappedCSS(),
-					MaxHeight: "24rem",
-					ID:        "theme-css-multi-all",
-				})
+			<div id="theme-css-output" class="codeblock overflow-x-auto" style="max-height: 24rem; overflow-y: auto;">
+				<pre class="ch-chroma"><code x-text="cssCode()"></code></pre>
 			</div>
 		</div>
 	</div>

--- a/site/internal/pages/demo/components/theme_templ.go
+++ b/site/internal/pages/demo/components/theme_templ.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/araihu/goshtoso/components/codeblock"
 	palettecomp "github.com/araihu/goshtoso/components/palette"
 	selectfield "github.com/araihu/goshtoso/components/select"
 	"github.com/araihu/goshtoso/site/internal/pages/demo"
@@ -842,6 +841,15 @@ func themePageScript() string {
 	}
 	sb.WriteString("],\n")
 
+	sb.WriteString("    themeLabels: {")
+	for i, info := range infos {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(fmt.Sprintf("'%s':'%s'", info.Key, info.Label))
+	}
+	sb.WriteString("},\n")
+
 	// themeClassMap: nested object themeKey -> token -> tailwind class.
 	// Used by the palette UI to show the "default" class for the active
 	// theme when the user has not overridden a token.
@@ -1034,6 +1042,11 @@ func themePageScript() string {
       const keys = (filterKey === 'all') ? order : [filterKey];
       const inner = keys.map(k => '    ' + (this.blocks[k] || '').split('\n').join('\n    ')).join('\n\n');
       return '@layer base {\n' + inner + '\n}\n';
+    },
+    cssExportLabel() {
+      const filterKey = this.cssFilter === 'current' ? (this.theme || 'goshtoso') : this.cssFilter;
+      const label = filterKey === 'all' ? 'All themes' : (this.themeLabels[filterKey] || filterKey);
+      return label + (this.cssMode === 'single' ? ' — single' : ' — @layer base');
     },
     copyCSS() {
       navigator.clipboard.writeText(this.cssCode()).then(() => {
@@ -1312,7 +1325,7 @@ func themeGridSection() templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(t.Key)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1177, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1190, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 			if templ_7745c5c3_Err != nil {
@@ -1325,7 +1338,7 @@ func themeGridSection() templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("theme === '%s' ? 'ring-2 ring-primary dark:ring-primary-dark' : 'hover:border-on-surface/30 dark:hover:border-on-surface-dark/30'", t.Key))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1180, Col: 165}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1193, Col: 165}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var7)
 			if templ_7745c5c3_Err != nil {
@@ -1338,7 +1351,7 @@ func themeGridSection() templ.Component {
 			var templ_7745c5c3_Var8 string
 			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("theme === '%s' ? '' : 'hidden'", t.Key))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1186, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1199, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
 			if templ_7745c5c3_Err != nil {
@@ -1351,7 +1364,7 @@ func themeGridSection() templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(t.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1189, Col: 107}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1202, Col: 107}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -1539,7 +1552,7 @@ func radiusIcon(key string) templ.Component {
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(radiusIconPath(key))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1259, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1272, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
 		if templ_7745c5c3_Err != nil {
@@ -1594,7 +1607,7 @@ func themeBorderSection() templ.Component {
 			var templ_7745c5c3_Var20 string
 			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(r.Key)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1276, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1289, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
 			if templ_7745c5c3_Err != nil {
@@ -1607,7 +1620,7 @@ func themeBorderSection() templ.Component {
 			var templ_7745c5c3_Var21 string
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("radius === '%s' ? 'bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark' : 'text-on-surface dark:text-on-surface-dark hover:bg-surface dark:hover:bg-surface-dark'", r.Key))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1279, Col: 221}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1292, Col: 221}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 			if templ_7745c5c3_Err != nil {
@@ -1620,7 +1633,7 @@ func themeBorderSection() templ.Component {
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue("Radius " + r.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1280, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1293, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
 			if templ_7745c5c3_Err != nil {
@@ -1641,7 +1654,7 @@ func themeBorderSection() templ.Component {
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(r.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1283, Col: 342}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1296, Col: 342}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -1744,7 +1757,7 @@ func modeColorGroup(title string, tokens []colorToken, isLight bool) templ.Compo
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1314, Col: 100}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1327, Col: 100}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
@@ -1811,7 +1824,7 @@ func colorGroup(title string, tokens []colorToken) templ.Component {
 		var templ_7745c5c3_Var28 string
 		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1338, Col: 104}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1351, Col: 104}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
@@ -1863,7 +1876,7 @@ func colorSwatch(token string) templ.Component {
 		var templ_7745c5c3_Var30 string
 		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue("'background-color:' + (resolved['" + token + "'] || '#888')")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1350, Col: 72}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1363, Col: 72}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
 		if templ_7745c5c3_Err != nil {
@@ -1950,7 +1963,7 @@ func colorRow(t colorToken) templ.Component {
 		var templ_7745c5c3_Var32 string
 		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(t.Key)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1400, Col: 24}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1413, Col: 24}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
 		if templ_7745c5c3_Err != nil {
@@ -1963,7 +1976,7 @@ func colorRow(t colorToken) templ.Component {
 		var templ_7745c5c3_Var33 string
 		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.ResolveAttributeValue(tokenHint(t.Key))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1400, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1413, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var33)
 		if templ_7745c5c3_Err != nil {
@@ -2366,7 +2379,7 @@ func toggleCell(i int, onClass string) templ.Component {
 		var templ_7745c5c3_Var45 string
 		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("%d", i))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1524, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1537, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var45)
 		if templ_7745c5c3_Err != nil {
@@ -2379,7 +2392,7 @@ func toggleCell(i int, onClass string) templ.Component {
 		var templ_7745c5c3_Var46 string
 		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("s[%d] ? '%s' : 'bg-outline dark:bg-outline-dark'", i, onClass))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1527, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1540, Col: 87}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var46)
 		if templ_7745c5c3_Err != nil {
@@ -2392,7 +2405,7 @@ func toggleCell(i int, onClass string) templ.Component {
 		var templ_7745c5c3_Var47 string
 		templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("s[%d] ? 'translate-x-6' : 'translate-x-1'", i))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1532, Col: 72}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1545, Col: 72}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var47)
 		if templ_7745c5c3_Err != nil {
@@ -2509,7 +2522,7 @@ func ringAvatar(label, classes string) templ.Component {
 		var templ_7745c5c3_Var52 string
 		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1554, Col: 9}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1567, Col: 9}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 		if templ_7745c5c3_Err != nil {
@@ -2585,7 +2598,7 @@ func themeContrastSection() templ.Component {
 			var templ_7745c5c3_Var55 string
 			templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.ResolveAttributeValue(t.Key)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1609, Col: 30}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1622, Col: 30}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var55)
 			if templ_7745c5c3_Err != nil {
@@ -2598,7 +2611,7 @@ func themeContrastSection() templ.Component {
 			var templ_7745c5c3_Var56 string
 			templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(t.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1609, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1622, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 			if templ_7745c5c3_Err != nil {
@@ -2638,7 +2651,6 @@ func themeCSSSection() templ.Component {
 			templ_7745c5c3_Var57 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		blocks := getThemeCSSBlocks()
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "<div><h2 class=\"text-2xl font-bold font-title text-on-surface-strong dark:text-on-surface-dark-strong mb-2\">Get CSS Code</h2><p class=\"text-sm text-on-surface dark:text-on-surface-dark mb-4\">Copy the code below and paste it into your CSS file. Pick a single theme or export every theme wrapped in a shared <code class=\"rounded bg-surface-alt px-1 py-0.5 text-xs font-mono text-on-surface-strong dark:bg-surface-dark-alt dark:text-on-surface-dark-strong\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -2646,7 +2658,7 @@ func themeCSSSection() templ.Component {
 		var templ_7745c5c3_Var58 string
 		templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs("@layer base")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1743, Col: 166}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1755, Col: 166}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 		if templ_7745c5c3_Err != nil {
@@ -2664,109 +2676,7 @@ func themeCSSSection() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</div><div class=\"inline-flex rounded-radius border border-outline dark:border-outline-dark p-0.5 bg-surface-alt dark:bg-surface-dark-alt\"><button @click=\"cssMode = 'single'\" class=\"px-3 py-1 text-xs font-medium rounded-radius transition-colors\" :class=\"cssMode === 'single' ? 'bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark' : 'text-on-surface dark:text-on-surface-dark'\">Single Theme</button> <button @click=\"cssMode = 'multiple'\" class=\"px-3 py-1 text-xs font-medium rounded-radius transition-colors\" :class=\"cssMode === 'multiple' ? 'bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark' : 'text-on-surface dark:text-on-surface-dark'\">Multiple Themes</button></div></div><div class=\"space-y-3\"><!-- Single mode, per-theme blocks (and \"all\" concatenated). -->")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		for _, k := range themeCSSOrder {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<div x-show=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var59 string
-			templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("cssMode === 'single' && ((cssFilter === 'current' && (theme || 'goshtoso') === '%s') || cssFilter === '%s')", k, k))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1770, Col: 146}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var59)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = codeblock.CodeBlock(codeblock.Config{
-				Language:  "css",
-				Label:     themeLabel(k) + " — single",
-				Code:      blocks[k],
-				MaxHeight: "24rem",
-				ID:        "theme-css-single-" + k,
-			}).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "<div x-show=\"cssMode === 'single' && cssFilter === 'all'\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = codeblock.CodeBlock(codeblock.Config{
-			Language:  "css",
-			Label:     "All themes — single",
-			Code:      concatThemes(),
-			MaxHeight: "24rem",
-			ID:        "theme-css-single-all",
-		}).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "</div><!-- Multi mode, per-theme wrapped in @layer base. -->")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		for _, k := range themeCSSOrder {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "<div x-show=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var60 string
-			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("cssMode === 'multiple' && ((cssFilter === 'current' && (theme || 'goshtoso') === '%s') || cssFilter === '%s')", k, k))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/theme.templ`, Line: 1791, Col: 148}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var60)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = codeblock.CodeBlock(codeblock.Config{
-				Language:  "css",
-				Label:     themeLabel(k) + " — @layer base",
-				Code:      wrapSingleTheme(k),
-				MaxHeight: "24rem",
-				ID:        "theme-css-multi-" + k,
-			}).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "<div x-show=\"cssMode === 'multiple' && cssFilter === 'all'\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = codeblock.CodeBlock(codeblock.Config{
-			Language:  "css",
-			Label:     "All themes — @layer base",
-			Code:      allThemesWrappedCSS(),
-			MaxHeight: "24rem",
-			ID:        "theme-css-multi-all",
-		}).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "</div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</div><div class=\"inline-flex rounded-radius border border-outline dark:border-outline-dark p-0.5 bg-surface-alt dark:bg-surface-dark-alt\"><button @click=\"cssMode = 'single'\" class=\"px-3 py-1 text-xs font-medium rounded-radius transition-colors\" :class=\"cssMode === 'single' ? 'bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark' : 'text-on-surface dark:text-on-surface-dark'\">Single Theme</button> <button @click=\"cssMode = 'multiple'\" class=\"px-3 py-1 text-xs font-medium rounded-radius transition-colors\" :class=\"cssMode === 'multiple' ? 'bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark' : 'text-on-surface dark:text-on-surface-dark'\">Multiple Themes</button></div></div><div class=\"rounded-radius border border-outline dark:border-outline-dark overflow-hidden\"><div class=\"flex items-center justify-between gap-3 px-4 py-2 bg-surface-alt dark:bg-surface-dark-alt border-b border-outline dark:border-outline-dark\"><span class=\"truncate text-xs font-medium text-on-surface dark:text-on-surface-dark\" x-text=\"cssExportLabel()\">Theme CSS</span> <button type=\"button\" @click=\"copyCSS()\" aria-label=\"Copy theme CSS code\" class=\"flex items-center gap-1 text-xs text-on-surface-muted hover:text-primary transition-colors dark:text-on-surface-dark-muted dark:hover:text-primary-dark\"><svg x-show=\"!copied\" xmlns=\"http://www.w3.org/2000/svg\" class=\"h-3.5 w-3.5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z\"></path></svg> <svg x-show=\"copied\" x-cloak xmlns=\"http://www.w3.org/2000/svg\" class=\"h-3.5 w-3.5 text-green-500\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M5 13l4 4L19 7\"></path></svg> <span x-text=\"copied ? 'Copied!' : 'Copy'\">Copy</span></button></div><div id=\"theme-css-output\" class=\"codeblock overflow-x-auto\" style=\"max-height: 24rem; overflow-y: auto;\"><pre class=\"ch-chroma\"><code x-text=\"cssCode()\"></code></pre></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/pages/demo/components/theme_test.go
+++ b/site/internal/pages/demo/components/theme_test.go
@@ -1,0 +1,22 @@
+package components
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThemeCSSExportRendersSingleDynamicOutput(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, themeDemoContent().Render(context.Background(), &buf))
+	html := buf.String()
+
+	assert.Contains(t, html, `id="theme-css-output"`)
+	assert.NotContains(t, html, `theme-css-single-`)
+	assert.NotContains(t, html, `theme-css-multi-`)
+	assert.Equal(t, 0, strings.Count(html, `<span class="ch-`))
+}

--- a/site/tests/e2e/theme_page_test.go
+++ b/site/tests/e2e/theme_page_test.go
@@ -379,14 +379,17 @@ func TestThemePage_CSSExport_FilterAndMode(t *testing.T) {
 	page := newPage(t, browser)
 	gotoThemePage(t, page)
 
-	// Default state: single mode + active theme = minimal single block visible.
-	require.NoError(t, page.Locator("#theme-css-single-minimal").WaitFor(playwright.LocatorWaitForOptions{
+	output := page.Locator("#theme-css-output code")
+
+	// Default state: single mode + active theme = minimal single block rendered.
+	require.NoError(t, output.WaitFor(playwright.LocatorWaitForOptions{
 		State:   playwright.WaitForSelectorStateVisible,
 		Timeout: playwright.Float(1500),
 	}))
-	hidden, err := page.Locator("#theme-css-multi-all").IsHidden()
+	text, err := output.TextContent()
 	require.NoError(t, err)
-	assert.True(t, hidden)
+	assert.Contains(t, text, "[data-theme=minimal]")
+	assert.NotContains(t, text, "@layer base")
 
 	// Switch to All Themes + Multiple. cssFilter is the Goshtoso Select
 	// component (custom dropdown), so open the trigger and click the option.
@@ -396,13 +399,11 @@ func TestThemePage_CSSExport_FilterAndMode(t *testing.T) {
 	}).Click())
 	require.NoError(t, page.Locator("button:has-text('Multiple Themes')").First().Click())
 
-	require.NoError(t, page.Locator("#theme-css-multi-all").WaitFor(playwright.LocatorWaitForOptions{
-		State:   playwright.WaitForSelectorStateVisible,
-		Timeout: playwright.Float(1500),
-	}))
-	hidden, err = page.Locator("#theme-css-single-minimal").IsHidden()
+	_, err = page.WaitForFunction(`() => {
+		const code = document.querySelector('#theme-css-output code');
+		return code && code.textContent.includes('@layer base') && code.textContent.includes('[data-theme=dracula]');
+	}`, nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(1500)})
 	require.NoError(t, err)
-	assert.True(t, hidden, "single-minimal block should be hidden after switching to multi/all")
 
 	// Switch back to a specific theme in single mode.
 	require.NoError(t, page.Locator("button:has-text('Single Theme')").First().Click())
@@ -410,10 +411,11 @@ func TestThemePage_CSSExport_FilterAndMode(t *testing.T) {
 	require.NoError(t, page.GetByRole("option", playwright.PageGetByRoleOptions{
 		Name: "Arctic", Exact: new(true),
 	}).Click())
-	require.NoError(t, page.Locator("#theme-css-single-arctic").WaitFor(playwright.LocatorWaitForOptions{
-		State:   playwright.WaitForSelectorStateVisible,
-		Timeout: playwright.Float(1500),
-	}))
+	_, err = page.WaitForFunction(`() => {
+		const code = document.querySelector('#theme-css-output code');
+		return code && code.textContent.includes('[data-theme=arctic]') && !code.textContent.includes('@layer base');
+	}`, nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(1500)})
+	require.NoError(t, err)
 }
 
 func TestThemePage_Showcase_UpdateBanner_Dismiss(t *testing.T) {


### PR DESCRIPTION
## Summary
- Generate lazy palette swatches only when a palette dropdown opens instead of shipping every swatch in inert templates.
- Replace 32 hidden theme CSS code blocks with one dynamic CSS output backed by the existing export state.
- Add render/E2E coverage for the lighter theme export behavior.

## Measured Impact
- `/docs/theme` full HTML: ~4.56 MB -> ~590 KB.
- `/docs/theme` HX fragment: ~4.42 MB -> ~446 KB.
- Warm local fetch: ~200 ms -> ~3-6 ms.

## Test Plan
- `git diff --check`
- `go test ./site/tests/e2e -run 'TestThemePage_' -count=1 -timeout 5m`
- `go test ./... -count=1`
- `go test $(go list ./site/... | grep -v /site/tests/e2e) -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored palette component's Alpine.js state management for improved maintainability
  * Simplified theme CSS export UI to display code in a single scrollable output panel instead of multiple code blocks

* **Tests**
  * Updated test assertions to reflect new palette lazy-loading implementation
  * Added test coverage for theme CSS export rendering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->