### PR TITLE
chore: pin demo site to v0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,4 +99,5 @@ before upgrading.
   complete component catalog plus a representative light/dark Goshtoso/Minimal
   theme matrix.
 
+[v0.0.13]: https://github.com/araihu/goshtoso/compare/v0.0.12...v0.0.13
 [v0.0.12]: https://github.com/araihu/goshtoso/compare/v0.0.11...v0.0.12

--- a/docs/audits/2026-07-26-head-dependency-fallback.md
+++ b/docs/audits/2026-07-26-head-dependency-fallback.md
@@ -129,3 +129,15 @@ Resultados finais antes do release:
 - os cinco recursos CDN default foram baixados e comparados byte a byte com os
   arquivos embedded usados para gerar SRI;
 - revisão independente final: nenhum achado restante ou bloqueador de release.
+
+## Resultado do release
+
+- PR [#187](https://github.com/araihu/goshtoso/pull/187) integrado em `main`;
+- commit de merge e alvo da tag: `6e1b94a473d3e6903347c75955b126b980abde32`;
+- tag anotada `v0.0.13` publicada e resolvida para o mesmo commit;
+- workflow de release concluído com sucesso e release público criado;
+- `styles.css` e `goshtoso-theme.css` publicados como assets do release;
+- descoberta remota confirmou as cinco skills, incluindo a versão atualizada de
+  `using-goshtoso`;
+- follow-up pós-tag fixa o módulo do site em `v0.0.13` e habilita o link de
+  comparação do changelog, que retornava 404 antes da tag existir.

--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.0.12
+	github.com/araihu/goshtoso v0.0.13
 	github.com/coder/websocket v1.8.14
 	github.com/playwright-community/playwright-go v0.5700.1
 	github.com/stretchr/testify v1.11.1

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6
 github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.0.12 h1:uX1Bvydmkvh1NNHNaLQ2V+XAscpapxBRkB0HFYuqzpY=
-github.com/araihu/goshtoso v0.0.12/go.mod h1:SWdh/AlXnVGgW881NzTAKWk7paNsTlKMH/EGujAJoXY=
+github.com/araihu/goshtoso v0.0.13 h1:In7mqr8LX/nG+85Fz5xcGre7znyCiaUBGltKJUEnGaI=
+github.com/araihu/goshtoso v0.0.13/go.mod h1:SWdh/AlXnVGgW881NzTAKWk7paNsTlKMH/EGujAJoXY=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
## Summary

- pin the standalone demo site module to the published Goshtoso v0.0.13
- add the now-valid v0.0.13 changelog comparison link
- preserve the audited release outcome, tag SHA, assets, and skill discovery

## Verification

- GOWORK=off site non-E2E tests
- git diff --check
- v0.0.13 comparison URL returns HTTP 200
- release workflow succeeded with styles.css and goshtoso-theme.css assets