### PR TITLE
Dispatch Fly deploys to central repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,16 +236,25 @@ jobs:
           if-no-files-found: ignore
 
   deploy:
-    name: Deploy to Fly.io
+    name: Trigger Fly deploy
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: [lint-build, test]
     runs-on: araihu
     concurrency: deploy-group
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - run: flyctl deploy --remote-only
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - name: Dispatch central deployment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.FLY_DEPLOY_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'araihu',
+              repo: 'fly-deploy',
+              event_type: 'goshtoso-main',
+              client_payload: {
+                goshtoso_ref: context.sha,
+                goshtoso_sha: context.sha,
+                goshtoso_run_id: String(context.runId),
+                source_repository: `${context.repo.owner}/${context.repo.repo}`,
+              },
+            })


### PR DESCRIPTION
## Summary
- Replace the direct `flyctl deploy` job with a repository dispatch to `araihu/fly-deploy`.
- Keep deployment gated on main-push CI success via `needs: [lint-build, test]`.
- Include the Goshtoso SHA, run ID, and source repository in the dispatch payload.

## Required secret
- `FLY_DEPLOY_DISPATCH_TOKEN`, with access to dispatch events to the private `araihu/fly-deploy` repository.

## Test Plan
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts f }' .github/workflows/ci.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow infrastructure to use a centralized deployment service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->