### PR TITLE
Center landing example cards on small screens

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -5069,6 +5069,11 @@
       left: auto;
     }
   }
+  .sm\:mx-0 {
+    @media (width >= 40rem) {
+      margin-inline: calc(var(--spacing) * 0);
+    }
+  }
   .sm\:ml-auto {
     @media (width >= 40rem) {
       margin-left: auto;

--- a/site/internal/pages/demo/components/landing.templ
+++ b/site/internal/pages/demo/components/landing.templ
@@ -229,7 +229,7 @@ templ landingContent() {
 			</p>
 			{{ featured := getFeaturedExampleApp() }}
 			<div class="space-y-6">
-				<a href={ templ.SafeURL(featured.URL) } data-example-card data-featured-example-card class="group block max-w-sm rounded-radius focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface dark:focus-visible:ring-primary-dark dark:focus-visible:ring-offset-surface-dark sm:max-w-none">
+				<a href={ templ.SafeURL(featured.URL) } data-example-card data-featured-example-card class="group mx-auto block w-full max-w-sm rounded-radius focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface dark:focus-visible:ring-primary-dark dark:focus-visible:ring-offset-surface-dark sm:max-w-none">
 					@card.Card(card.Config{
 						Image:       featured.Image,
 						ImageAlt:    featured.ImageAlt,
@@ -243,7 +243,7 @@ templ landingContent() {
 				</a>
 				<div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
 					for _, a := range getSupportingExampleApps() {
-						<a href={ templ.SafeURL(a.URL) } data-example-card data-supporting-example-card class="group block h-full rounded-radius focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface dark:focus-visible:ring-primary-dark dark:focus-visible:ring-offset-surface-dark">
+						<a href={ templ.SafeURL(a.URL) } data-example-card data-supporting-example-card class="group mx-auto block h-full w-full max-w-sm rounded-radius focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface dark:focus-visible:ring-primary-dark dark:focus-visible:ring-offset-surface-dark sm:mx-0 sm:max-w-none">
 							@card.Card(card.Config{
 								Image:       a.Image,
 								ImageAlt:    a.ImageAlt,

--- a/site/internal/pages/demo/components/landing_templ.go
+++ b/site/internal/pages/demo/components/landing_templ.go
@@ -309,7 +309,7 @@ func landingContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" data-example-card data-featured-example-card class=\"group block max-w-sm rounded-radius focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface dark:focus-visible:ring-primary-dark dark:focus-visible:ring-offset-surface-dark sm:max-w-none\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" data-example-card data-featured-example-card class=\"group mx-auto block w-full max-w-sm rounded-radius focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface dark:focus-visible:ring-primary-dark dark:focus-visible:ring-offset-surface-dark sm:max-w-none\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -344,7 +344,7 @@ func landingContent() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" data-example-card data-supporting-example-card class=\"group block h-full rounded-radius focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface dark:focus-visible:ring-primary-dark dark:focus-visible:ring-offset-surface-dark\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" data-example-card data-supporting-example-card class=\"group mx-auto block h-full w-full max-w-sm rounded-radius focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface dark:focus-visible:ring-primary-dark dark:focus-visible:ring-offset-surface-dark sm:mx-0 sm:max-w-none\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/site/tests/e2e/landing_test.go
+++ b/site/tests/e2e/landing_test.go
@@ -202,6 +202,29 @@ func TestLanding_HeroAndStructure(t *testing.T) {
 		require.Less(t, widthRatio, 1.05, "featured example should not stay wider than supporting cards on mobile")
 	})
 
+	t.Run("SmallScreensCenterExampleCards", func(t *testing.T) {
+		small := newPage(t, browser, playwright.BrowserNewPageOptions{
+			Viewport: &playwright.Size{Width: 576, Height: 779},
+		})
+		_, err := small.Goto(baseURL+"/", playwright.PageGotoOptions{
+			WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+		})
+		require.NoError(t, err)
+
+		examplesBox, err := small.Locator("#examples").BoundingBox()
+		require.NoError(t, err)
+		featuredBox, err := small.Locator("#examples a[data-featured-example-card] article").BoundingBox()
+		require.NoError(t, err)
+		supportingBox, err := small.Locator("#examples a[data-supporting-example-card] article").First().BoundingBox()
+		require.NoError(t, err)
+
+		examplesCenter := examplesBox.X + examplesBox.Width/2
+		featuredCenter := featuredBox.X + featuredBox.Width/2
+		supportingCenter := supportingBox.X + supportingBox.Width/2
+		require.InDelta(t, examplesCenter, featuredCenter, 2.0, "featured example should be horizontally centered on small screens")
+		require.InDelta(t, examplesCenter, supportingCenter, 2.0, "supporting examples should be horizontally centered on small screens")
+	})
+
 	t.Run("StackStripCondensed", func(t *testing.T) {
 		strip := page.Locator("#stack-strip")
 		visible, err := strip.IsVisible()


### PR DESCRIPTION
## Summary
- center featured and supporting example cards on small screens
- preserve regular grid flow at sm and larger breakpoints
- add a 576px landing E2E assertion for horizontal centering

## Verification
- templ generate
- just css
- cd site && go test ./tests/e2e -count=1 -timeout 5m -run 'TestLanding_HeroAndStructure'\n- cd site && go test ./tests/e2e -count=1 -timeout 5m -run 'TestLanding_NoConsoleErrors'\n- go build -o bin/server ./site/cmd/server\n- git diff --check\n- node /Users/guilhermecastro/.agents/skills/impeccable/scripts/detect.mjs --json site/internal/pages/demo/components/landing.templ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive layout of example gallery cards on small screens with proper centering and sizing.

* **Tests**
  * Added automated testing to verify small-screen example card layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->