### PR TITLE
docs: improve component examples and API references

### DIFF
--- a/docs/COMPONENT_DOCS_AUDIT.md
+++ b/docs/COMPONENT_DOCS_AUDIT.md
@@ -1,0 +1,58 @@
+# Component Docs Audit
+
+Date: 2026-07-02
+
+This audit tracks component demo pages that lag behind the current Goshtoso
+documentation pattern: one preview and one code block per variant, followed by
+a standalone `demo.APIReference` outside the fragment wrapper. The goal is to
+make the site useful for first-time evaluation and returning API lookup without
+turning component pages into marketing copy.
+
+## Starting Findings
+
+1. `codeblock`: API props were embedded in `ComponentDemoProps` instead of a
+   standalone `demo.APIReference`.
+2. `steps`: API props were embedded in `ComponentDemoProps` instead of a
+   standalone `demo.APIReference`.
+3. `palette`: the API table omitted `LazyWhen`, and the examples did not explain
+   the lazy-rendering path used inside dropdown shells. The page also had too few
+   practical variants for a broad color-picker component.
+4. `drawer`: examples covered right and left placement, but not persistent
+   dismissal behavior or HTMX body targeting/open triggers.
+5. `tooltip`: the API table had a stale duplicate `Trigger` row where
+   `TriggerMode` should have been documented.
+6. `toast`: the API table omitted server-rendered action toasts via
+   `ActionLabel` and `ActionHTMX`.
+7. `select`: the page demonstrated Alpine and large lists, but shell-mode fields
+   (`Shell`, `TriggerLeading`, `ValueExpr`, `TriggerLabel`) needed clearer
+   standalone documentation.
+8. `table`: the API reference compressed infinite-scroll behavior; it needed to
+   surface `PaginationConfig.ContainerHeight` and the default page-scroll model.
+
+## Completed Work
+
+- Move CodeBlock and Steps API docs into standalone `demo.APIReference` tables.
+- Add the missing Palette, Tooltip, and Toast API rows.
+- Add Palette examples for restricted brand hues and compact required-field
+  pickers.
+- Add Drawer examples for persistent drawers and HTMX-targeted drawer bodies.
+- Add a Select shell-mode section and API rows.
+- Expand the Table API table with nested pagination, infinite-scroll, and filter
+  HTMX fields.
+- Regenerate templ output for every edited `.templ` page.
+
+## Verification
+
+- `templ generate`
+- `go test ./components/codeblock ./components/steps ./components/palette ./components/drawer ./components/tooltip ./components/toast ./components/select ./components/table -count=1`
+- `cd site && go test ./internal/pages/demo/components -count=1`
+- Structural docs scan: no component demo pages missing a standalone
+  `demo.APIReference`, and no remaining broad weak-docs signals from the audit
+  heuristic.
+- `git diff --check`
+
+## Future Polish
+
+- Consider splitting Table's single API reference into grouped sections for
+  columns, rows, pagination, filters, and HTMX behavior if the page gets a
+  dedicated reference-layout component.

--- a/site/internal/pages/demo/components/codeblock.templ
+++ b/site/internal/pages/demo/components/codeblock.templ
@@ -11,20 +11,14 @@ templ CodeBlockDemoPage() {
 }
 
 templ codeBlockDemoContent() {
-	@demo.ComponentDemo(
-		demo.ComponentDemoProps{
-			Title:         "Code Block",
-			Description:   "Syntax-highlighted code block rendered server-side via Chroma. Reacts to the active theme and dark mode. Includes a copy-to-clipboard button.",
-			Props: []demo.PropDoc{
-				{Name: "Language", Type: "string", Default: `""`, Description: `Chroma lexer key (e.g. "go", "css", "html", "bash"). "templ" aliases to Go. Unknown values fall back to plain text.`},
-				{Name: "Code", Type: "string", Default: `""`, Description: "Source code to render. Passed verbatim to the highlighter."},
-				{Name: "Label", Type: "string", Default: "Language", Description: "Header label. Defaults to the Language value when empty."},
-				{Name: "MaxHeight", Type: "string", Default: `""`, Description: "Optional CSS max-height (e.g. \"300px\") that enables vertical scroll inside the block."},
-				{Name: "ID", Type: "string", Default: "auto", Description: "Override the auto-generated element ID. Used by the copy handler to read textContent."},
+	<div id="codeblock-fragment">
+		@demo.ComponentDemo(
+			demo.ComponentDemoProps{
+				Title:       "Code Block",
+				Description: "Syntax-highlighted code rendered server-side with Chroma. It follows the active theme, includes an accessible copy button, and falls back to plain text when a lexer is unknown.",
 			},
-		},
-		codeBlockDemoPreview(),
-		`@codeblock.CodeBlock(codeblock.Config{
+			codeBlockDemoPreview(),
+			`@codeblock.CodeBlock(codeblock.Config{
     Language: "go",
     Label:    "Hello",
     Code:     `+"`"+`package main
@@ -33,57 +27,61 @@ func main() {
     fmt.Println("hello, world")
 }`+"`"+`,
 })`,
-	)
-
-	@demo.DemoSection(
-		demo.DemoSectionProps{
-			Title:       "HTML",
-			Description: "Tag names render pink; attribute names render purple; quoted values render blue.",
-		},
-		codeBlockHTMLPreview(),
-		`@codeblock.CodeBlock(codeblock.Config{
+		)
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "HTML",
+				Description: "Use Language: \"html\" for templates, fragments, and Alpine/HTMX snippets.",
+			},
+			codeBlockHTMLPreview(),
+			`@codeblock.CodeBlock(codeblock.Config{
     Language: "html",
     Code:     `+"`"+`<button x-data="{open:false}" @click="open=!open" class="btn">Toggle</button>`+"`"+`,
 })`,
-	)
-
-	@demo.DemoSection(
-		demo.DemoSectionProps{
-			Title:       "CSS",
-			Description: "Selectors, properties, and values all share the palette.",
-		},
-		codeBlockCSSPreview(),
-		`@codeblock.CodeBlock(codeblock.Config{
+		)
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "CSS",
+				Description: "CSS snippets use the same highlighted shell, so theme token examples stay readable in light and dark mode.",
+			},
+			codeBlockCSSPreview(),
+			`@codeblock.CodeBlock(codeblock.Config{
     Language: "css",
     Code:     `+"`"+`.btn { color: var(--color-primary); padding: 0.5rem 1rem; }`+"`"+`,
 })`,
-	)
-
-	@demo.DemoSection(
-		demo.DemoSectionProps{
-			Title:       "Bash",
-			Description: "Built-in commands and flags use the keyword palette; quoted strings use the literal palette.",
-		},
-		codeBlockBashPreview(),
-		`@codeblock.CodeBlock(codeblock.Config{
+		)
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Bash",
+				Description: "Command snippets can set a short Label when the language name is not specific enough.",
+			},
+			codeBlockBashPreview(),
+			`@codeblock.CodeBlock(codeblock.Config{
     Language: "bash",
     Label:    "Install",
     Code:     "go get github.com/a-h/templ",
 })`,
-	)
-
-	@demo.DemoSection(
-		demo.DemoSectionProps{
-			Title:       "Scrollable (MaxHeight)",
-			Description: "Long snippets stay contained when MaxHeight is set.",
-		},
-		codeBlockScrollPreview(),
-		`@codeblock.CodeBlock(codeblock.Config{
+		)
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Scrollable",
+				Description: "Set MaxHeight for long snippets that should scroll inside the code panel instead of pushing the page apart.",
+			},
+			codeBlockScrollPreview(),
+			`@codeblock.CodeBlock(codeblock.Config{
     Language:  "go",
     MaxHeight: "180px",
     Code:      longGoSnippet,
 })`,
-	)
+		)
+	</div>
+	@demo.APIReference([]demo.PropDoc{
+		{Name: "Language", Type: "string", Default: `""`, Description: `Chroma lexer key such as "go", "css", "html", or "bash"; "templ" aliases to Go and unknown values render as plain text.`},
+		{Name: "Code", Type: "string", Default: `""`, Description: "Source code to display and copy."},
+		{Name: "Label", Type: "string", Default: "Language", Description: "Header label; defaults to the resolved language when empty."},
+		{Name: "MaxHeight", Type: "string", Default: `""`, Description: `Optional CSS max-height such as "300px"; enables vertical scrolling inside the code body.`},
+		{Name: "ID", Type: "string", Default: "auto", Description: "Optional code element id; otherwise generated from the label, language, and code content for copy-button targeting."},
+	})
 }
 
 templ codeBlockDemoPreview() {

--- a/site/internal/pages/demo/components/codeblock_templ.go
+++ b/site/internal/pages/demo/components/codeblock_templ.go
@@ -64,17 +64,14 @@ func codeBlockDemoContent() templ.Component {
 			templ_7745c5c3_Var2 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"codeblock-fragment\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Code Block",
-				Description: "Syntax-highlighted code block rendered server-side via Chroma. Reacts to the active theme and dark mode. Includes a copy-to-clipboard button.",
-				Props: []demo.PropDoc{
-					{Name: "Language", Type: "string", Default: `""`, Description: `Chroma lexer key (e.g. "go", "css", "html", "bash"). "templ" aliases to Go. Unknown values fall back to plain text.`},
-					{Name: "Code", Type: "string", Default: `""`, Description: "Source code to render. Passed verbatim to the highlighter."},
-					{Name: "Label", Type: "string", Default: "Language", Description: "Header label. Defaults to the Language value when empty."},
-					{Name: "MaxHeight", Type: "string", Default: `""`, Description: "Optional CSS max-height (e.g. \"300px\") that enables vertical scroll inside the block."},
-					{Name: "ID", Type: "string", Default: "auto", Description: "Override the auto-generated element ID. Used by the copy handler to read textContent."},
-				},
+				Description: "Syntax-highlighted code rendered server-side with Chroma. It follows the active theme, includes an accessible copy button, and falls back to plain text when a lexer is unknown.",
 			},
 			codeBlockDemoPreview(),
 			`@codeblock.CodeBlock(codeblock.Config{
@@ -93,7 +90,7 @@ func main() {
 		templ_7745c5c3_Err = demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "HTML",
-				Description: "Tag names render pink; attribute names render purple; quoted values render blue.",
+				Description: "Use Language: \"html\" for templates, fragments, and Alpine/HTMX snippets.",
 			},
 			codeBlockHTMLPreview(),
 			`@codeblock.CodeBlock(codeblock.Config{
@@ -107,7 +104,7 @@ func main() {
 		templ_7745c5c3_Err = demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "CSS",
-				Description: "Selectors, properties, and values all share the palette.",
+				Description: "CSS snippets use the same highlighted shell, so theme token examples stay readable in light and dark mode.",
 			},
 			codeBlockCSSPreview(),
 			`@codeblock.CodeBlock(codeblock.Config{
@@ -121,7 +118,7 @@ func main() {
 		templ_7745c5c3_Err = demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Bash",
-				Description: "Built-in commands and flags use the keyword palette; quoted strings use the literal palette.",
+				Description: "Command snippets can set a short Label when the language name is not specific enough.",
 			},
 			codeBlockBashPreview(),
 			`@codeblock.CodeBlock(codeblock.Config{
@@ -135,8 +132,8 @@ func main() {
 		}
 		templ_7745c5c3_Err = demo.DemoSection(
 			demo.DemoSectionProps{
-				Title:       "Scrollable (MaxHeight)",
-				Description: "Long snippets stay contained when MaxHeight is set.",
+				Title:       "Scrollable",
+				Description: "Set MaxHeight for long snippets that should scroll inside the code panel instead of pushing the page apart.",
 			},
 			codeBlockScrollPreview(),
 			`@codeblock.CodeBlock(codeblock.Config{
@@ -145,6 +142,20 @@ func main() {
     Code:      longGoSnippet,
 })`,
 		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "Language", Type: "string", Default: `""`, Description: `Chroma lexer key such as "go", "css", "html", or "bash"; "templ" aliases to Go and unknown values render as plain text.`},
+			{Name: "Code", Type: "string", Default: `""`, Description: "Source code to display and copy."},
+			{Name: "Label", Type: "string", Default: "Language", Description: "Header label; defaults to the resolved language when empty."},
+			{Name: "MaxHeight", Type: "string", Default: `""`, Description: `Optional CSS max-height such as "300px"; enables vertical scrolling inside the code body.`},
+			{Name: "ID", Type: "string", Default: "auto", Description: "Optional code element id; otherwise generated from the label, language, and code content for copy-button targeting."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -173,7 +184,7 @@ func codeBlockDemoPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"w-full max-w-3xl mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"w-full max-w-3xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -191,7 +202,7 @@ func main() {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -220,7 +231,7 @@ func codeBlockHTMLPreview() templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"w-full max-w-3xl mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"w-full max-w-3xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -231,7 +242,7 @@ func codeBlockHTMLPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -260,7 +271,7 @@ func codeBlockCSSPreview() templ.Component {
 			templ_7745c5c3_Var5 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"w-full max-w-3xl mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"w-full max-w-3xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -275,7 +286,7 @@ func codeBlockCSSPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -304,7 +315,7 @@ func codeBlockBashPreview() templ.Component {
 			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"w-full max-w-3xl mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"w-full max-w-3xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -316,7 +327,7 @@ func codeBlockBashPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -345,7 +356,7 @@ func codeBlockScrollPreview() templ.Component {
 			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div class=\"w-full max-w-3xl mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"w-full max-w-3xl mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -379,7 +390,7 @@ func main() {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/pages/demo/components/drawer.templ
+++ b/site/internal/pages/demo/components/drawer.templ
@@ -42,8 +42,45 @@ templ drawerDemoContent() {
 }) {
     <div id="filtersDrawer-body">...</div>
 }`,
-		)
-	</div>
+			)
+
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Persistent Drawer",
+					Description: "Set Persistent: true when the drawer hosts an unfinished form or confirmation flow. The close button still works, but backdrop clicks and Escape do not dismiss it.",
+				},
+				drawerPersistentPreview(),
+				`@drawer.Drawer(drawer.Config{
+    ID:         "editProfile",
+    Title:      "Edit profile",
+    Persistent: true,
+}) {
+    <form id="editProfile-body">...</form>
+}`,
+			)
+
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "HTMX Body Target",
+					Description: "Give BodyID a stable value so HTMX responses can replace only the drawer body, then open the drawer with a drawer:open event or HX-Trigger header.",
+				},
+				drawerHTMXPreview(),
+				`@drawer.Drawer(drawer.Config{
+    ID:     "orderDrawer",
+    Title:  "Order details",
+    BodyID: "orderDrawerBody",
+}) {
+    <div id="orderDrawerBody">Select an order.</div>
+}
+
+<button
+    hx-get="/orders/42/drawer"
+    hx-target="#orderDrawerBody"
+    x-on:click="$dispatch('drawer:open', { id: 'orderDrawer' })">
+    View order
+</button>`,
+			)
+		</div>
 	@demo.APIReference([]demo.PropDoc{
 		{Name: "ID", Type: "string", Default: `""`, Description: "Unique drawer id used for Alpine state, events, body id, and aria-labelledby wiring."},
 		{Name: "Title", Type: "string", Default: `""`, Description: "Accessible drawer heading."},
@@ -110,6 +147,62 @@ templ drawerLeftPreview() {
 					<input type="checkbox" class="size-4 rounded border-outline text-primary dark:border-outline-dark"/>
 					<span>Needs attention</span>
 				</label>
+			</div>
+		}
+	</div>
+}
+
+templ drawerPersistentPreview() {
+	<div id="drawer-persistent" class="w-full max-w-2xl mx-auto">
+		<button
+			type="button"
+			x-data
+			x-on:click="$dispatch('drawer:open', { id: 'editProfile' })"
+			class="inline-flex items-center justify-center rounded-radius border border-outline px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:text-on-surface-dark dark:hover:bg-surface-dark-alt"
+		>
+			Open persistent drawer
+		</button>
+		@drawer.Drawer(drawer.Config{
+			ID:         "editProfile",
+			Title:      "Edit profile",
+			Persistent: true,
+		}) {
+			<form class="space-y-4 p-4">
+				<div>
+					<label for="drawer-name" class="text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong">Display name</label>
+					<input id="drawer-name" name="name" value="Goshtoso" class="mt-1 w-full rounded-radius border border-outline bg-surface px-3 py-2 text-sm text-on-surface dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark"/>
+				</div>
+				<p class="text-sm text-on-surface-muted dark:text-on-surface-dark-muted">Backdrop clicks and Escape are ignored while this form is open.</p>
+			</form>
+		}
+	</div>
+}
+
+templ drawerHTMXPreview() {
+	<div id="drawer-htmx" class="w-full max-w-2xl mx-auto">
+		<button
+			type="button"
+			x-data
+			x-on:click="$dispatch('drawer:open', { id: 'orderDrawer' })"
+			class="inline-flex items-center justify-center rounded-radius bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:bg-primary-dark dark:text-on-primary-dark dark:hover:bg-primary-dark/90"
+		>
+			Open order drawer
+		</button>
+		@drawer.Drawer(drawer.Config{
+			ID:     "orderDrawer",
+			Title:  "Order details",
+			BodyID: "orderDrawerBody",
+			Width:  drawer.WidthLG,
+		}) {
+			<div id="orderDrawerBody" class="space-y-4 p-4">
+				<div>
+					<p class="text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong">Order #42</p>
+					<p class="mt-1 text-sm text-on-surface-muted dark:text-on-surface-dark-muted">This body has a stable id so an HTMX response can replace only the drawer content.</p>
+				</div>
+				<div class="rounded-radius border border-outline p-3 text-sm dark:border-outline-dark">
+					<p class="font-medium">Swap target</p>
+					<p class="mt-1 font-mono text-xs text-on-surface-muted dark:text-on-surface-dark-muted">#orderDrawerBody</p>
+				</div>
 			</div>
 		}
 	</div>

--- a/site/internal/pages/demo/components/drawer_templ.go
+++ b/site/internal/pages/demo/components/drawer_templ.go
@@ -104,6 +104,47 @@ func drawerDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Persistent Drawer",
+				Description: "Set Persistent: true when the drawer hosts an unfinished form or confirmation flow. The close button still works, but backdrop clicks and Escape do not dismiss it.",
+			},
+			drawerPersistentPreview(),
+			`@drawer.Drawer(drawer.Config{
+    ID:         "editProfile",
+    Title:      "Edit profile",
+    Persistent: true,
+}) {
+    <form id="editProfile-body">...</form>
+}`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "HTMX Body Target",
+				Description: "Give BodyID a stable value so HTMX responses can replace only the drawer body, then open the drawer with a drawer:open event or HX-Trigger header.",
+			},
+			drawerHTMXPreview(),
+			`@drawer.Drawer(drawer.Config{
+    ID:     "orderDrawer",
+    Title:  "Order details",
+    BodyID: "orderDrawerBody",
+}) {
+    <div id="orderDrawerBody">Select an order.</div>
+}
+
+<button
+    hx-get="/orders/42/drawer"
+    hx-target="#orderDrawerBody"
+    x-on:click="$dispatch('drawer:open', { id: 'orderDrawer' })">
+    View order
+</button>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -237,6 +278,125 @@ func drawerLeftPreview() templ.Component {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func drawerPersistentPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"drawer-persistent\" class=\"w-full max-w-2xl mx-auto\"><button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'editProfile' })\" class=\"inline-flex items-center justify-center rounded-radius border border-outline px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:text-on-surface-dark dark:hover:bg-surface-dark-alt\">Open persistent drawer</button>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var8 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<form class=\"space-y-4 p-4\"><div><label for=\"drawer-name\" class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Display name</label> <input id=\"drawer-name\" name=\"name\" value=\"Goshtoso\" class=\"mt-1 w-full rounded-radius border border-outline bg-surface px-3 py-2 text-sm text-on-surface dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark\"></div><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Backdrop clicks and Escape are ignored while this form is open.</p></form>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = drawer.Drawer(drawer.Config{
+			ID:         "editProfile",
+			Title:      "Edit profile",
+			Persistent: true,
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var8), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func drawerHTMXPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div id=\"drawer-htmx\" class=\"w-full max-w-2xl mx-auto\"><button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'orderDrawer' })\" class=\"inline-flex items-center justify-center rounded-radius bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:bg-primary-dark dark:text-on-primary-dark dark:hover:bg-primary-dark/90\">Open order drawer</button>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var10 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"orderDrawerBody\" class=\"space-y-4 p-4\"><div><p class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Order #42</p><p class=\"mt-1 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">This body has a stable id so an HTMX response can replace only the drawer content.</p></div><div class=\"rounded-radius border border-outline p-3 text-sm dark:border-outline-dark\"><p class=\"font-medium\">Swap target</p><p class=\"mt-1 font-mono text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">#orderDrawerBody</p></div></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = drawer.Drawer(drawer.Config{
+			ID:     "orderDrawer",
+			Title:  "Order details",
+			BodyID: "orderDrawerBody",
+			Width:  drawer.WidthLG,
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/pages/demo/components/palette.templ
+++ b/site/internal/pages/demo/components/palette.templ
@@ -32,11 +32,10 @@ templ paletteDemoContent() {
     <p>Selected: <span x-text="picked || '—'"></span></p>
 </div>`,
 			)
-
 			@demo.DemoSection(
 				demo.DemoSectionProps{
 					Title:       "Inside a Select Shell",
-					Description: "Host the palette inside a Select with Shell: true; the trigger label reflects the picked value via ValueExpr.",
+					Description: "Host the palette inside a Select with Shell: true; the trigger label reflects the picked value via ValueExpr. Add LazyWhen when the full swatch grid should render only after the shell opens.",
 				},
 				paletteShellPreview(),
 				`<div x-data="{ shellPicked: '' }">
@@ -49,10 +48,37 @@ templ paletteDemoContent() {
         @palette.Palette(palette.Config{
             ID:          "demo-shell-palette",
             Alpine: &palette.AlpineConfig{Model: "shellPicked"},
+            LazyWhen:    "isOpen",
             ShowHex:     true,
         })
     }
 </div>`,
+			)
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Restricted Hues",
+					Description: "Pass Hues and Shades when a workflow should offer only approved brand choices instead of the full Tailwind palette.",
+				},
+				paletteRestrictedPreview(),
+				`@palette.Palette(palette.Config{
+    ID:     "brand-palette",
+    Hues:   []string{"purple", "sky", "teal"},
+    Shades: []string{"300", "500", "700"},
+})`,
+			)
+			@demo.DemoSection(
+				demo.DemoSectionProps{
+					Title:       "Compact Picker",
+					Description: "HideNeutral and HideReset trim the control for required color fields where white, black, and clearing the value are not valid choices.",
+				},
+				paletteCompactPreview(),
+				`@palette.Palette(palette.Config{
+    ID:          "compact-palette",
+    Hues:        []string{"red", "amber", "green", "blue"},
+    Shades:      []string{"400", "600"},
+    HideNeutral: true,
+    HideReset:   true,
+})`,
 			)
 		</div>
 		@demo.APIReference([]demo.PropDoc{
@@ -64,6 +90,7 @@ templ paletteDemoContent() {
 			{Name: "HideReset", Type: "bool", Default: "false", Description: "Hide the reset/clear control."},
 			{Name: "ShowHex", Type: "bool", Default: "false", Description: "Show the hex value of the hovered/selected swatch."},
 			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the palette container."},
+			{Name: "LazyWhen", Type: "string", Default: `""`, Description: "Alpine expression that delays swatch-grid rendering until truthy; useful inside Select shells with an open state."},
 		})
 	</div>
 }
@@ -73,9 +100,9 @@ templ paletteStandalonePreview() {
 	<div id="palette-standalone" class="w-full max-w-md mx-auto">
 		<div class="rounded-radius border border-outline dark:border-outline-dark">
 			@palette.Palette(palette.Config{
-				ID:          "demo-palette",
-				Alpine: &palette.AlpineConfig{Model: "picked"},
-				ShowHex:     true,
+				ID:      "demo-palette",
+				Alpine:  &palette.AlpineConfig{Model: "picked"},
+				ShowHex: true,
 			})
 		</div>
 		<p class="mt-3 text-sm text-on-surface-muted dark:text-on-surface-dark-muted">Selected: <span x-text="picked || '—'"></span></p>
@@ -92,11 +119,40 @@ templ paletteShellPreview() {
 			ValueExpr:      "shellPicked || 'Pick a color'",
 		}) {
 			@palette.Palette(palette.Config{
-				ID:          "demo-shell-palette",
-				Alpine: &palette.AlpineConfig{Model: "shellPicked"},
-				ShowHex:     true,
+				ID:       "demo-shell-palette",
+				Alpine:   &palette.AlpineConfig{Model: "shellPicked"},
+				LazyWhen: "isOpen",
+				ShowHex:  true,
 			})
 		}
+	</div>
+}
+
+// paletteRestrictedPreview renders a curated brand-color subset.
+templ paletteRestrictedPreview() {
+	<div id="palette-restricted" class="w-full max-w-sm mx-auto">
+		<div class="rounded-radius border border-outline dark:border-outline-dark">
+			@palette.Palette(palette.Config{
+				ID:     "brand-palette",
+				Hues:   []string{"purple", "sky", "teal"},
+				Shades: []string{"300", "500", "700"},
+			})
+		</div>
+	</div>
+}
+
+// paletteCompactPreview renders a required-field palette without neutral/reset choices.
+templ paletteCompactPreview() {
+	<div id="palette-compact" class="w-full max-w-xs mx-auto">
+		<div class="rounded-radius border border-outline dark:border-outline-dark">
+			@palette.Palette(palette.Config{
+				ID:          "compact-palette",
+				Hues:        []string{"red", "amber", "green", "blue"},
+				Shades:      []string{"400", "600"},
+				HideNeutral: true,
+				HideReset:   true,
+			})
+		</div>
 	</div>
 }
 

--- a/site/internal/pages/demo/components/palette_templ.go
+++ b/site/internal/pages/demo/components/palette_templ.go
@@ -93,7 +93,7 @@ func paletteDemoContent() templ.Component {
 		templ_7745c5c3_Err = demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Inside a Select Shell",
-				Description: "Host the palette inside a Select with Shell: true; the trigger label reflects the picked value via ValueExpr.",
+				Description: "Host the palette inside a Select with Shell: true; the trigger label reflects the picked value via ValueExpr. Add LazyWhen when the full swatch grid should render only after the shell opens.",
 			},
 			paletteShellPreview(),
 			`<div x-data="{ shellPicked: '' }">
@@ -106,10 +106,43 @@ func paletteDemoContent() templ.Component {
         @palette.Palette(palette.Config{
             ID:          "demo-shell-palette",
             Alpine: &palette.AlpineConfig{Model: "shellPicked"},
+            LazyWhen:    "isOpen",
             ShowHex:     true,
         })
     }
 </div>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Restricted Hues",
+				Description: "Pass Hues and Shades when a workflow should offer only approved brand choices instead of the full Tailwind palette.",
+			},
+			paletteRestrictedPreview(),
+			`@palette.Palette(palette.Config{
+    ID:     "brand-palette",
+    Hues:   []string{"purple", "sky", "teal"},
+    Shades: []string{"300", "500", "700"},
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Compact Picker",
+				Description: "HideNeutral and HideReset trim the control for required color fields where white, black, and clearing the value are not valid choices.",
+			},
+			paletteCompactPreview(),
+			`@palette.Palette(palette.Config{
+    ID:          "compact-palette",
+    Hues:        []string{"red", "amber", "green", "blue"},
+    Shades:      []string{"400", "600"},
+    HideNeutral: true,
+    HideReset:   true,
+})`,
 		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -127,6 +160,7 @@ func paletteDemoContent() templ.Component {
 			{Name: "HideReset", Type: "bool", Default: "false", Description: "Hide the reset/clear control."},
 			{Name: "ShowHex", Type: "bool", Default: "false", Description: "Show the hex value of the hovered/selected swatch."},
 			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the palette container."},
+			{Name: "LazyWhen", Type: "string", Default: `""`, Description: "Alpine expression that delays swatch-grid rendering until truthy; useful inside Select shells with an open state."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -220,9 +254,10 @@ func paletteShellPreview() templ.Component {
 			}
 			ctx = templ.InitializeContext(ctx)
 			templ_7745c5c3_Err = palette.Palette(palette.Config{
-				ID:      "demo-shell-palette",
-				Alpine:  &palette.AlpineConfig{Model: "shellPicked"},
-				ShowHex: true,
+				ID:       "demo-shell-palette",
+				Alpine:   &palette.AlpineConfig{Model: "shellPicked"},
+				LazyWhen: "isOpen",
+				ShowHex:  true,
 			}).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -246,7 +281,8 @@ func paletteShellPreview() templ.Component {
 	})
 }
 
-func paletteShellTriggerSwatch() templ.Component {
+// paletteRestrictedPreview renders a curated brand-color subset.
+func paletteRestrictedPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -267,7 +303,92 @@ func paletteShellTriggerSwatch() templ.Component {
 			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<span data-shell-selected-preview aria-hidden=\"true\" class=\"size-4 shrink-0 rounded-sm border border-outline bg-surface shadow-sm dark:border-outline-dark dark:bg-surface-dark\" x-bind:style=\"{ backgroundColor: shellPicked ? (shellPicked[0] === '#' ? shellPicked : (shellPicked === 'white' || shellPicked === 'black' ? shellPicked : 'var(--color-' + shellPicked + ')')) : 'transparent' }\"></span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div id=\"palette-restricted\" class=\"w-full max-w-sm mx-auto\"><div class=\"rounded-radius border border-outline dark:border-outline-dark\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = palette.Palette(palette.Config{
+			ID:     "brand-palette",
+			Hues:   []string{"purple", "sky", "teal"},
+			Shades: []string{"300", "500", "700"},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// paletteCompactPreview renders a required-field palette without neutral/reset choices.
+func paletteCompactPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div id=\"palette-compact\" class=\"w-full max-w-xs mx-auto\"><div class=\"rounded-radius border border-outline dark:border-outline-dark\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = palette.Palette(palette.Config{
+			ID:          "compact-palette",
+			Hues:        []string{"red", "amber", "green", "blue"},
+			Shades:      []string{"400", "600"},
+			HideNeutral: true,
+			HideReset:   true,
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func paletteShellTriggerSwatch() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<span data-shell-selected-preview aria-hidden=\"true\" class=\"size-4 shrink-0 rounded-sm border border-outline bg-surface shadow-sm dark:border-outline-dark dark:bg-surface-dark\" x-bind:style=\"{ backgroundColor: shellPicked ? (shellPicked[0] === '#' ? shellPicked : (shellPicked === 'white' || shellPicked === 'black' ? shellPicked : 'var(--color-' + shellPicked + ')')) : 'transparent' }\"></span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/pages/demo/components/select.templ
+++ b/site/internal/pages/demo/components/select.templ
@@ -32,7 +32,6 @@ templ selectDemoContent() {
     },
 })`,
 		)
-
 		@demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Error State",
@@ -48,7 +47,6 @@ templ selectDemoContent() {
     Options:    options,
 })`,
 		)
-
 		@demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Success State",
@@ -66,7 +64,6 @@ templ selectDemoContent() {
     },
 })`,
 		)
-
 		@demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Large List",
@@ -81,7 +78,6 @@ templ selectDemoContent() {
     Options:      countryOptions(),
 })`,
 		)
-
 		@demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Dependent Selects (Alpine.js)",
@@ -93,7 +89,6 @@ templ selectDemoContent() {
     @selectfield.Select(selectfield.Config{ID: "year", Alpine: &selectfield.AlpineConfig{Model: "secondValue", BindDisabled: "!firstValue"}, Options: years})
 </div>`,
 		)
-
 		@demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Disabled",
@@ -108,7 +103,6 @@ templ selectDemoContent() {
     Options:  options,
 })`,
 		)
-
 		@demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Readonly",
@@ -122,6 +116,25 @@ templ selectDemoContent() {
     Readonly: true,
     Options:  options,
 })`,
+		)
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Shell Mode",
+				Description: "Set Shell: true when Select should provide trigger and dropdown chrome while custom templ children own the value. Use ValueExpr for the trigger text and dispatch select-close after a pick.",
+			},
+			selectShellPreview(),
+			`<div x-data="{ access: 'Viewer' }">
+    @selectfield.Select(selectfield.Config{
+        ID:           "access-shell",
+        Label:        "Access level",
+        Shell:        true,
+        TriggerLabel: "Role",
+        ValueExpr:    "access",
+    }) {
+        <button type="button" x-on:click="access = 'Admin'; $dispatch('select-close')">Admin</button>
+        <button type="button" x-on:click="access = 'Viewer'; $dispatch('select-close')">Viewer</button>
+    }
+</div>`,
 		)
 	</div>
 	// API reference lives outside #select-fragment.
@@ -139,6 +152,10 @@ templ selectDemoContent() {
 		{Name: "Alpine", Type: "*AlpineConfig", Default: "nil", Description: "Client-side Alpine bindings (Model, BindDisabled)."},
 		{Name: "InputAttrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the select."},
 		{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+		{Name: "Shell", Type: "bool", Default: "false", Description: "Render only the trigger/dropdown shell and use child content as the dropdown body."},
+		{Name: "TriggerLeading", Type: "templ.Component", Default: "nil", Description: "Optional component rendered before the trigger text, such as a swatch or icon."},
+		{Name: "ValueExpr", Type: "string", Default: `""`, Description: "Alpine expression used for shell-mode trigger text and aria-label."},
+		{Name: "TriggerLabel", Type: "string", Default: `""`, Description: "Static label shown on the left side of a shell trigger, with ValueExpr rendered muted on the right."},
 	})
 }
 
@@ -156,7 +173,6 @@ templ selectDefaultPreview() {
 			},
 		})
 	</div>
-
 }
 
 // selectErrorPreview renders the error-state select.
@@ -164,18 +180,17 @@ templ selectErrorPreview() {
 	<div id="select-error" class="w-full max-w-xs mx-auto">
 		@selectfield.Select(selectfield.Config{
 			ID:         "os-error",
-				Name:       "os-error",
-				Label:      "Operating System",
-				State:      selectfield.StateError,
-				HelperText: "Error: Please select an operating system",
-				Options: []selectfield.Option{
-					{Value: "mac", Label: "Mac"},
-					{Value: "windows", Label: "Windows"},
-					{Value: "linux", Label: "Linux"},
-				},
-			})
-		</div>
-
+			Name:       "os-error",
+			Label:      "Operating System",
+			State:      selectfield.StateError,
+			HelperText: "Error: Please select an operating system",
+			Options: []selectfield.Option{
+				{Value: "mac", Label: "Mac"},
+				{Value: "windows", Label: "Windows"},
+				{Value: "linux", Label: "Linux"},
+			},
+		})
+	</div>
 }
 
 // selectSuccessPreview renders the success-state select.
@@ -183,17 +198,16 @@ templ selectSuccessPreview() {
 	<div id="select-success" class="w-full max-w-xs mx-auto">
 		@selectfield.Select(selectfield.Config{
 			ID:    "os-success",
-				Name:  "os-success",
-				Label: "Operating System",
-				State: selectfield.StateSuccess,
-				Options: []selectfield.Option{
-					{Value: "mac", Label: "Mac", Selected: true},
-					{Value: "windows", Label: "Windows"},
-					{Value: "linux", Label: "Linux"},
-				},
-			})
-		</div>
-
+			Name:  "os-success",
+			Label: "Operating System",
+			State: selectfield.StateSuccess,
+			Options: []selectfield.Option{
+				{Value: "mac", Label: "Mac", Selected: true},
+				{Value: "windows", Label: "Windows"},
+				{Value: "linux", Label: "Linux"},
+			},
+		})
+	</div>
 }
 
 // selectCountryPreview renders a select with a large option list.
@@ -201,50 +215,48 @@ templ selectCountryPreview() {
 	<div id="select-country" class="w-full max-w-xs mx-auto">
 		@selectfield.Select(selectfield.Config{
 			ID:           "country",
-				Name:         "country",
-				Label:        "Country",
-				Autocomplete: "country",
-				Options:      countryOptions(),
-			})
-		</div>
-
+			Name:         "country",
+			Label:        "Country",
+			Autocomplete: "country",
+			Options:      countryOptions(),
+		})
+	</div>
 }
 
 // selectDependentPreview renders the Alpine-bound dependent selects.
 templ selectDependentPreview() {
 	<div id="select-dependent" class="w-full max-w-xs mx-auto">
 		<div x-data="{ firstValue: '', secondValue: '' }" class="flex w-full flex-col gap-4">
-				@selectfield.Select(selectfield.Config{
-					ID:          "modelName",
-					Name:        "modelName",
-					Label:       "Model",
-					Placeholder: "Select Model",
-					Alpine: &selectfield.AlpineConfig{Model: "firstValue"},
-					Options: []selectfield.Option{
-						{Value: "camery", Label: "Camery"},
-						{Value: "4runner", Label: "4Runner"},
-						{Value: "tacoma", Label: "Tacoma"},
-						{Value: "rav4", Label: "Rav4"},
-						{Value: "corolla", Label: "Corolla"},
-					},
-				})
-				@selectfield.Select(selectfield.Config{
-					ID:                 "year",
-					Name:               "year",
-					Label:              "Year",
-					Placeholder:        "Select Year",
-					Alpine: &selectfield.AlpineConfig{Model: "secondValue", BindDisabled: "!firstValue"},
-					Options: []selectfield.Option{
-						{Value: "2024", Label: "2024"},
-						{Value: "2023", Label: "2023"},
-						{Value: "2022", Label: "2022"},
-						{Value: "2021", Label: "2021"},
-						{Value: "2020", Label: "2020"},
-					},
-				})
-			</div>
+			@selectfield.Select(selectfield.Config{
+				ID:          "modelName",
+				Name:        "modelName",
+				Label:       "Model",
+				Placeholder: "Select Model",
+				Alpine:      &selectfield.AlpineConfig{Model: "firstValue"},
+				Options: []selectfield.Option{
+					{Value: "camery", Label: "Camery"},
+					{Value: "4runner", Label: "4Runner"},
+					{Value: "tacoma", Label: "Tacoma"},
+					{Value: "rav4", Label: "Rav4"},
+					{Value: "corolla", Label: "Corolla"},
+				},
+			})
+			@selectfield.Select(selectfield.Config{
+				ID:          "year",
+				Name:        "year",
+				Label:       "Year",
+				Placeholder: "Select Year",
+				Alpine:      &selectfield.AlpineConfig{Model: "secondValue", BindDisabled: "!firstValue"},
+				Options: []selectfield.Option{
+					{Value: "2024", Label: "2024"},
+					{Value: "2023", Label: "2023"},
+					{Value: "2022", Label: "2022"},
+					{Value: "2021", Label: "2021"},
+					{Value: "2020", Label: "2020"},
+				},
+			})
 		</div>
-
+	</div>
 }
 
 // selectDisabledPreview renders the disabled select.
@@ -252,36 +264,77 @@ templ selectDisabledPreview() {
 	<div id="select-disabled" class="w-full max-w-xs mx-auto">
 		@selectfield.Select(selectfield.Config{
 			ID:       "os-disabled",
-				Name:     "os-disabled",
-				Label:    "Operating System",
-				Disabled: true,
-				Options: []selectfield.Option{
-					{Value: "mac", Label: "Mac"},
-					{Value: "windows", Label: "Windows"},
-					{Value: "linux", Label: "Linux"},
-				},
-			})
-		</div>
-
+			Name:     "os-disabled",
+			Label:    "Operating System",
+			Disabled: true,
+			Options: []selectfield.Option{
+				{Value: "mac", Label: "Mac"},
+				{Value: "windows", Label: "Windows"},
+				{Value: "linux", Label: "Linux"},
+			},
+		})
+	</div>
 }
 
 // selectReadonlyPreview renders the readonly select inside a form.
 templ selectReadonlyPreview() {
 	<div id="select-readonly" class="w-full max-w-xs mx-auto">
 		<form id="readonlySelectForm" method="get" action="javascript:void(0)">
-				@selectfield.Select(selectfield.Config{
-					ID:       "os-readonly",
-					Name:     "os-readonly",
-					Label:    "Operating System",
-					Readonly: true,
-					Options: []selectfield.Option{
-						{Value: "mac", Label: "Mac"},
-						{Value: "windows", Label: "Windows", Selected: true},
-						{Value: "linux", Label: "Linux"},
-					},
-				})
-			</form>
+			@selectfield.Select(selectfield.Config{
+				ID:       "os-readonly",
+				Name:     "os-readonly",
+				Label:    "Operating System",
+				Readonly: true,
+				Options: []selectfield.Option{
+					{Value: "mac", Label: "Mac"},
+					{Value: "windows", Label: "Windows", Selected: true},
+					{Value: "linux", Label: "Linux"},
+				},
+			})
+		</form>
+	</div>
+}
+
+// selectShellPreview renders Select as trigger/dropdown chrome around custom content.
+templ selectShellPreview() {
+	<div id="select-shell" class="w-full max-w-xs mx-auto">
+		<div x-data="{ access: 'Viewer' }">
+			@selectfield.Select(selectfield.Config{
+				ID:           "access-shell",
+				Label:        "Access level",
+				Shell:        true,
+				TriggerLabel: "Role",
+				ValueExpr:    "access",
+			}) {
+				<div class="w-64 p-2">
+					<button
+						type="button"
+						x-on:click="access = 'Admin'; $dispatch('select-close')"
+						class="flex w-full flex-col rounded-radius px-3 py-2 text-left text-sm hover:bg-surface dark:hover:bg-surface-dark"
+					>
+						<span class="font-medium text-on-surface-strong dark:text-on-surface-dark-strong">Admin</span>
+						<span class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted">Can update settings and manage members.</span>
+					</button>
+					<button
+						type="button"
+						x-on:click="access = 'Editor'; $dispatch('select-close')"
+						class="flex w-full flex-col rounded-radius px-3 py-2 text-left text-sm hover:bg-surface dark:hover:bg-surface-dark"
+					>
+						<span class="font-medium text-on-surface-strong dark:text-on-surface-dark-strong">Editor</span>
+						<span class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted">Can edit content without changing access.</span>
+					</button>
+					<button
+						type="button"
+						x-on:click="access = 'Viewer'; $dispatch('select-close')"
+						class="flex w-full flex-col rounded-radius px-3 py-2 text-left text-sm hover:bg-surface dark:hover:bg-surface-dark"
+					>
+						<span class="font-medium text-on-surface-strong dark:text-on-surface-dark-strong">Viewer</span>
+						<span class="text-xs text-on-surface-muted dark:text-on-surface-dark-muted">Can read project data only.</span>
+					</button>
+				</div>
+			}
 		</div>
+	</div>
 }
 
 func countryOptions() []selectfield.Option {

--- a/site/internal/pages/demo/components/select_templ.go
+++ b/site/internal/pages/demo/components/select_templ.go
@@ -194,6 +194,28 @@ func selectDemoContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Shell Mode",
+				Description: "Set Shell: true when Select should provide trigger and dropdown chrome while custom templ children own the value. Use ValueExpr for the trigger text and dispatch select-close after a pick.",
+			},
+			selectShellPreview(),
+			`<div x-data="{ access: 'Viewer' }">
+    @selectfield.Select(selectfield.Config{
+        ID:           "access-shell",
+        Label:        "Access level",
+        Shell:        true,
+        TriggerLabel: "Role",
+        ValueExpr:    "access",
+    }) {
+        <button type="button" x-on:click="access = 'Admin'; $dispatch('select-close')">Admin</button>
+        <button type="button" x-on:click="access = 'Viewer'; $dispatch('select-close')">Viewer</button>
+    }
+</div>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -212,6 +234,10 @@ func selectDemoContent() templ.Component {
 			{Name: "Alpine", Type: "*AlpineConfig", Default: "nil", Description: "Client-side Alpine bindings (Model, BindDisabled)."},
 			{Name: "InputAttrs", Type: "templ.Attributes", Default: "nil", Description: "Arbitrary attributes on the select."},
 			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the container."},
+			{Name: "Shell", Type: "bool", Default: "false", Description: "Render only the trigger/dropdown shell and use child content as the dropdown body."},
+			{Name: "TriggerLeading", Type: "templ.Component", Default: "nil", Description: "Optional component rendered before the trigger text, such as a swatch or icon."},
+			{Name: "ValueExpr", Type: "string", Default: `""`, Description: "Alpine expression used for shell-mode trigger text and aria-label."},
+			{Name: "TriggerLabel", Type: "string", Default: `""`, Description: "Static label shown on the left side of a shell trigger, with ValueExpr rendered muted on the right."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -565,6 +591,68 @@ func selectReadonlyPreview() templ.Component {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</form></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// selectShellPreview renders Select as trigger/dropdown chrome around custom content.
+func selectShellPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"select-shell\" class=\"w-full max-w-xs mx-auto\"><div x-data=\"{ access: 'Viewer' }\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var11 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<div class=\"w-64 p-2\"><button type=\"button\" x-on:click=\"access = 'Admin'; $dispatch('select-close')\" class=\"flex w-full flex-col rounded-radius px-3 py-2 text-left text-sm hover:bg-surface dark:hover:bg-surface-dark\"><span class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Admin</span> <span class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">Can update settings and manage members.</span></button> <button type=\"button\" x-on:click=\"access = 'Editor'; $dispatch('select-close')\" class=\"flex w-full flex-col rounded-radius px-3 py-2 text-left text-sm hover:bg-surface dark:hover:bg-surface-dark\"><span class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Editor</span> <span class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">Can edit content without changing access.</span></button> <button type=\"button\" x-on:click=\"access = 'Viewer'; $dispatch('select-close')\" class=\"flex w-full flex-col rounded-radius px-3 py-2 text-left text-sm hover:bg-surface dark:hover:bg-surface-dark\"><span class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Viewer</span> <span class=\"text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">Can read project data only.</span></button></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = selectfield.Select(selectfield.Config{
+			ID:           "access-shell",
+			Label:        "Access level",
+			Shell:        true,
+			TriggerLabel: "Role",
+			ValueExpr:    "access",
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/pages/demo/components/steps.templ
+++ b/site/internal/pages/demo/components/steps.templ
@@ -16,18 +16,8 @@ templ stepsDemoContent() {
 	<div>
 		@demo.ComponentDemo(
 			demo.ComponentDemoProps{
-				Title:         "Steps",
-				Description:   "Steps show progress through multi-stage flows. Supports horizontal and vertical layouts, with optional labels, using Goshtoso theme tokens only.",
-				Props: []demo.PropDoc{
-					{Name: "Steps", Type: "[]steps.Step", Default: "nil", Description: "Ordered progress items to render."},
-					{Name: "ID", Type: "string", Default: "\"\"", Description: "Stable root id for HTMX targets and swaps."},
-					{Name: "Orientation", Type: "steps.Orientation", Default: "steps.OrientationHorizontal", Description: "Horizontal or vertical layout."},
-					{Name: "ShowLabels", Type: "bool", Default: "false", Description: "Shows visible labels next to each step."},
-					{Name: "AriaLabel", Type: "string", Default: "\"progress\"", Description: "Accessible label for the ordered list."},
-					{Name: "LiveRegion", Type: "bool", Default: "false", Description: "Announces swapped state changes after HTMX updates."},
-					{Name: "RootClass", Type: "string", Default: "\"\"", Description: "Extra classes appended to root list."},
-					{Name: "RootAttrs", Type: "templ.Attributes", Default: "nil", Description: "Pass-through attributes for root hx-* and data-* hooks."},
-				},
+				Title:       "Steps",
+				Description: "Progress indicators for multi-stage flows. Use visible labels for task-heavy screens, compact numbered steps for tight layouts, and HTMX swaps when the server owns the current step.",
 			},
 			stepsDefaultPreview(),
 			`@steps.Steps(steps.Config{
@@ -90,9 +80,19 @@ templ stepsDemoContent() {
         {Label: "Get started", Status: steps.StatusUpcoming},
     },
 })`,
-		)
-	</div>
-}
+			)
+		</div>
+		@demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Stable root id for HTMX targets, swaps, and tests."},
+			{Name: "Steps", Type: "[]Step", Default: "nil", Description: "Ordered progress items. Each Step supports ID, Label, AriaLabel, Number, Status, and StepAttrs."},
+			{Name: "Orientation", Type: "Orientation", Default: "OrientationHorizontal", Description: `Layout direction: "horizontal" or "vertical".`},
+			{Name: "ShowLabels", Type: "bool", Default: "false", Description: "Shows visible labels beside the step indicators."},
+			{Name: "AriaLabel", Type: "string", Default: `"progress"`, Description: "Accessible label for the ordered list."},
+			{Name: "LiveRegion", Type: "bool", Default: "false", Description: "Announces swapped state changes after HTMX updates."},
+			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes appended to the root ordered list."},
+			{Name: "RootAttrs", Type: "templ.Attributes", Default: "nil", Description: "Pass-through attributes for root hx-* hooks, data attributes, and test selectors."},
+		})
+	}
 
 templ stepsDefaultPreview() {
 	<div class="w-full max-w-4xl mx-auto">

--- a/site/internal/pages/demo/components/steps_templ.go
+++ b/site/internal/pages/demo/components/steps_templ.go
@@ -73,17 +73,7 @@ func stepsDemoContent() templ.Component {
 		templ_7745c5c3_Err = demo.ComponentDemo(
 			demo.ComponentDemoProps{
 				Title:       "Steps",
-				Description: "Steps show progress through multi-stage flows. Supports horizontal and vertical layouts, with optional labels, using Goshtoso theme tokens only.",
-				Props: []demo.PropDoc{
-					{Name: "Steps", Type: "[]steps.Step", Default: "nil", Description: "Ordered progress items to render."},
-					{Name: "ID", Type: "string", Default: "\"\"", Description: "Stable root id for HTMX targets and swaps."},
-					{Name: "Orientation", Type: "steps.Orientation", Default: "steps.OrientationHorizontal", Description: "Horizontal or vertical layout."},
-					{Name: "ShowLabels", Type: "bool", Default: "false", Description: "Shows visible labels next to each step."},
-					{Name: "AriaLabel", Type: "string", Default: "\"progress\"", Description: "Accessible label for the ordered list."},
-					{Name: "LiveRegion", Type: "bool", Default: "false", Description: "Announces swapped state changes after HTMX updates."},
-					{Name: "RootClass", Type: "string", Default: "\"\"", Description: "Extra classes appended to root list."},
-					{Name: "RootAttrs", Type: "templ.Attributes", Default: "nil", Description: "Pass-through attributes for root hx-* and data-* hooks."},
-				},
+				Description: "Progress indicators for multi-stage flows. Use visible labels for task-heavy screens, compact numbered steps for tight layouts, and HTMX swaps when the server owns the current step.",
 			},
 			stepsDefaultPreview(),
 			`@steps.Steps(steps.Config{
@@ -157,6 +147,19 @@ func stepsDemoContent() templ.Component {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.APIReference([]demo.PropDoc{
+			{Name: "ID", Type: "string", Default: `""`, Description: "Stable root id for HTMX targets, swaps, and tests."},
+			{Name: "Steps", Type: "[]Step", Default: "nil", Description: "Ordered progress items. Each Step supports ID, Label, AriaLabel, Number, Status, and StepAttrs."},
+			{Name: "Orientation", Type: "Orientation", Default: "OrientationHorizontal", Description: `Layout direction: "horizontal" or "vertical".`},
+			{Name: "ShowLabels", Type: "bool", Default: "false", Description: "Shows visible labels beside the step indicators."},
+			{Name: "AriaLabel", Type: "string", Default: `"progress"`, Description: "Accessible label for the ordered list."},
+			{Name: "LiveRegion", Type: "bool", Default: "false", Description: "Announces swapped state changes after HTMX updates."},
+			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes appended to the root ordered list."},
+			{Name: "RootAttrs", Type: "templ.Attributes", Default: "nil", Description: "Pass-through attributes for root hx-* hooks, data attributes, and test selectors."},
+		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/pages/demo/components/table.templ
+++ b/site/internal/pages/demo/components/table.templ
@@ -191,7 +191,7 @@ templ tableDemoContent() {
 		@demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Infinite Scroll Table",
-				Description: "Use Pagination.Mode: table.PaginationInfiniteScroll. A sentinel row drives htmx.ajax from an IntersectionObserver to append the next page.",
+				Description: "Use Pagination.Mode: table.PaginationInfiniteScroll. By default the sentinel watches the page scroller; set Pagination.ContainerHeight only when the table needs its own capped scroll area.",
 			},
 			tableInfinitePreview(),
 			`@table.Table(table.Config{
@@ -224,7 +224,17 @@ templ tableDemoContent() {
 		{Name: "LazyLoad", Type: "bool", Default: "false", Description: "Render a loading tbody that fetches row HTML from HTMX.Endpoint."},
 		{Name: "LazyTrigger", Type: "string", Default: `"load"`, Description: `HTMX trigger for lazy tbody loading, such as "load" or "click from:#load-lazy-table".`},
 		{Name: "Pagination", Type: "*PaginationConfig", Default: "nil", Description: "Pagination/infinite-scroll config (CurrentPage, TotalPages, PerPage, Mode, ...)."},
+		{Name: "Pagination.Mode", Type: "PaginationMode", Default: "PaginationTraditional", Description: `Use PaginationInfiniteScroll to append rows from the sentinel instead of rendering page links.`},
+		{Name: "Pagination.CurrentPage", Type: "int", Default: "0", Description: "Current 1-indexed page for page links and next-page calculations."},
+		{Name: "Pagination.TotalPages", Type: "int", Default: "0", Description: "Total page count for traditional pagination."},
+		{Name: "Pagination.PerPage", Type: "int", Default: "0", Description: "Rows requested per page."},
+		{Name: "Pagination.HasMore", Type: "bool", Default: "false", Description: "Infinite-scroll sentinel flag; false stops requesting more rows."},
+		{Name: "Pagination.ContainerHeight", Type: "string", Default: `""`, Description: `Optional table-local scroll height, such as "400px"; empty uses the nearest page scroller.`},
+		{Name: "InfiniteScroll", Type: "*InfiniteScrollConfig", Default: "nil", Description: "Deprecated compatibility field; prefer Pagination.Mode: PaginationInfiniteScroll."},
 		{Name: "Filters", Type: "*FilterConfig", Default: "nil", Description: "Filter bar config (Variant, Collapsible, Filters[]: search/select/toggle)."},
+		{Name: "Filters.Variant", Type: "FilterVariant", Default: "FilterVariantBar", Description: "Switches between the bordered/collapsible filter bar and inline filter controls."},
+		{Name: "Filters.HTMX", Type: "*FilterHTMXConfig", Default: "nil", Description: "Optional Target and Swap overrides for filter requests; defaults to the table tbody and innerHTML."},
+		{Name: "Filter.OptionsHTMX", Type: "*FilterOptionsHTMXConfig", Default: "nil", Description: "Loads select-filter options from a GET endpoint when static Options are not enough."},
 		{Name: "ExtraQueryParams", Type: "string", Default: `""`, Description: "Extra query string appended to every HTMX request."},
 		{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the table container."},
 	})

--- a/site/internal/pages/demo/components/table_templ.go
+++ b/site/internal/pages/demo/components/table_templ.go
@@ -267,7 +267,7 @@ func tableDemoContent() templ.Component {
 		templ_7745c5c3_Err = demo.DemoSection(
 			demo.DemoSectionProps{
 				Title:       "Infinite Scroll Table",
-				Description: "Use Pagination.Mode: table.PaginationInfiniteScroll. A sentinel row drives htmx.ajax from an IntersectionObserver to append the next page.",
+				Description: "Use Pagination.Mode: table.PaginationInfiniteScroll. By default the sentinel watches the page scroller; set Pagination.ContainerHeight only when the table needs its own capped scroll area.",
 			},
 			tableInfinitePreview(),
 			`@table.Table(table.Config{
@@ -304,7 +304,17 @@ func tableDemoContent() templ.Component {
 			{Name: "LazyLoad", Type: "bool", Default: "false", Description: "Render a loading tbody that fetches row HTML from HTMX.Endpoint."},
 			{Name: "LazyTrigger", Type: "string", Default: `"load"`, Description: `HTMX trigger for lazy tbody loading, such as "load" or "click from:#load-lazy-table".`},
 			{Name: "Pagination", Type: "*PaginationConfig", Default: "nil", Description: "Pagination/infinite-scroll config (CurrentPage, TotalPages, PerPage, Mode, ...)."},
+			{Name: "Pagination.Mode", Type: "PaginationMode", Default: "PaginationTraditional", Description: `Use PaginationInfiniteScroll to append rows from the sentinel instead of rendering page links.`},
+			{Name: "Pagination.CurrentPage", Type: "int", Default: "0", Description: "Current 1-indexed page for page links and next-page calculations."},
+			{Name: "Pagination.TotalPages", Type: "int", Default: "0", Description: "Total page count for traditional pagination."},
+			{Name: "Pagination.PerPage", Type: "int", Default: "0", Description: "Rows requested per page."},
+			{Name: "Pagination.HasMore", Type: "bool", Default: "false", Description: "Infinite-scroll sentinel flag; false stops requesting more rows."},
+			{Name: "Pagination.ContainerHeight", Type: "string", Default: `""`, Description: `Optional table-local scroll height, such as "400px"; empty uses the nearest page scroller.`},
+			{Name: "InfiniteScroll", Type: "*InfiniteScrollConfig", Default: "nil", Description: "Deprecated compatibility field; prefer Pagination.Mode: PaginationInfiniteScroll."},
 			{Name: "Filters", Type: "*FilterConfig", Default: "nil", Description: "Filter bar config (Variant, Collapsible, Filters[]: search/select/toggle)."},
+			{Name: "Filters.Variant", Type: "FilterVariant", Default: "FilterVariantBar", Description: "Switches between the bordered/collapsible filter bar and inline filter controls."},
+			{Name: "Filters.HTMX", Type: "*FilterHTMXConfig", Default: "nil", Description: "Optional Target and Swap overrides for filter requests; defaults to the table tbody and innerHTML."},
+			{Name: "Filter.OptionsHTMX", Type: "*FilterOptionsHTMXConfig", Default: "nil", Description: "Loads select-filter options from a GET endpoint when static Options are not enough."},
 			{Name: "ExtraQueryParams", Type: "string", Default: `""`, Description: "Extra query string appended to every HTMX request."},
 			{Name: "RootClass", Type: "string", Default: `""`, Description: "Extra classes on the table container."},
 		}).Render(ctx, templ_7745c5c3_Buffer)

--- a/site/internal/pages/demo/components/toast.templ
+++ b/site/internal/pages/demo/components/toast.templ
@@ -74,6 +74,25 @@ func handler(w http.ResponseWriter, r *http.Request) {
     Sender:  &toast.Sender{Name: "Jack Ellis", Avatar: "/avatar.webp"},
 })`,
 		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Action Toast",
+				Description: "Server-rendered toasts can include one inline action button. Set ActionLabel and ActionHTMX for undo, retry, or view-detail flows.",
+			},
+			toastActionPreview(),
+			`@toast.Toast(toast.Config{
+    Variant:         toast.Success,
+    Title:           "Project archived",
+    Message:         "The project moved to archived items.",
+    DisplayDuration: -1,
+    ActionLabel:     "Undo archive",
+    ActionHTMX: &toast.HTMXConfig{
+        Post: "/api/components/toast",
+        Swap: "none",
+    },
+})`,
+		)
 	</div>
 	// API reference lives outside #toast-fragment.
 	@demo.APIReference([]demo.PropDoc{
@@ -82,6 +101,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		{Name: "Message", Type: "string", Default: `""`, Description: "Toast body text."},
 		{Name: "Sender", Type: "*Sender", Default: "nil", Description: "Message-variant sender (Name + Avatar); adds avatar and reply button."},
 		{Name: "DisplayDuration", Type: "int", Default: "0", Description: "Auto-dismiss delay in ms (0 uses the container default; negative keeps a server-rendered toast visible until dismissed)."},
+		{Name: "ActionLabel", Type: "string", Default: `""`, Description: "Optional inline action button label for server-rendered toasts."},
+		{Name: "ActionHTMX", Type: "*HTMXConfig", Default: "nil", Description: "HTMX request for the action button (Get/Post, Target, Swap)."},
 	})
 }
 
@@ -206,5 +227,22 @@ templ toastStaticPreview() {
 					},
 				})
 		</div>
+	</div>
+}
+
+// toastActionPreview renders a persistent server-side toast with an HTMX action.
+templ toastActionPreview() {
+	<div id="toast-action" class="w-full max-w-2xl mx-auto">
+		@toast.Toast(toast.Config{
+			Variant:         toast.Success,
+			Title:           "Project archived",
+			Message:         "The project moved to archived items.",
+			DisplayDuration: -1,
+			ActionLabel:     "Undo archive",
+			ActionHTMX: &toast.HTMXConfig{
+				Post: "/api/components/toast",
+				Swap: "none",
+			},
+		})
 	</div>
 }

--- a/site/internal/pages/demo/components/toast_templ.go
+++ b/site/internal/pages/demo/components/toast_templ.go
@@ -139,6 +139,27 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Action Toast",
+				Description: "Server-rendered toasts can include one inline action button. Set ActionLabel and ActionHTMX for undo, retry, or view-detail flows.",
+			},
+			toastActionPreview(),
+			`@toast.Toast(toast.Config{
+    Variant:         toast.Success,
+    Title:           "Project archived",
+    Message:         "The project moved to archived items.",
+    DisplayDuration: -1,
+    ActionLabel:     "Undo archive",
+    ActionHTMX: &toast.HTMXConfig{
+        Post: "/api/components/toast",
+        Swap: "none",
+    },
+})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -149,6 +170,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 			{Name: "Message", Type: "string", Default: `""`, Description: "Toast body text."},
 			{Name: "Sender", Type: "*Sender", Default: "nil", Description: "Message-variant sender (Name + Avatar); adds avatar and reply button."},
 			{Name: "DisplayDuration", Type: "int", Default: "0", Description: "Auto-dismiss delay in ms (0 uses the container default; negative keeps a server-rendered toast visible until dismissed)."},
+			{Name: "ActionLabel", Type: "string", Default: `""`, Description: "Optional inline action button label for server-rendered toasts."},
+			{Name: "ActionHTMX", Type: "*HTMXConfig", Default: "nil", Description: "HTMX request for the action button (Get/Post, Target, Swap)."},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -292,6 +315,54 @@ func toastStaticPreview() templ.Component {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// toastActionPreview renders a persistent server-side toast with an HTMX action.
+func toastActionPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"toast-action\" class=\"w-full max-w-2xl mx-auto\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = toast.Toast(toast.Config{
+			Variant:         toast.Success,
+			Title:           "Project archived",
+			Message:         "The project moved to archived items.",
+			DisplayDuration: -1,
+			ActionLabel:     "Undo archive",
+			ActionHTMX: &toast.HTMXConfig{
+				Post: "/api/components/toast",
+				Swap: "none",
+			},
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/pages/demo/components/tooltip.templ
+++ b/site/internal/pages/demo/components/tooltip.templ
@@ -63,7 +63,7 @@ templ tooltipDemoContent() {
 		{Name: "Label", Type: "string", Default: `""`, Description: "Tooltip text (heading line)."},
 		{Name: "Description", Type: "string", Default: `""`, Description: "Optional secondary line for a rich tooltip."},
 		{Name: "Position", Type: "Position", Default: "Top", Description: `Placement: "top", "bottom", "left", "right".`},
-		{Name: "Trigger", Type: "Trigger", Default: "Hover", Description: `Activation: "hover" (hover/focus) or "click".`},
+		{Name: "TriggerMode", Type: "Trigger", Default: "Hover", Description: `Activation: "hover" (hover/focus) or "click".`},
 		{Name: "TriggerLabel", Type: "string", Default: `""`, Description: "Label of the trigger element."},
 		{Name: "Trigger", Type: "templ.Component", Default: "nil", Description: "Custom trigger content (overrides TriggerLabel)."},
 	})

--- a/site/internal/pages/demo/components/tooltip_templ.go
+++ b/site/internal/pages/demo/components/tooltip_templ.go
@@ -128,7 +128,7 @@ func tooltipDemoContent() templ.Component {
 			{Name: "Label", Type: "string", Default: `""`, Description: "Tooltip text (heading line)."},
 			{Name: "Description", Type: "string", Default: `""`, Description: "Optional secondary line for a rich tooltip."},
 			{Name: "Position", Type: "Position", Default: "Top", Description: `Placement: "top", "bottom", "left", "right".`},
-			{Name: "Trigger", Type: "Trigger", Default: "Hover", Description: `Activation: "hover" (hover/focus) or "click".`},
+			{Name: "TriggerMode", Type: "Trigger", Default: "Hover", Description: `Activation: "hover" (hover/focus) or "click".`},
 			{Name: "TriggerLabel", Type: "string", Default: `""`, Description: "Label of the trigger element."},
 			{Name: "Trigger", Type: "templ.Component", Default: "nil", Description: "Custom trigger content (overrides TriggerLabel)."},
 		}).Render(ctx, templ_7745c5c3_Buffer)

--- a/site/tests/e2e/drawer_coverage_test.go
+++ b/site/tests/e2e/drawer_coverage_test.go
@@ -37,7 +37,8 @@ func TestDrawerCoverageDemo(t *testing.T) {
 	require.NoError(t, page.Locator("#drawer-default").WaitFor())
 	require.NoError(t, page.Locator("#drawer-left").WaitFor())
 	require.NoError(t, page.GetByRole("heading", playwright.PageGetByRoleOptions{
-		Name: "Drawer",
+		Name:  "Drawer",
+		Level: playwright.Int(1),
 	}).WaitFor())
 
 	projectDialog := page.GetByRole("dialog", playwright.PageGetByRoleOptions{


### PR DESCRIPTION
## Summary
- add a component docs audit note with findings, completed work, and verification
- move CodeBlock and Steps props into standalone API reference tables
- expand Palette, Drawer, Toast, Select, and Table docs with missing examples/API rows
- fix Tooltip API docs to document TriggerMode instead of a duplicate Trigger row

## Verification
- templ generate
- go test ./components/codeblock ./components/steps ./components/palette ./components/drawer ./components/tooltip ./components/toast ./components/select ./components/table -count=1
- cd site && go test ./internal/pages/demo/components -count=1
- structural docs scan: no component demo pages missing a standalone demo.APIReference and no broad weak-docs signals
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new demo examples for drawers, palette pickers, selects, toasts, and code blocks.
  * Introduced shell-mode select behavior, lazy-loaded palette rendering, persistent drawer support, and action-enabled toasts.
  * Expanded table and steps demos with clearer guidance and more complete examples.

* **Documentation**
  * Updated component documentation across demos to better explain available options and usage.
  * Added or refreshed API reference details for several component settings, including tooltip activation behavior and table pagination/filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->