### PR TITLE
chore(site): remove homepage table endpoint copy

### DIFF
--- a/site/internal/pages/demo/components/landing.templ
+++ b/site/internal/pages/demo/components/landing.templ
@@ -184,12 +184,6 @@ templ landingContent() {
 					@badge.Badge(badge.Config{Label: "Pending", Variant: badge.Warning})
 					@toggle.Toggle(toggle.Config{ID: "homeToggle", Label: "Notifications", Checked: true})
 				</div>
-				<div id="playground-server-proof" class="flex flex-col gap-2 rounded-radius border border-outline bg-surface-alt px-4 py-3 text-sm text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark sm:flex-row sm:items-center sm:justify-between">
-					<span>
-						Table rows are lazy-loaded from Go through HTMX.
-					</span>
-					<code class="font-mono text-on-surface-strong dark:text-on-surface-dark-strong">/api/components/table/rows</code>
-				</div>
 				@table.Table(table.Config{
 					ID:       "home-table",
 					HTMX:     &table.HTMXConfig{Endpoint: "/api/components/table/rows?variant=lazy"},

--- a/site/internal/pages/demo/components/landing_templ.go
+++ b/site/internal/pages/demo/components/landing_templ.go
@@ -273,7 +273,7 @@ func landingContent() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div><div id=\"playground-server-proof\" class=\"flex flex-col gap-2 rounded-radius border border-outline bg-surface-alt px-4 py-3 text-sm text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark sm:flex-row sm:items-center sm:justify-between\"><span>Table rows are lazy-loaded from Go through HTMX.</span> <code class=\"font-mono text-on-surface-strong dark:text-on-surface-dark-strong\">/api/components/table/rows</code></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -303,7 +303,7 @@ func landingContent() templ.Component {
 		var templ_7745c5c3_Var8 templ.SafeURL
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(featured.URL))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 232, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 226, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -338,7 +338,7 @@ func landingContent() templ.Component {
 			var templ_7745c5c3_Var9 templ.SafeURL
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(a.URL))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 246, Col: 36}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 240, Col: 36}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {

--- a/site/tests/e2e/landing_test.go
+++ b/site/tests/e2e/landing_test.go
@@ -93,16 +93,15 @@ func TestLanding_HeroAndStructure(t *testing.T) {
 		require.NoError(t, err, "live HTMX table should populate rows")
 	})
 
-	t.Run("PlaygroundExplainsServerRenderedLoop", func(t *testing.T) {
-		proof := page.Locator("#playground-server-proof")
-		visible, err := proof.IsVisible()
+	t.Run("PlaygroundOmitsServerEndpointCopy", func(t *testing.T) {
+		proofCount, err := page.Locator("#playground-server-proof").Count()
 		require.NoError(t, err)
-		require.True(t, visible, "live playground should explain the HTMX endpoint behind the table")
+		require.Zero(t, proofCount)
 
-		text, err := proof.InnerText()
+		text, err := page.Locator("body").InnerText()
 		require.NoError(t, err)
-		require.Contains(t, text, "/api/components/table/rows")
-		require.Contains(t, text, "lazy-loaded from Go")
+		require.NotContains(t, text, "Table rows are lazy-loaded from Go through HTMX.")
+		require.NotContains(t, text, "/api/components/table/rows")
 	})
 
 	t.Run("ExampleGalleryLinks", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove the homepage callout describing the HTMX table endpoint
- keep the lazy-loaded table behavior unchanged
- update landing-page E2E coverage to assert the copy stays absent

## Validation
- `go test ./site/tests/e2e/... -count=1 -timeout 5m -run TestLanding_HeroAndStructure`
- site unit tests excluding E2E
- `go build -o bin/server ./site/cmd/server`
- site `golangci-lint run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Removed the informational banner from the homepage’s Live Playground section.
  * The playground controls and table remain available without the additional implementation details.

* **Bug Fixes**
  * Updated error location reporting for certain example link-generation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->