### PR TITLE
docs: fix release badge automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,19 @@ jobs:
             assets/styles.css
             assets/goshtoso-theme.css
 
+      # Keep the README release badge on the same shields.io endpoint gist
+      # pattern used by the coverage badge, so new tags update the badge without
+      # committing badge churn back to main.
+      - name: Update release badge gist
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: fb3843c3a13793eb6cc0af638bc00ad4
+          filename: release.json
+          label: release
+          message: ${{ github.ref_name }}
+          color: blue
+
       # The site module tracks released library tags (not every main SHA).
       # Bump its require to this tag and commit the pin back to main.
       - name: Bump site module to released library tag

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://github.com/araihu/goshtoso/actions/workflows/ci.yml"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/guilycst/fb3843c3a13793eb6cc0af638bc00ad4/raw/coverage.json" alt="Coverage" /></a>
   <a href="https://pkg.go.dev/github.com/araihu/goshtoso"><img src="https://pkg.go.dev/badge/github.com/araihu/goshtoso.svg" alt="Go Reference" /></a>
   <a href="https://goreportcard.com/report/github.com/araihu/goshtoso"><img src="https://goreportcard.com/badge/github.com/araihu/goshtoso" alt="Go Report Card" /></a>
-  <a href="https://github.com/araihu/goshtoso/releases/tag/v0.0.4"><img src="https://img.shields.io/badge/release-v0.0.4-blue.svg" alt="Release: v0.0.4" /></a>
+  <a href="https://github.com/araihu/goshtoso/releases/latest"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/guilycst/fb3843c3a13793eb6cc0af638bc00ad4/raw/release.json" alt="Latest release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
 </p>
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,9 +1,21 @@
 # Version Compatibility
 
 Each released Goshtoso tag and the Tailwind CSS version its CSS was built with.
-The source of truth is `assets/tailwind.version`; match your own Tailwind build
-to the row for the Goshtoso version you depend on (see `goshtoso -version`).
+For current releases, the source of truth is `assets/tailwind.version`; match
+your own Tailwind build to the row for the Goshtoso version you depend on (see
+`goshtoso -version`).
+
+`v0.0.1` predates the checked-in `assets/tailwind.version` file; later tags
+record the pin directly in the release source.
 
 | Goshtoso | Tailwind CSS |
 |----------|--------------|
+| v0.0.9   | 4.3.0        |
+| v0.0.8   | 4.3.0        |
+| v0.0.7   | 4.3.0        |
+| v0.0.6   | 4.3.0        |
+| v0.0.5   | 4.3.0        |
+| v0.0.4   | 4.3.0        |
+| v0.0.3   | 4.3.0        |
+| v0.0.2   | 4.3.0        |
 | v0.0.1   | 4.3.0        |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,7 @@
 # Goshtoso Components - Usage Guide
 
-This guide explains how to use Goshtoso (Go + Alpine.js + Tailwind CSS + HTMX + Templ) components from the tks-console and other projects.
+This guide explains how to use Goshtoso components in Go web applications built
+with templ, Tailwind CSS, HTMX, and Alpine.js.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Point the README release badge at the shared shields.io gist endpoint (`release.json`) instead of a hardcoded release badge.
- Add a release workflow step that updates `release.json` with the pushed tag name.
- Refresh version compatibility docs and remove app-specific wording from the usage guide.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release yaml ok"'`
- `gh gist view fb3843c3a13793eb6cc0af638bc00ad4 --filename release.json`

## Notes
- Seeded the shared badge gist with `release.json` for current latest release `v0.0.9` so the README endpoint renders immediately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added latest release badge to README
  * Clarified component usage documentation for Go web applications built with templ, Tailwind CSS, HTMX, and Alpine.js
  * Updated version compatibility information

* **Chores**
  * Enhanced release workflow automation with badge updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->