### PR TITLE
feat(search): show result metadata

### DIFF
--- a/.agents/skills/using-goshtoso/references/components-reference.md
+++ b/.agents/skills/using-goshtoso/references/components-reference.md
@@ -1208,6 +1208,9 @@ import "github.com/araihu/goshtoso/components/search"  // package search
 | `Title` | `string` | Title is the primary result text. |
 | `Description` | `string` | Description is optional supporting text. |
 | `Href` | `string` | Href turns the result into a link. |
+| `Kind` | `string` | Kind is optional type metadata for the result. |
+| `Method` | `string` | Method is optional method metadata, commonly an HTTP verb. |
+| `Path` | `string` | Path is optional route or resource path metadata. |
 | `Section` | `string` | Section is optional grouping or eyebrow text. |
 | `Keywords` | `[]string` | Keywords are extra terms included in client-side filtering. |
 | `Attrs` | `templ.Attributes` | Attrs are extra attributes spread onto the result button. |

--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -1208,6 +1208,9 @@ import "github.com/araihu/goshtoso/components/search"  // package search
 | `Title` | `string` | Title is the primary result text. |
 | `Description` | `string` | Description is optional supporting text. |
 | `Href` | `string` | Href turns the result into a link. |
+| `Kind` | `string` | Kind is optional type metadata for the result. |
+| `Method` | `string` | Method is optional method metadata, commonly an HTTP verb. |
+| `Path` | `string` | Path is optional route or resource path metadata. |
 | `Section` | `string` | Section is optional grouping or eyebrow text. |
 | `Keywords` | `[]string` | Keywords are extra terms included in client-side filtering. |
 | `Attrs` | `templ.Attributes` | Attrs are extra attributes spread onto the result button. |

--- a/components/search/search.templ
+++ b/components/search/search.templ
@@ -3,6 +3,7 @@ package search
 import (
 	"fmt"
 
+	"github.com/araihu/goshtoso/components/badge"
 	"github.com/araihu/goshtoso/components/kbd"
 )
 
@@ -132,6 +133,15 @@ templ resultItem(item Item, index int) {
 		data-search-result
 		data-search-title={ item.Title }
 		data-search-description={ item.Description }
+		if item.Kind != "" {
+			data-search-kind={ item.Kind }
+		}
+		if item.NormalizedMethod() != "" {
+			data-search-method={ item.NormalizedMethod() }
+		}
+		if item.Path != "" {
+			data-search-path={ item.Path }
+		}
 		if item.Section != "" {
 			data-search-section={ item.Section }
 		}
@@ -150,7 +160,27 @@ templ resultItem(item Item, index int) {
 		{ item.Attrs... }
 	>
 		<div class="flex items-start justify-between gap-3">
-			<strong class="min-w-0 text-base font-semibold" x-html="highlight($el.closest('[data-search-result]').dataset.searchTitle)">{ item.Title }</strong>
+			<div class="min-w-0 space-y-1">
+				<div class="flex min-w-0 flex-wrap items-center gap-2">
+					if item.NormalizedMethod() != "" {
+						@badge.Badge(badge.Config{Label: item.NormalizedMethod(), Variant: methodBadgeVariant(item.Method), Size: badge.SizeSM, RootClass: "shrink-0 font-mono font-bold uppercase"})
+					}
+					<strong class="min-w-0 text-base font-semibold" x-html="highlight($el.closest('[data-search-result]').dataset.searchTitle)">{ item.Title }</strong>
+				</div>
+				if item.Kind != "" || item.Path != "" {
+					<div class="flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-on-surface-muted dark:text-on-surface-dark-muted">
+						if item.Kind != "" {
+							<span>{ item.Kind }</span>
+						}
+						if item.Kind != "" && item.Path != "" {
+							<span aria-hidden="true">·</span>
+						}
+						if item.Path != "" {
+							<code class="min-w-0 font-mono text-[11px] text-on-surface dark:text-on-surface-dark">{ item.Path }</code>
+						}
+					</div>
+				}
+			</div>
 			if item.Section != "" {
 				<span class="shrink-0 rounded-radius border border-outline px-2 py-0.5 text-xs font-medium text-on-surface-muted dark:border-outline-dark dark:text-on-surface-dark-muted">{ item.Section }</span>
 			}
@@ -169,6 +199,9 @@ templ clientResultItems() {
 			x-bind:id="item.id || null"
 			x-bind:data-search-title="item.title"
 			x-bind:data-search-description="item.description"
+			x-bind:data-search-kind="item.kind || null"
+			x-bind:data-search-method="item.method || null"
+			x-bind:data-search-path="item.path || null"
 			x-bind:data-search-section="item.section || null"
 			x-bind:data-search-href="item.href || null"
 			x-bind:data-search-text="item.searchText"
@@ -180,7 +213,27 @@ templ clientResultItems() {
 			role="option"
 		>
 			<div class="flex items-start justify-between gap-3">
-				<strong class="min-w-0 text-base font-semibold" x-html="highlight(item.title)"></strong>
+				<div class="min-w-0 space-y-1">
+					<div class="flex min-w-0 flex-wrap items-center gap-2">
+						<template x-if="item.method">
+							<span class="shrink-0 rounded-radius w-fit font-medium text-[10px] px-1.5 py-0.5 font-mono font-bold uppercase" x-bind:class="methodBadgeClasses(item.method)" x-text="item.method"></span>
+						</template>
+						<strong class="min-w-0 text-base font-semibold" x-html="highlight(item.title)"></strong>
+					</div>
+					<template x-if="item.kind || item.path">
+						<div class="flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-on-surface-muted dark:text-on-surface-dark-muted">
+							<template x-if="item.kind">
+								<span x-text="item.kind"></span>
+							</template>
+							<template x-if="item.kind && item.path">
+								<span aria-hidden="true">·</span>
+							</template>
+							<template x-if="item.path">
+								<code class="min-w-0 font-mono text-[11px] text-on-surface dark:text-on-surface-dark" x-text="item.path"></code>
+							</template>
+						</div>
+					</template>
+				</div>
 				<template x-if="item.section">
 					<span class="shrink-0 rounded-radius border border-outline px-2 py-0.5 text-xs font-medium text-on-surface-muted dark:border-outline-dark dark:text-on-surface-dark-muted" x-text="item.section"></span>
 				</template>
@@ -280,7 +333,22 @@ templ searchScript() {
 				return String(value);
 			},
 			searchTextForItem: function (item) {
-				return [item.title, item.description, item.section].concat(item.keywords || []).filter(Boolean).join(' ');
+				return [item.title, item.description, item.kind, item.method, item.path, item.section].concat(item.keywords || []).filter(Boolean).join(' ');
+			},
+			methodBadgeClasses: function (method) {
+				switch (this.stringValue(method).trim().toUpperCase()) {
+					case 'GET':
+						return 'border border-primary bg-primary text-on-primary dark:border-primary-dark dark:bg-primary-dark dark:text-on-primary-dark';
+					case 'POST':
+						return 'border border-success bg-success text-on-success';
+					case 'PUT':
+					case 'PATCH':
+						return 'border border-warning bg-warning text-on-warning';
+					case 'DELETE':
+						return 'border border-danger bg-danger text-on-danger';
+					default:
+						return 'border border-outline bg-surface-alt text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark';
+				}
 			},
 			safeHref: function (value) {
 				var href = this.stringValue(value).trim();
@@ -306,6 +374,9 @@ templ searchScript() {
 						title: self.stringValue(raw.title !== undefined ? raw.title : raw.Title),
 						description: self.stringValue(raw.description !== undefined ? raw.description : raw.Description),
 						href: self.safeHref(raw.href !== undefined ? raw.href : raw.Href),
+						kind: self.stringValue(raw.kind !== undefined ? raw.kind : raw.Kind),
+						method: self.stringValue(raw.method !== undefined ? raw.method : raw.Method).trim().toUpperCase(),
+						path: self.stringValue(raw.path !== undefined ? raw.path : raw.Path),
 						section: self.stringValue(raw.section !== undefined ? raw.section : raw.Section),
 						keywords: keywords.map(function (keyword) { return self.stringValue(keyword); }),
 						index: index

--- a/components/search/search_templ.go
+++ b/components/search/search_templ.go
@@ -11,6 +11,7 @@ import templruntime "github.com/a-h/templ/runtime"
 import (
 	"fmt"
 
+	"github.com/araihu/goshtoso/components/badge"
 	"github.com/araihu/goshtoso/components/kbd"
 )
 
@@ -114,7 +115,7 @@ func SearchField(cfg Config) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(id)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 25, Col: 9}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 26, Col: 9}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
 		if templ_7745c5c3_Err != nil {
@@ -127,7 +128,7 @@ func SearchField(cfg Config) templ.Component {
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("goshtosoSearchField('%s', %t)", JSString(id), cfg.GlobalShortcut))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 27, Col: 89}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 28, Col: 89}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 		if templ_7745c5c3_Err != nil {
@@ -172,7 +173,7 @@ func SearchField(cfg Config) templ.Component {
 		var templ_7745c5c3_Var9 string
 		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-dialog")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 40, Col: 33}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 41, Col: 33}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
 		if templ_7745c5c3_Err != nil {
@@ -193,7 +194,7 @@ func SearchField(cfg Config) templ.Component {
 		var templ_7745c5c3_Var10 string
 		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.GetLabel())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 43, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 44, Col: 57}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
@@ -250,7 +251,7 @@ func SearchModal(cfg Config) templ.Component {
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprintf("goshtosoSearchModal('%s', %d, %d)", JSString(id), cfg.GetMaxResults(), cfg.GetDescriptionMaxLength()))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 56, Col: 125}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 57, Col: 125}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var12)
 		if templ_7745c5c3_Err != nil {
@@ -263,7 +264,7 @@ func SearchModal(cfg Config) templ.Component {
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-label")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 65, Col: 33}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 66, Col: 33}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var13)
 		if templ_7745c5c3_Err != nil {
@@ -276,7 +277,7 @@ func SearchModal(cfg Config) templ.Component {
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-dialog")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 66, Col: 21}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 67, Col: 21}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var14)
 		if templ_7745c5c3_Err != nil {
@@ -294,7 +295,7 @@ func SearchModal(cfg Config) templ.Component {
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.ItemsURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 68, Col: 40}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 69, Col: 40}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var15)
 			if templ_7745c5c3_Err != nil {
@@ -342,7 +343,7 @@ func SearchModal(cfg Config) templ.Component {
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-label")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 83, Col: 29}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 84, Col: 29}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
 		if templ_7745c5c3_Err != nil {
@@ -355,7 +356,7 @@ func SearchModal(cfg Config) templ.Component {
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-input")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 83, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 84, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
 		if templ_7745c5c3_Err != nil {
@@ -368,7 +369,7 @@ func SearchModal(cfg Config) templ.Component {
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.GetLabel())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 83, Col: 86}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 84, Col: 86}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
@@ -381,7 +382,7 @@ func SearchModal(cfg Config) templ.Component {
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(id + "-input")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 92, Col: 23}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 93, Col: 23}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 		if templ_7745c5c3_Err != nil {
@@ -394,7 +395,7 @@ func SearchModal(cfg Config) templ.Component {
 		var templ_7745c5c3_Var22 string
 		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.GetPlaceholder())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 95, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 96, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var22)
 		if templ_7745c5c3_Err != nil {
@@ -423,7 +424,7 @@ func SearchModal(cfg Config) templ.Component {
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.GetLabel() + " results")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 106, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 107, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var23)
 		if templ_7745c5c3_Err != nil {
@@ -453,7 +454,7 @@ func SearchModal(cfg Config) templ.Component {
 		var templ_7745c5c3_Var24 string
 		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.GetEmptyText())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 119, Col: 25}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 120, Col: 25}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
@@ -500,7 +501,7 @@ func resultItem(item Item, index int) templ.Component {
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 130, Col: 15}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 131, Col: 15}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var26)
 			if templ_7745c5c3_Err != nil {
@@ -518,7 +519,7 @@ func resultItem(item Item, index int) templ.Component {
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 133, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 134, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
 		if templ_7745c5c3_Err != nil {
@@ -531,7 +532,7 @@ func resultItem(item Item, index int) templ.Component {
 		var templ_7745c5c3_Var28 string
 		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 134, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 135, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var28)
 		if templ_7745c5c3_Err != nil {
@@ -541,15 +542,15 @@ func resultItem(item Item, index int) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		if item.Section != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, " data-search-section=\"")
+		if item.Kind != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, " data-search-kind=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var29 string
-			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Section)
+			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Kind)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 136, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 137, Col: 31}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var29)
 			if templ_7745c5c3_Err != nil {
@@ -560,15 +561,15 @@ func resultItem(item Item, index int) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		if item.SafeHref() != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, " data-search-href=\"")
+		if item.NormalizedMethod() != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, " data-search-method=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var30 string
-			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.SafeHref())
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.NormalizedMethod())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 139, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 140, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
 			if templ_7745c5c3_Err != nil {
@@ -579,33 +580,90 @@ func resultItem(item Item, index int) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, " data-search-text=\"")
+		if item.Path != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, " data-search-path=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var31 string
+			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Path)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 143, Col: 31}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var31)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if item.Section != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, " data-search-section=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var32 string
+			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.Section)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 146, Col: 37}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if item.SafeHref() != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, " data-search-href=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var33 string
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.SafeHref())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 149, Col: 37}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var33)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, " data-search-text=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var31 string
-		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.SearchText())
+		var templ_7745c5c3_Var34 string
+		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.ResolveAttributeValue(item.SearchText())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 141, Col: 38}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 151, Col: 38}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var31)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "\" data-result-index=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var34)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var32 string
-		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprint(index))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 142, Col: 39}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\" data-result-index=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\" x-bind:hidden=\"!isResultVisible($el)\" x-bind:style=\"'order: ' + resultOrder($el)\" x-bind:class=\"isActive($el) ? 'bg-surface-alt text-on-surface-strong shadow-[inset_2px_0_0_var(--color-outline-strong)] dark:bg-surface-dark dark:text-on-surface-dark-strong dark:shadow-[inset_2px_0_0_var(--color-outline-dark-strong)]' : 'text-on-surface hover:bg-surface-alt hover:text-on-surface-strong focus:bg-surface-alt focus:text-on-surface-strong dark:text-on-surface-dark dark:hover:bg-surface-dark dark:hover:text-on-surface-dark-strong dark:focus:bg-surface-dark dark:focus:text-on-surface-dark-strong'\" x-on:mouseenter=\"setActive($el)\" x-on:click=\"selectResult($el)\" class=\"flex w-full flex-col gap-2 p-4 text-left transition focus:outline-none\" role=\"option\"")
+		var templ_7745c5c3_Var35 string
+		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.ResolveAttributeValue(fmt.Sprint(index))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 152, Col: 39}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var35)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\" x-bind:hidden=\"!isResultVisible($el)\" x-bind:style=\"'order: ' + resultOrder($el)\" x-bind:class=\"isActive($el) ? 'bg-surface-alt text-on-surface-strong shadow-[inset_2px_0_0_var(--color-outline-strong)] dark:bg-surface-dark dark:text-on-surface-dark-strong dark:shadow-[inset_2px_0_0_var(--color-outline-dark-strong)]' : 'text-on-surface hover:bg-surface-alt hover:text-on-surface-strong focus:bg-surface-alt focus:text-on-surface-strong dark:text-on-surface-dark dark:hover:bg-surface-dark dark:hover:text-on-surface-dark-strong dark:focus:bg-surface-dark dark:focus:text-on-surface-dark-strong'\" x-on:mouseenter=\"setActive($el)\" x-on:click=\"selectResult($el)\" class=\"flex w-full flex-col gap-2 p-4 text-left transition focus:outline-none\" role=\"option\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -613,66 +671,134 @@ func resultItem(item Item, index int) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "><div class=\"flex items-start justify-between gap-3\"><strong class=\"min-w-0 text-base font-semibold\" x-html=\"highlight($el.closest('[data-search-result]').dataset.searchTitle)\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "><div class=\"flex items-start justify-between gap-3\"><div class=\"min-w-0 space-y-1\"><div class=\"flex min-w-0 flex-wrap items-center gap-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var33 string
-		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(item.Title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 153, Col: 139}
+		if item.NormalizedMethod() != "" {
+			templ_7745c5c3_Err = badge.Badge(badge.Config{Label: item.NormalizedMethod(), Variant: methodBadgeVariant(item.Method), Size: badge.SizeSM, RootClass: "shrink-0 font-mono font-bold uppercase"}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<strong class=\"min-w-0 text-base font-semibold\" x-html=\"highlight($el.closest('[data-search-result]').dataset.searchTitle)\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</strong> ")
+		var templ_7745c5c3_Var36 string
+		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(item.Title)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 168, Col: 141}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</strong></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if item.Kind != "" || item.Path != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<div class=\"flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if item.Kind != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "<span>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var37 string
+				templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(item.Kind)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 173, Col: 24}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</span> ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			if item.Kind != "" && item.Path != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "<span aria-hidden=\"true\">·</span> ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			if item.Path != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<code class=\"min-w-0 font-mono text-[11px] text-on-surface dark:text-on-surface-dark\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var38 string
+				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(item.Path)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 179, Col: 104}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</code>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if item.Section != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<span class=\"shrink-0 rounded-radius border border-outline px-2 py-0.5 text-xs font-medium text-on-surface-muted dark:border-outline-dark dark:text-on-surface-dark-muted\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "<span class=\"shrink-0 rounded-radius border border-outline px-2 py-0.5 text-xs font-medium text-on-surface-muted dark:border-outline-dark dark:text-on-surface-dark-muted\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var34 string
-			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(item.Section)
+			var templ_7745c5c3_Var39 string
+			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(item.Section)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 155, Col: 189}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 185, Col: 189}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if item.Description != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<p class=\"text-sm leading-6 text-on-surface-muted dark:text-on-surface-dark-muted\" x-html=\"highlight(truncate($el.closest('[data-search-result]').dataset.searchDescription))\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "<p class=\"text-sm leading-6 text-on-surface-muted dark:text-on-surface-dark-muted\" x-html=\"highlight(truncate($el.closest('[data-search-result]').dataset.searchDescription))\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var35 string
-			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(item.Description)
+			var templ_7745c5c3_Var40 string
+			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(item.Description)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 159, Col: 196}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 189, Col: 196}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "</button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -696,12 +822,12 @@ func clientResultItems() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var36 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var36 == nil {
-			templ_7745c5c3_Var36 = templ.NopComponent
+		templ_7745c5c3_Var41 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var41 == nil {
+			templ_7745c5c3_Var41 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<template x-for=\"(item, index) in visibleResults()\" x-bind:key=\"item.key\"><button type=\"button\" data-search-result x-bind:id=\"item.id || null\" x-bind:data-search-title=\"item.title\" x-bind:data-search-description=\"item.description\" x-bind:data-search-section=\"item.section || null\" x-bind:data-search-href=\"item.href || null\" x-bind:data-search-text=\"item.searchText\" x-bind:data-result-index=\"item.index\" x-bind:class=\"isActiveIndex(index) ? 'bg-surface-alt text-on-surface-strong shadow-[inset_2px_0_0_var(--color-outline-strong)] dark:bg-surface-dark dark:text-on-surface-dark-strong dark:shadow-[inset_2px_0_0_var(--color-outline-dark-strong)]' : 'text-on-surface hover:bg-surface-alt hover:text-on-surface-strong focus:bg-surface-alt focus:text-on-surface-strong dark:text-on-surface-dark dark:hover:bg-surface-dark dark:hover:text-on-surface-dark-strong dark:focus:bg-surface-dark dark:focus:text-on-surface-dark-strong'\" x-on:mouseenter=\"setActiveIndex(index)\" x-on:click=\"selectResult(item)\" class=\"flex w-full flex-col gap-2 p-4 text-left transition focus:outline-none\" role=\"option\"><div class=\"flex items-start justify-between gap-3\"><strong class=\"min-w-0 text-base font-semibold\" x-html=\"highlight(item.title)\"></strong><template x-if=\"item.section\"><span class=\"shrink-0 rounded-radius border border-outline px-2 py-0.5 text-xs font-medium text-on-surface-muted dark:border-outline-dark dark:text-on-surface-dark-muted\" x-text=\"item.section\"></span></template></div><template x-if=\"item.description\"><p class=\"text-sm leading-6 text-on-surface-muted dark:text-on-surface-dark-muted\" x-html=\"highlight(truncate(item.description))\"></p></template></button></template>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "<template x-for=\"(item, index) in visibleResults()\" x-bind:key=\"item.key\"><button type=\"button\" data-search-result x-bind:id=\"item.id || null\" x-bind:data-search-title=\"item.title\" x-bind:data-search-description=\"item.description\" x-bind:data-search-kind=\"item.kind || null\" x-bind:data-search-method=\"item.method || null\" x-bind:data-search-path=\"item.path || null\" x-bind:data-search-section=\"item.section || null\" x-bind:data-search-href=\"item.href || null\" x-bind:data-search-text=\"item.searchText\" x-bind:data-result-index=\"item.index\" x-bind:class=\"isActiveIndex(index) ? 'bg-surface-alt text-on-surface-strong shadow-[inset_2px_0_0_var(--color-outline-strong)] dark:bg-surface-dark dark:text-on-surface-dark-strong dark:shadow-[inset_2px_0_0_var(--color-outline-dark-strong)]' : 'text-on-surface hover:bg-surface-alt hover:text-on-surface-strong focus:bg-surface-alt focus:text-on-surface-strong dark:text-on-surface-dark dark:hover:bg-surface-dark dark:hover:text-on-surface-dark-strong dark:focus:bg-surface-dark dark:focus:text-on-surface-dark-strong'\" x-on:mouseenter=\"setActiveIndex(index)\" x-on:click=\"selectResult(item)\" class=\"flex w-full flex-col gap-2 p-4 text-left transition focus:outline-none\" role=\"option\"><div class=\"flex items-start justify-between gap-3\"><div class=\"min-w-0 space-y-1\"><div class=\"flex min-w-0 flex-wrap items-center gap-2\"><template x-if=\"item.method\"><span class=\"shrink-0 rounded-radius w-fit font-medium text-[10px] px-1.5 py-0.5 font-mono font-bold uppercase\" x-bind:class=\"methodBadgeClasses(item.method)\" x-text=\"item.method\"></span></template><strong class=\"min-w-0 text-base font-semibold\" x-html=\"highlight(item.title)\"></strong></div><template x-if=\"item.kind || item.path\"><div class=\"flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-on-surface-muted dark:text-on-surface-dark-muted\"><template x-if=\"item.kind\"><span x-text=\"item.kind\"></span></template><template x-if=\"item.kind && item.path\"><span aria-hidden=\"true\">·</span></template><template x-if=\"item.path\"><code class=\"min-w-0 font-mono text-[11px] text-on-surface dark:text-on-surface-dark\" x-text=\"item.path\"></code></template></div></template></div><template x-if=\"item.section\"><span class=\"shrink-0 rounded-radius border border-outline px-2 py-0.5 text-xs font-medium text-on-surface-muted dark:border-outline-dark dark:text-on-surface-dark-muted\" x-text=\"item.section\"></span></template></div><template x-if=\"item.description\"><p class=\"text-sm leading-6 text-on-surface-muted dark:text-on-surface-dark-muted\" x-html=\"highlight(truncate(item.description))\"></p></template></button></template>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -725,30 +851,30 @@ func searchIcon(classes string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var37 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var37 == nil {
-			templ_7745c5c3_Var37 = templ.NopComponent
+		templ_7745c5c3_Var42 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var42 == nil {
+			templ_7745c5c3_Var42 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var38 = []any{classes}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var38...)
+		var templ_7745c5c3_Var43 = []any{classes}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var43...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" fill=\"none\" stroke-width=\"2\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" fill=\"none\" stroke-width=\"2\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var39 string
-		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var38).String())
+		var templ_7745c5c3_Var44 string
+		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.ResolveAttributeValue(templ.CSSClasses(templ_7745c5c3_Var43).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/search/search.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var39)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var44)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "\" aria-hidden=\"true\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -772,9 +898,9 @@ func searchScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var40 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var40 == nil {
-			templ_7745c5c3_Var40 = templ.NopComponent
+		templ_7745c5c3_Var45 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var45 == nil {
+			templ_7745c5c3_Var45 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = templ.Raw(`<script>
@@ -858,7 +984,22 @@ func searchScript() templ.Component {
 				return String(value);
 			},
 			searchTextForItem: function (item) {
-				return [item.title, item.description, item.section].concat(item.keywords || []).filter(Boolean).join(' ');
+				return [item.title, item.description, item.kind, item.method, item.path, item.section].concat(item.keywords || []).filter(Boolean).join(' ');
+			},
+			methodBadgeClasses: function (method) {
+				switch (this.stringValue(method).trim().toUpperCase()) {
+					case 'GET':
+						return 'border border-primary bg-primary text-on-primary dark:border-primary-dark dark:bg-primary-dark dark:text-on-primary-dark';
+					case 'POST':
+						return 'border border-success bg-success text-on-success';
+					case 'PUT':
+					case 'PATCH':
+						return 'border border-warning bg-warning text-on-warning';
+					case 'DELETE':
+						return 'border border-danger bg-danger text-on-danger';
+					default:
+						return 'border border-outline bg-surface-alt text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark';
+				}
 			},
 			safeHref: function (value) {
 				var href = this.stringValue(value).trim();
@@ -884,6 +1025,9 @@ func searchScript() templ.Component {
 						title: self.stringValue(raw.title !== undefined ? raw.title : raw.Title),
 						description: self.stringValue(raw.description !== undefined ? raw.description : raw.Description),
 						href: self.safeHref(raw.href !== undefined ? raw.href : raw.Href),
+						kind: self.stringValue(raw.kind !== undefined ? raw.kind : raw.Kind),
+						method: self.stringValue(raw.method !== undefined ? raw.method : raw.Method).trim().toUpperCase(),
+						path: self.stringValue(raw.path !== undefined ? raw.path : raw.Path),
 						section: self.stringValue(raw.section !== undefined ? raw.section : raw.Section),
 						keywords: keywords.map(function (keyword) { return self.stringValue(keyword); }),
 						index: index

--- a/components/search/search_test.go
+++ b/components/search/search_test.go
@@ -14,7 +14,7 @@ func TestSearchRendersTriggerKbdAndResults(t *testing.T) {
 		Label:       "Search components",
 		Placeholder: "Search docs...",
 		Items: []Item{
-			{ID: "result-kbd", Title: "KBD", Description: "Keyboard hints", Href: "/components/kbd", Section: "Display", Keywords: []string{"shortcut"}},
+			{ID: "result-kbd", Title: "KBD", Description: "Keyboard hints", Href: "/components/kbd", Kind: "Component", Method: "GET", Path: "/components/kbd", Section: "Display", Keywords: []string{"shortcut"}},
 		},
 	}).Render(context.Background(), &buf)
 	if err != nil {
@@ -32,7 +32,14 @@ func TestSearchRendersTriggerKbdAndResults(t *testing.T) {
 		`data-search-title="KBD"`,
 		`data-search-description="Keyboard hints"`,
 		`data-search-href="/components/kbd"`,
-		`data-search-text="KBD Keyboard hints Display shortcut"`,
+		`data-search-kind="Component"`,
+		`data-search-method="GET"`,
+		`data-search-path="/components/kbd"`,
+		`data-search-text="KBD Keyboard hints Component GET /components/kbd Display shortcut"`,
+		`rounded-radius w-fit font-medium text-[10px] px-1.5 py-0.5 border border-primary bg-primary text-on-primary`,
+		`shrink-0 font-mono font-bold uppercase`,
+		`>GET</span>`,
+		`Component`,
 		`Search docs...`,
 	} {
 		if !strings.Contains(html, want) {
@@ -74,10 +81,27 @@ func TestSearchModalCanLoadResultsFromItemsURL(t *testing.T) {
 		`data-search-source-url="/search.json"`,
 		`<template x-for="(item, index) in visibleResults()"`,
 		`x-bind:id="item.id || null"`,
+		`x-bind:data-search-kind="item.kind || null"`,
+		`x-bind:data-search-method="item.method || null"`,
+		`x-bind:data-search-path="item.path || null"`,
+		`<template x-if="item.method">`,
+		`x-text="item.method"`,
+		`<template x-if="item.kind || item.path">`,
 		`x-on:click="selectResult(item)"`,
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("SearchModal with ItemsURL missing %q in\n%s", want, html)
+		}
+	}
+	for _, want := range []string{
+		`kind: self.stringValue(raw.kind !== undefined ? raw.kind : raw.Kind)`,
+		`method: self.stringValue(raw.method !== undefined ? raw.method : raw.Method).trim().toUpperCase()`,
+		`path: self.stringValue(raw.path !== undefined ? raw.path : raw.Path)`,
+		`item.method`,
+		`item.path`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("SearchModal client normalizer missing %q in\n%s", want, html)
 		}
 	}
 	if strings.Contains(html, "Static result that should not render") || strings.Contains(html, `id="static-result"`) {

--- a/components/search/types.go
+++ b/components/search/types.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/a-h/templ"
+
+	"github.com/araihu/goshtoso/components/badge"
 )
 
 // Item describes one search result rendered by Search.
@@ -17,6 +19,12 @@ type Item struct {
 	Description string
 	// Href turns the result into a link.
 	Href string
+	// Kind is optional type metadata for the result.
+	Kind string
+	// Method is optional method metadata, commonly an HTTP verb.
+	Method string
+	// Path is optional route or resource path metadata.
+	Path string
 	// Section is optional grouping or eyebrow text.
 	Section string
 	// Keywords are extra terms included in client-side filtering.
@@ -161,9 +169,25 @@ func (cfg Config) DialogClasses() string {
 
 // SearchText returns the normalized client-side search corpus for an item.
 func (item Item) SearchText() string {
-	parts := []string{item.Title, item.Description, item.Section}
+	parts := []string{item.Title, item.Description, item.Kind, item.NormalizedMethod(), item.Path, item.Section}
 	parts = append(parts, item.Keywords...)
-	return strings.TrimSpace(strings.Join(parts, " "))
+	return strings.Join(nonEmptySearchTextParts(parts), " ")
+}
+
+// NormalizedMethod returns a display-ready method label.
+func (item Item) NormalizedMethod() string {
+	return strings.ToUpper(strings.TrimSpace(item.Method))
+}
+
+func nonEmptySearchTextParts(parts []string) []string {
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			values = append(values, part)
+		}
+	}
+	return values
 }
 
 // SafeHref returns a navigation target only for schemes that cannot execute
@@ -182,5 +206,20 @@ func (item Item) SafeHref() string {
 		return href
 	default:
 		return ""
+	}
+}
+
+func methodBadgeVariant(method string) badge.Variant {
+	switch strings.ToUpper(strings.TrimSpace(method)) {
+	case "GET":
+		return badge.Primary
+	case "POST":
+		return badge.Success
+	case "PUT", "PATCH":
+		return badge.Warning
+	case "DELETE":
+		return badge.Danger
+	default:
+		return badge.Default
 	}
 }

--- a/site/internal/pages/demo/components/search.templ
+++ b/site/internal/pages/demo/components/search.templ
@@ -24,6 +24,7 @@ templ searchDemoContent() {
     Placeholder: "Search docs...",
     Items: []search.Item{
         {Title: "Sidebar", Description: "Navigation with grouped sections.", Href: "/components/sidebar", Section: "Navigation"},
+        {Title: "List teams", Description: "Operation result with method and route metadata.", Href: "/api/teams", Kind: "Operation", Method: "GET", Path: "/teams", Section: "API"},
         {Title: "KBD", Description: "Semantic keyboard shortcuts.", Href: "/components/kbd", Section: "Display"},
     },
 })`,
@@ -88,6 +89,7 @@ templ searchDefaultPreview() {
 			Placeholder: "Search docs...",
 			Items: []search.Item{
 				{ID: "search-demo-sidebar", Title: "Sidebar", Description: "Navigation with grouped sections and optional search slot.", Href: "/components/sidebar", Section: "Navigation", Keywords: []string{"menu docs"}},
+				{ID: "search-demo-list-teams", Title: "List teams", Description: "Operation result with method and route metadata.", Href: "/api/teams", Kind: "Operation", Method: "GET", Path: "/teams", Section: "API", Keywords: []string{"teams operation"}},
 				{ID: "search-demo-dependencies", Title: "Dependencies", Description: "Local CSS and JavaScript runtime tags.", Href: "/components/dependencies", Section: "Display", Keywords: []string{"head assets runtime"}},
 				{ID: "search-demo-kbd", Title: "KBD", Description: "Semantic keyboard shortcut hints.", Href: "/components/kbd", Section: "Display", Keywords: []string{"shortcut key"}},
 				{ID: "search-demo-text-input", Title: "Text Input", Description: "Inputs with search, password, masks, and validation states.", Href: "/components/text-input", Section: "Form", Keywords: []string{"field"}},

--- a/site/internal/pages/demo/components/search_templ.go
+++ b/site/internal/pages/demo/components/search_templ.go
@@ -80,6 +80,7 @@ func searchDemoContent() templ.Component {
     Placeholder: "Search docs...",
     Items: []search.Item{
         {Title: "Sidebar", Description: "Navigation with grouped sections.", Href: "/components/sidebar", Section: "Navigation"},
+        {Title: "List teams", Description: "Operation result with method and route metadata.", Href: "/api/teams", Kind: "Operation", Method: "GET", Path: "/teams", Section: "API"},
         {Title: "KBD", Description: "Semantic keyboard shortcuts.", Href: "/components/kbd", Section: "Display"},
     },
 })`,
@@ -182,6 +183,7 @@ func searchDefaultPreview() templ.Component {
 			Placeholder: "Search docs...",
 			Items: []search.Item{
 				{ID: "search-demo-sidebar", Title: "Sidebar", Description: "Navigation with grouped sections and optional search slot.", Href: "/components/sidebar", Section: "Navigation", Keywords: []string{"menu docs"}},
+				{ID: "search-demo-list-teams", Title: "List teams", Description: "Operation result with method and route metadata.", Href: "/api/teams", Kind: "Operation", Method: "GET", Path: "/teams", Section: "API", Keywords: []string{"teams operation"}},
 				{ID: "search-demo-dependencies", Title: "Dependencies", Description: "Local CSS and JavaScript runtime tags.", Href: "/components/dependencies", Section: "Display", Keywords: []string{"head assets runtime"}},
 				{ID: "search-demo-kbd", Title: "KBD", Description: "Semantic keyboard shortcut hints.", Href: "/components/kbd", Section: "Display", Keywords: []string{"shortcut key"}},
 				{ID: "search-demo-text-input", Title: "Text Input", Description: "Inputs with search, password, masks, and validation states.", Href: "/components/text-input", Section: "Form", Keywords: []string{"field"}},

--- a/site/internal/server/search_handler.go
+++ b/site/internal/server/search_handler.go
@@ -10,6 +10,9 @@ type searchItemResponse struct {
 	Title       string   `json:"title"`
 	Description string   `json:"description,omitempty"`
 	Href        string   `json:"href,omitempty"`
+	Kind        string   `json:"kind,omitempty"`
+	Method      string   `json:"method,omitempty"`
+	Path        string   `json:"path,omitempty"`
 	Section     string   `json:"section,omitempty"`
 	Keywords    []string `json:"keywords,omitempty"`
 }
@@ -28,6 +31,17 @@ func (s *Server) handleSearchItems(w http.ResponseWriter, r *http.Request) {
 			Href:        "/components/table",
 			Section:     "Remote",
 			Keywords:    []string{"fetched remote json"},
+		},
+		{
+			ID:          "search-remote-list-teams",
+			Title:       "List teams",
+			Description: "Operation result with method and route metadata.",
+			Href:        "/api/teams",
+			Kind:        "Operation",
+			Method:      "GET",
+			Path:        "/teams",
+			Section:     "Remote API",
+			Keywords:    []string{"teams operation"},
 		},
 		{
 			ID:          "search-remote-combobox",

--- a/site/tests/e2e/search_test.go
+++ b/site/tests/e2e/search_test.go
@@ -87,6 +87,18 @@ func TestSearch_ItemsURLFetchesAndFilters(t *testing.T) {
 	visible, err := page.Locator("#remote-search-dialog [data-search-result]:visible").Count()
 	require.NoError(t, err)
 	assert.Equal(t, 1, visible)
+
+	require.NoError(t, input.Fill("teams"))
+	result := page.Locator("#search-remote-list-teams:visible")
+	require.NoError(t, result.WaitFor())
+	assert.NoError(t, result.Locator("text=GET").WaitFor())
+	assert.NoError(t, result.Locator("text=/teams").WaitFor())
+	method, err := result.GetAttribute("data-search-method")
+	require.NoError(t, err)
+	assert.Equal(t, "GET", method)
+	path, err := result.GetAttribute("data-search-path")
+	require.NoError(t, err)
+	assert.Equal(t, "/teams", path)
 }
 
 func TestSidebarSearch_UsesKbdAndNavigates(t *testing.T) {


### PR DESCRIPTION
## Summary
- add optional `Kind`, `Method`, and `Path` metadata to search result items
- render method badges plus kind/path metadata for static and remote search results
- update search demos and generated Goshtoso skill references

## Test Plan
- [x] `templ generate`
- [x] `just css`
- [x] `go run ./cmd/skillgen`
- [x] `go test ./components/search -count=1`
- [x] `go test ./... -count=1`
- [x] `go build -o bin/server ./site/cmd/server`
- [x] `cd site && go test $(go list ./... | grep -v /tests/e2e) -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results now show Kind, Method, and Path; Method is shown as a color-coded badge and Path as monospace
  * Search filtering includes Kind/Method/Path for more precise matches
* **Documentation**
  * Component reference and demo updated to reflect the new result metadata and a sample "List teams" item
* **Tests**
  * E2E and unit tests updated to cover rendering and filtering of the new metadata
<!-- end of auto-generated comment: release notes by coderabbit.ai -->