### PR TITLE
docs: clean up OSS readiness nits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ Generated artifacts are checked in but **must never be hand-edited**
 templ generate
 
 # after editing CSS / introducing a new Tailwind utility class
-tailwindcss -i css/main.css -o assets/styles.css
+# fetches the pinned Tailwind binary and regenerates theme + component CSS
+just css
 
 go build -o bin/server ./site/cmd/server
 ```
@@ -79,6 +80,7 @@ Run the full gate locally — CI enforces all of it:
 
 ```bash
 templ generate
+just css                                             # if CSS/theme output changed
 golangci-lint run                                   # cyclomatic ceiling: 20
 go fix ./...                                         # also runs via pre-commit hook
 go build -o bin/server ./site/cmd/server

--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.0.7
+	github.com/araihu/goshtoso v0.0.9
 	github.com/coder/websocket v1.8.14
 	github.com/playwright-community/playwright-go v0.5700.1
 	github.com/stretchr/testify v1.11.1

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6
 github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.0.7 h1:QS8DNRPW/USsbdrWM+0NuPy3ToAVaIm416s1/v4c8As=
-github.com/araihu/goshtoso v0.0.7/go.mod h1:pEJfw8LGHQpyX60yGckzuxog5XwwtGfvKI7Y8f7PP24=
+github.com/araihu/goshtoso v0.0.9 h1:KwzjVoRe5jKnav3FJPPUk28Pye4JhTdUNQrOA8xnRTI=
+github.com/araihu/goshtoso v0.0.9/go.mod h1:pEJfw8LGHQpyX60yGckzuxog5XwwtGfvKI7Y8f7PP24=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
## Summary
- Pin the demo site module to the latest Goshtoso release, v0.0.9
- Update contributor CSS regeneration docs to use `just css` so pinned Tailwind and theme output stay in sync

## Test Plan
- [x] `git diff --check`
- [x] `go test ./... -count=1`
- [x] `cd site && go test $(go list ./... | grep -v /tests/e2e) -count=1`
- [x] `go build -o bin/server ./site/cmd/server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer contribution guidelines for build and regeneration processes.

* **Chores**
  * Updated internal dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->