### PR TITLE
chore(ci) bump Go toolchain to 1.26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  GO_VERSION: '1.26.1'
+  GO_VERSION: '1.26.5'
   TEMPL_VERSION: 'v0.3.1020'
   PLAYWRIGHT_VERSION: 'v0.5700.1'
   GOLANGCI_LINT_VERSION: 'v2.12.2'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.5'
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /src
 

--- a/examples/getting-started/go.mod
+++ b/examples/getting-started/go.mod
@@ -1,6 +1,6 @@
 module github.com/araihu/goshtoso/examples/getting-started
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020

--- a/examples/getting-started/main.go
+++ b/examples/getting-started/main.go
@@ -172,14 +172,14 @@ func appMux() *http.ServeMux {
 		pageRows := dogsToRows(dogs[:min(perPage, len(dogs))])
 
 		Page(table.Config{
-			ID:           "breeds",
-			HTMXEndpoint: "/api/breeds",
-			Columns:      columns(),
-			Rows:         pageRows,
-			SortBy:       "breed",
-			SortDir:      table.SortAsc,
-			Pagination:   &table.PaginationConfig{CurrentPage: 1, TotalPages: totalPages, PerPage: perPage},
-			Filters:      filters(),
+			ID:         "breeds",
+			HTMX:       &table.HTMXConfig{Endpoint: "/api/breeds"},
+			Columns:    columns(),
+			Rows:       pageRows,
+			SortBy:     "breed",
+			SortDir:    table.SortAsc,
+			Pagination: &table.PaginationConfig{CurrentPage: 1, TotalPages: totalPages, PerPage: perPage},
+			Filters:    filters(),
 		}).Render(r.Context(), w)
 	})
 
@@ -223,13 +223,13 @@ func appMux() *http.ServeMux {
 		}
 
 		cfg := table.Config{
-			ID:           "breeds",
-			Columns:      columns(),
-			Rows:         dogsToRows(dogs[start:end]),
-			HTMXEndpoint: "/api/breeds",
-			SortBy:       orderBy,
-			SortDir:      table.SortDir(orderDir),
-			Pagination:   &table.PaginationConfig{CurrentPage: page, TotalPages: totalPages, PerPage: pp},
+			ID:         "breeds",
+			Columns:    columns(),
+			Rows:       dogsToRows(dogs[start:end]),
+			HTMX:       &table.HTMXConfig{Endpoint: "/api/breeds"},
+			SortBy:     orderBy,
+			SortDir:    table.SortDir(orderDir),
+			Pagination: &table.PaginationConfig{CurrentPage: page, TotalPages: totalPages, PerPage: pp},
 		}
 
 		// Render table rows

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/araihu/goshtoso
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,6 +1,6 @@
 module github.com/araihu/goshtoso/site
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020

--- a/site/tests/e2e/Dockerfile
+++ b/site/tests/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-bookworm
+FROM golang:1.26.5-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/usr/local/go/bin:/go/bin:${PATH}"


### PR DESCRIPTION
Rolling subtree-sync for prefix `goshtoso` (base `main`).

## Included monorepo merges

- `85d88d0319f5` — https://github.com/guilycst/totvs-work/commit/85d88d0319f5c89e3345be817ce0ed6270cefdd6 (goshtoso)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the project and example configurations to use the latest Go 1.26.5 toolchain.
  * Refreshed development, release, container, and end-to-end build environments for improved consistency.
  * Updated the getting-started example to use the current table configuration format while preserving existing filtering, sorting, and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->