### PR TITLE
feat: expose public runtime manifest and library identity

### DIFF
--- a/.agents/skills/using-goshtoso/SKILL.md
+++ b/.agents/skills/using-goshtoso/SKILL.md
@@ -81,6 +81,19 @@ Choose deliberately:
 - Await `window.goshtosoDependencies.ready` before application JavaScript that
   requires every dynamically loaded dependency.
 
+For offline inventories or build descriptors, use
+`assets.DefaultRuntimeManifest()` instead of copying versioned paths from
+generated files or the module cache. Its caller-owned dependency slice is in
+execution order and includes roles, CDN primary, Handler-served local URL, SRI,
+enabled, minimal-set membership, defer, and loader-readiness semantics. Cache
+the separate stylesheet and bootstrap loader local URLs too; do not execute the
+loader and the direct local dependency scripts together.
+
+Bind same-version caches only when `assets.GoshtosoVersion().Status` is
+`assets.VersionExact`. Development, replaced, and unavailable builds leave the
+exact `Version` empty. Replacement request/target metadata is diagnostic only:
+the requested release version does not identify replacement bytes.
+
 If the consumer sets Content Security Policy, test the rendered application
 under that exact policy. The bundled standard Alpine runtime requires dynamic
 function evaluation, and Alpine/component state writes inline style

--- a/assets/embed.go
+++ b/assets/embed.go
@@ -1,5 +1,7 @@
-// Package assets provides embedded static files (CSS, JS, images) for Goshtoso components.
-// Use Handler() to serve them at /assets/ in your HTTP server.
+// Package assets provides embedded static files and their public runtime
+// contract for Goshtoso components. Use Handler to serve them at /assets/,
+// DefaultRuntimeManifest to inspect the ordered dependency/fallback set, and
+// GoshtosoVersion to identify the exact library module linked into a consumer.
 //
 // Usage:
 //
@@ -91,7 +93,7 @@ func vendorVersion(module string) string {
 }
 
 // AlpineVersion returns the Alpine.js version Goshtoso vendors (core, collapse,
-// and focus share this version). Pinned in js/runtime/versions.json.
+// focus, and mask share this version). Pinned in js/runtime/versions.json.
 func AlpineVersion() string { return vendorVersion("alpinejs") }
 
 // HTMXVersion returns the vendored HTMX version (js/runtime/versions.json).

--- a/assets/library_version.go
+++ b/assets/library_version.go
@@ -1,0 +1,123 @@
+package assets
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// GoshtosoModulePath is the Go module path whose build identity
+// GoshtosoVersion resolves.
+const GoshtosoModulePath = "github.com/araihu/goshtoso"
+
+// VersionStatus describes whether a consumer binary has an exact,
+// release-safe Goshtoso module identity.
+type VersionStatus string
+
+const (
+	// VersionExact means Version identifies the unreplaced module recorded by Go
+	// build information. Version can be a release or immutable pseudo-version;
+	// Sum records its checksum when Go build information provides one.
+	VersionExact VersionStatus = "exact"
+	// VersionDevelopment means Goshtoso is the unversioned main module or has a
+	// development marker instead of an exact module version.
+	VersionDevelopment VersionStatus = "development"
+	// VersionReplaced means Go build information records a replacement. The
+	// requested version does not identify the replacement bytes.
+	VersionReplaced VersionStatus = "replaced"
+	// VersionUnavailable means build information is absent or does not contain
+	// the Goshtoso module.
+	VersionUnavailable VersionStatus = "unavailable"
+)
+
+// VersionReference is one module record from Go build information.
+type VersionReference struct {
+	Path    string
+	Version string
+	Sum     string
+}
+
+// VersionInfo reports the Goshtoso module identity linked into the running
+// consumer. Version is populated only when Status is VersionExact; Sum carries
+// the Go module checksum when build information provides one.
+// For VersionReplaced, Requested records the dependency requested by the
+// consumer and Replacement records the module/path actually selected; neither
+// is promoted to Version because replacement bytes may be local or otherwise
+// differ from the requested release. Consumers that bind caches or offline
+// readiness to exact library bytes must fail closed unless Status is
+// VersionExact.
+type VersionInfo struct {
+	ModulePath  string
+	Status      VersionStatus
+	Version     string
+	Sum         string
+	Requested   VersionReference
+	Replacement VersionReference
+}
+
+// GoshtosoVersion reads immutable Go build information for the running
+// consumer and returns its linked Goshtoso identity. Development, replaced, and
+// unavailable builds deliberately return an empty Version so they cannot be
+// mislabeled as a release.
+func GoshtosoVersion() VersionInfo {
+	info, ok := debug.ReadBuildInfo()
+	return resolveGoshtosoVersion(info, ok)
+}
+
+func resolveGoshtosoVersion(info *debug.BuildInfo, ok bool) VersionInfo {
+	result := VersionInfo{
+		ModulePath: GoshtosoModulePath,
+		Status:     VersionUnavailable,
+	}
+	if !ok || info == nil {
+		return result
+	}
+
+	module := findGoshtosoModule(info)
+	if module == nil {
+		return result
+	}
+	if module.Replace != nil {
+		result.Status = VersionReplaced
+		result.Requested = versionReference(*module)
+		result.Replacement = versionReference(*module.Replace)
+		return result
+	}
+	if isDevelopmentVersion(module.Version) {
+		result.Status = VersionDevelopment
+		return result
+	}
+
+	result.Status = VersionExact
+	result.Version = module.Version
+	result.Sum = module.Sum
+	return result
+}
+
+func findGoshtosoModule(info *debug.BuildInfo) *debug.Module {
+	if info.Main.Path == GoshtosoModulePath {
+		return &info.Main
+	}
+	for _, dependency := range info.Deps {
+		if dependency != nil && dependency.Path == GoshtosoModulePath {
+			return dependency
+		}
+	}
+	return nil
+}
+
+func versionReference(module debug.Module) VersionReference {
+	return VersionReference{
+		Path:    module.Path,
+		Version: module.Version,
+		Sum:     module.Sum,
+	}
+}
+
+func isDevelopmentVersion(version string) bool {
+	switch strings.ToLower(strings.TrimSpace(version)) {
+	case "", "(devel)", "devel", "development", "(development)":
+		return true
+	default:
+		return false
+	}
+}

--- a/assets/library_version_test.go
+++ b/assets/library_version_test.go
@@ -1,0 +1,117 @@
+package assets
+
+import (
+	"reflect"
+	"runtime/debug"
+	"testing"
+)
+
+func TestResolveGoshtosoVersionDistinguishesExactDevelopmentUnavailableAndReplaced(t *testing.T) {
+	tests := []struct {
+		name string
+		info *debug.BuildInfo
+		ok   bool
+		want VersionInfo
+	}{
+		{
+			name: "released dependency",
+			info: &debug.BuildInfo{Deps: []*debug.Module{{
+				Path: GoshtosoModulePath, Version: "v0.0.13", Sum: "h1:release",
+			}}},
+			ok: true,
+			want: VersionInfo{
+				ModulePath: GoshtosoModulePath,
+				Status:     VersionExact,
+				Version:    "v0.0.13",
+				Sum:        "h1:release",
+			},
+		},
+		{
+			name: "exact main module",
+			info: &debug.BuildInfo{Main: debug.Module{
+				Path: GoshtosoModulePath, Version: "v0.0.14", Sum: "h1:main",
+			}},
+			ok: true,
+			want: VersionInfo{
+				ModulePath: GoshtosoModulePath,
+				Status:     VersionExact,
+				Version:    "v0.0.14",
+				Sum:        "h1:main",
+			},
+		},
+		{
+			name: "development main module",
+			info: &debug.BuildInfo{Main: debug.Module{
+				Path: GoshtosoModulePath, Version: "(devel)",
+			}},
+			ok:   true,
+			want: VersionInfo{ModulePath: GoshtosoModulePath, Status: VersionDevelopment},
+		},
+		{
+			name: "empty development version",
+			info: &debug.BuildInfo{Main: debug.Module{Path: GoshtosoModulePath}},
+			ok:   true,
+			want: VersionInfo{ModulePath: GoshtosoModulePath, Status: VersionDevelopment},
+		},
+		{
+			name: "module absent",
+			info: &debug.BuildInfo{Main: debug.Module{Path: "example.com/consumer", Version: "v1.0.0"}},
+			ok:   true,
+			want: VersionInfo{ModulePath: GoshtosoModulePath, Status: VersionUnavailable},
+		},
+		{
+			name: "build info unavailable",
+			info: nil,
+			ok:   false,
+			want: VersionInfo{ModulePath: GoshtosoModulePath, Status: VersionUnavailable},
+		},
+		{
+			name: "local path replacement",
+			info: &debug.BuildInfo{Deps: []*debug.Module{{
+				Path: GoshtosoModulePath, Version: "v0.0.13", Sum: "h1:requested",
+				Replace: &debug.Module{Path: "../goshtoso"},
+			}}},
+			ok: true,
+			want: VersionInfo{
+				ModulePath: GoshtosoModulePath,
+				Status:     VersionReplaced,
+				Requested: VersionReference{
+					Path: GoshtosoModulePath, Version: "v0.0.13", Sum: "h1:requested",
+				},
+				Replacement: VersionReference{Path: "../goshtoso"},
+			},
+		},
+		{
+			name: "versioned replacement",
+			info: &debug.BuildInfo{Deps: []*debug.Module{{
+				Path: GoshtosoModulePath, Version: "v0.0.13", Sum: "h1:requested",
+				Replace: &debug.Module{
+					Path: "example.com/goshtoso-fork", Version: "v1.2.3", Sum: "h1:replacement",
+				},
+			}}},
+			ok: true,
+			want: VersionInfo{
+				ModulePath: GoshtosoModulePath,
+				Status:     VersionReplaced,
+				Requested: VersionReference{
+					Path: GoshtosoModulePath, Version: "v0.0.13", Sum: "h1:requested",
+				},
+				Replacement: VersionReference{
+					Path: "example.com/goshtoso-fork", Version: "v1.2.3", Sum: "h1:replacement",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := resolveGoshtosoVersion(test.info, test.ok)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("resolveGoshtosoVersion() = %#v, want %#v", got, test.want)
+			}
+			if got.Status != VersionExact && (got.Version != "" || got.Sum != "") {
+				t.Fatalf("non-exact status exposed release identity: %#v", got)
+			}
+		})
+	}
+}

--- a/assets/runtime_manifest.go
+++ b/assets/runtime_manifest.go
@@ -1,0 +1,130 @@
+package assets
+
+const (
+	// StylesURL is the assets.Handler URL for Goshtoso's compiled component CSS.
+	StylesURL = "/assets/styles.css"
+	// DependencyLoaderURL is the assets.Handler URL for the ordered CDN/fallback loader.
+	DependencyLoaderURL = "/assets/js/dependency-loader.js"
+	// ComboboxURL is the assets.Handler URL for Goshtoso's combobox keyboard helper.
+	ComboboxURL = "/assets/js/combobox.js"
+)
+
+// RuntimeAssetKind describes how a runtime manifest asset is included in HTML.
+type RuntimeAssetKind string
+
+const (
+	// RuntimeAssetStylesheet identifies a stylesheet link.
+	RuntimeAssetStylesheet RuntimeAssetKind = "stylesheet"
+	// RuntimeAssetScript identifies an executable script.
+	RuntimeAssetScript RuntimeAssetKind = "script"
+)
+
+// RuntimeAssetRole identifies one asset's purpose without requiring callers to
+// infer execution semantics from its URL.
+type RuntimeAssetRole string
+
+const (
+	// RuntimeRoleStylesheet identifies Goshtoso's compiled CSS.
+	RuntimeRoleStylesheet RuntimeAssetRole = "stylesheet"
+	// RuntimeRoleDependencyLoader identifies the ordered CDN/fallback bootstrap.
+	RuntimeRoleDependencyLoader RuntimeAssetRole = "dependency-loader"
+	// RuntimeRoleAlpineCollapse identifies the Alpine Collapse plugin.
+	RuntimeRoleAlpineCollapse RuntimeAssetRole = "alpine-collapse"
+	// RuntimeRoleAlpineFocus identifies the Alpine Focus plugin.
+	RuntimeRoleAlpineFocus RuntimeAssetRole = "alpine-focus"
+	// RuntimeRoleAlpineMask identifies the Alpine Mask plugin.
+	RuntimeRoleAlpineMask RuntimeAssetRole = "alpine-mask"
+	// RuntimeRoleAlpineJS identifies Alpine.js core.
+	RuntimeRoleAlpineJS RuntimeAssetRole = "alpine"
+	// RuntimeRoleHTMX identifies HTMX core.
+	RuntimeRoleHTMX RuntimeAssetRole = "htmx"
+	// RuntimeRoleCombobox identifies Goshtoso's combobox keyboard helper.
+	RuntimeRoleCombobox RuntimeAssetRole = "combobox"
+)
+
+// RuntimeAsset describes one stylesheet or script in Goshtoso's default head
+// dependency contract. PrimaryURL is used by the CDN-first loader; LocalURL is
+// the same-version embedded URL served by Handler. Integrity is SHA-384 SRI for
+// dependencies whose primary and local bytes are required to match.
+// IncludeInMinimal selects DependenciesMinimal membership. Defer is the direct
+// local-script tag behavior. WaitForWindowLoaded is loader readiness behavior
+// used before dynamically inserting the script.
+type RuntimeAsset struct {
+	Role                RuntimeAssetRole
+	Kind                RuntimeAssetKind
+	PrimaryURL          string
+	LocalURL            string
+	Integrity           string
+	Enabled             bool
+	IncludeInMinimal    bool
+	Defer               bool
+	WaitForWindowLoaded bool
+}
+
+// RuntimeManifest is Goshtoso's complete default embedded runtime/fallback
+// contract. Dependencies are in execution order. Loader is separate because
+// CDN-first rendering executes it to load Dependencies, while direct local
+// rendering executes Dependencies and must not execute the loader as well.
+type RuntimeManifest struct {
+	Stylesheet   RuntimeAsset
+	Loader       RuntimeAsset
+	Dependencies []RuntimeAsset
+}
+
+// DefaultRuntimeManifest returns the complete default runtime/fallback
+// contract. The returned value and dependency slice are caller-owned; mutation
+// cannot affect later calls, assets.Handler, or head.Dependencies rendering.
+// Mount Handler directly at /assets/ to serve every LocalURL.
+func DefaultRuntimeManifest() RuntimeManifest {
+	return RuntimeManifest{
+		Stylesheet: RuntimeAsset{
+			Role:             RuntimeRoleStylesheet,
+			Kind:             RuntimeAssetStylesheet,
+			PrimaryURL:       StylesURL,
+			LocalURL:         StylesURL,
+			Enabled:          true,
+			IncludeInMinimal: true,
+		},
+		Loader: RuntimeAsset{
+			Role:             RuntimeRoleDependencyLoader,
+			Kind:             RuntimeAssetScript,
+			PrimaryURL:       DependencyLoaderURL,
+			LocalURL:         DependencyLoaderURL,
+			Enabled:          true,
+			IncludeInMinimal: true,
+			Defer:            true,
+		},
+		Dependencies: []RuntimeAsset{
+			{
+				Role: RuntimeRoleAlpineCollapse, Kind: RuntimeAssetScript,
+				PrimaryURL: AlpineCollapseCDNURL, LocalURL: AlpineCollapseURL,
+				Integrity: AlpineCollapseIntegrity, Enabled: true, Defer: true,
+			},
+			{
+				Role: RuntimeRoleAlpineFocus, Kind: RuntimeAssetScript,
+				PrimaryURL: AlpineFocusCDNURL, LocalURL: AlpineFocusURL,
+				Integrity: AlpineFocusIntegrity, Enabled: true, Defer: true,
+			},
+			{
+				Role: RuntimeRoleAlpineMask, Kind: RuntimeAssetScript,
+				PrimaryURL: AlpineMaskCDNURL, LocalURL: AlpineMaskURL,
+				Integrity: AlpineMaskIntegrity, Enabled: true, Defer: true,
+			},
+			{
+				Role: RuntimeRoleAlpineJS, Kind: RuntimeAssetScript,
+				PrimaryURL: AlpineJSCDNURL, LocalURL: AlpineJSURL,
+				Integrity: AlpineJSIntegrity, Enabled: true, IncludeInMinimal: true, Defer: true,
+			},
+			{
+				Role: RuntimeRoleHTMX, Kind: RuntimeAssetScript,
+				PrimaryURL: HTMXCDNURL, LocalURL: HTMXURL,
+				Integrity: HTMXIntegrity, Enabled: true, IncludeInMinimal: true, WaitForWindowLoaded: true,
+			},
+			{
+				Role: RuntimeRoleCombobox, Kind: RuntimeAssetScript,
+				PrimaryURL: ComboboxURL, LocalURL: ComboboxURL,
+				Enabled: true, IncludeInMinimal: true, Defer: true,
+			},
+		},
+	}
+}

--- a/assets/runtime_manifest_test.go
+++ b/assets/runtime_manifest_test.go
@@ -1,0 +1,152 @@
+package assets
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestDefaultRuntimeManifestHasCompleteOrderedContract(t *testing.T) {
+	manifest := DefaultRuntimeManifest()
+
+	if manifest.Stylesheet != (RuntimeAsset{
+		Role:             RuntimeRoleStylesheet,
+		Kind:             RuntimeAssetStylesheet,
+		PrimaryURL:       StylesURL,
+		LocalURL:         StylesURL,
+		Enabled:          true,
+		IncludeInMinimal: true,
+	}) {
+		t.Fatalf("stylesheet = %#v", manifest.Stylesheet)
+	}
+	if manifest.Loader != (RuntimeAsset{
+		Role:             RuntimeRoleDependencyLoader,
+		Kind:             RuntimeAssetScript,
+		PrimaryURL:       DependencyLoaderURL,
+		LocalURL:         DependencyLoaderURL,
+		Enabled:          true,
+		IncludeInMinimal: true,
+		Defer:            true,
+	}) {
+		t.Fatalf("loader = %#v", manifest.Loader)
+	}
+
+	wantRoles := []RuntimeAssetRole{
+		RuntimeRoleAlpineCollapse,
+		RuntimeRoleAlpineFocus,
+		RuntimeRoleAlpineMask,
+		RuntimeRoleAlpineJS,
+		RuntimeRoleHTMX,
+		RuntimeRoleCombobox,
+	}
+	gotRoles := make([]RuntimeAssetRole, 0, len(manifest.Dependencies))
+	for _, dependency := range manifest.Dependencies {
+		gotRoles = append(gotRoles, dependency.Role)
+		if dependency.Kind != RuntimeAssetScript {
+			t.Errorf("%s kind = %q, want %q", dependency.Role, dependency.Kind, RuntimeAssetScript)
+		}
+		if !dependency.Enabled {
+			t.Errorf("%s must be enabled", dependency.Role)
+		}
+		if dependency.LocalURL == "" {
+			t.Errorf("%s local URL is empty", dependency.Role)
+		}
+	}
+	if !reflect.DeepEqual(gotRoles, wantRoles) {
+		t.Fatalf("dependency roles = %v, want %v", gotRoles, wantRoles)
+	}
+	wantMinimal := []bool{false, false, false, true, true, true}
+	for index, dependency := range manifest.Dependencies {
+		if dependency.IncludeInMinimal != wantMinimal[index] {
+			t.Errorf("%s IncludeInMinimal = %t, want %t", dependency.Role, dependency.IncludeInMinimal, wantMinimal[index])
+		}
+	}
+
+	assertRuntimeAsset(t, manifest.Dependencies[0], AlpineCollapseCDNURL, AlpineCollapseURL, true, false)
+	assertRuntimeAsset(t, manifest.Dependencies[1], AlpineFocusCDNURL, AlpineFocusURL, true, false)
+	assertRuntimeAsset(t, manifest.Dependencies[2], AlpineMaskCDNURL, AlpineMaskURL, true, false)
+	assertRuntimeAsset(t, manifest.Dependencies[3], AlpineJSCDNURL, AlpineJSURL, true, false)
+	assertRuntimeAsset(t, manifest.Dependencies[4], HTMXCDNURL, HTMXURL, false, true)
+	assertRuntimeAsset(t, manifest.Dependencies[5], ComboboxURL, ComboboxURL, true, false)
+}
+
+func TestDefaultRuntimeManifestIsCallerOwned(t *testing.T) {
+	mutated := DefaultRuntimeManifest()
+	mutated.Stylesheet.LocalURL = "/mutated.css"
+	mutated.Loader.PrimaryURL = "/mutated-loader.js"
+	mutated.Dependencies[0].LocalURL = "/mutated-collapse.js"
+	mutated.Dependencies = append(mutated.Dependencies, RuntimeAsset{Role: "mutated"})
+
+	fresh := DefaultRuntimeManifest()
+	if fresh.Stylesheet.LocalURL != StylesURL {
+		t.Fatalf("fresh stylesheet URL = %q", fresh.Stylesheet.LocalURL)
+	}
+	if fresh.Loader.PrimaryURL != DependencyLoaderURL {
+		t.Fatalf("fresh loader URL = %q", fresh.Loader.PrimaryURL)
+	}
+	if fresh.Dependencies[0].LocalURL != AlpineCollapseURL {
+		t.Fatalf("fresh collapse URL = %q", fresh.Dependencies[0].LocalURL)
+	}
+	if len(fresh.Dependencies) != 6 {
+		t.Fatalf("fresh dependency count = %d, want 6", len(fresh.Dependencies))
+	}
+}
+
+func TestDefaultRuntimeManifestLocalURLsMatchHandlerBytesAndSRI(t *testing.T) {
+	server := httptest.NewServer(Handler())
+	t.Cleanup(server.Close)
+
+	manifest := DefaultRuntimeManifest()
+	declared := append([]RuntimeAsset{manifest.Stylesheet, manifest.Loader}, manifest.Dependencies...)
+	integrityCount := 0
+	for _, asset := range declared {
+		response, err := http.Get(server.URL + asset.LocalURL)
+		if err != nil {
+			t.Fatalf("GET %s: %v", asset.LocalURL, err)
+		}
+		body, readErr := io.ReadAll(response.Body)
+		closeErr := response.Body.Close()
+		if readErr != nil || closeErr != nil {
+			t.Fatalf("read %s: %v; close: %v", asset.LocalURL, readErr, closeErr)
+		}
+		if response.StatusCode != http.StatusOK {
+			t.Errorf("GET %s status = %d, want 200", asset.LocalURL, response.StatusCode)
+		}
+		if asset.Integrity == "" {
+			continue
+		}
+		integrityCount++
+		sum := sha512.Sum384(body)
+		got := "sha384-" + base64.StdEncoding.EncodeToString(sum[:])
+		if got != asset.Integrity {
+			t.Errorf("%s served SRI = %q, manifest = %q", asset.Role, got, asset.Integrity)
+		}
+	}
+	if integrityCount != 5 {
+		t.Fatalf("manifest SRI count = %d, want 5 version-matched third-party dependencies", integrityCount)
+	}
+}
+
+func assertRuntimeAsset(
+	t *testing.T,
+	asset RuntimeAsset,
+	primaryURL string,
+	localURL string,
+	deferScript bool,
+	waitForWindowLoaded bool,
+) {
+	t.Helper()
+	if asset.PrimaryURL != primaryURL || asset.LocalURL != localURL {
+		t.Errorf("%s URLs = (%q, %q), want (%q, %q)", asset.Role, asset.PrimaryURL, asset.LocalURL, primaryURL, localURL)
+	}
+	if asset.Defer != deferScript {
+		t.Errorf("%s defer = %t, want %t", asset.Role, asset.Defer, deferScript)
+	}
+	if asset.WaitForWindowLoaded != waitForWindowLoaded {
+		t.Errorf("%s wait for window = %t, want %t", asset.Role, asset.WaitForWindowLoaded, waitForWindowLoaded)
+	}
+}

--- a/components/head/head.templ
+++ b/components/head/head.templ
@@ -23,11 +23,11 @@ package head
 // CDN requests. Stock CDN Tailwind cannot be used: it lacks Goshtoso's theme
 // tokens, which only exist in the compiled styles.css.
 templ dependenciesTemplate(cfg config) {
-	<link rel="stylesheet" href={ cfg.stylesheetURL }/>
+	<link rel="stylesheet" href={ cfg.manifest.Stylesheet.PrimaryURL }/>
 	if cfg.localRuntime {
 		@localDependencyScripts(cfg, false)
 	} else {
-		<script defer src={ cfg.loaderURL } { cfg.loaderAttributes(false)... }></script>
+		<script defer src={ cfg.manifest.Loader.PrimaryURL } { cfg.loaderAttributes(false)... }></script>
 	}
 }
 
@@ -35,28 +35,21 @@ templ dependenciesTemplate(cfg config) {
 // (no Alpine plugins). Use it when your page needs no plugin-backed components.
 // Same /assets/ mount requirement as Dependencies.
 templ dependenciesMinimalTemplate(cfg config) {
-	<link rel="stylesheet" href={ cfg.stylesheetURL }/>
+	<link rel="stylesheet" href={ cfg.manifest.Stylesheet.PrimaryURL }/>
 	if cfg.localRuntime {
 		@localDependencyScripts(cfg, true)
 	} else {
-		<script defer src={ cfg.loaderURL } { cfg.loaderAttributes(true)... }></script>
+		<script defer src={ cfg.manifest.Loader.PrimaryURL } { cfg.loaderAttributes(true)... }></script>
 	}
 }
 
 templ localDependencyScripts(cfg config, minimal bool) {
-	if !minimal {
-		<!-- Alpine.js plugins must load before Alpine core. -->
-		@localDependencyScript(cfg, cfg.alpineCollapse, true)
-		@localDependencyScript(cfg, cfg.alpineFocus, true)
-		@localDependencyScript(cfg, cfg.alpineMask, true)
+	<!-- Alpine.js plugins must load before Alpine core. -->
+	for _, source := range cfg.localDependencies(minimal) {
+		@localDependencyScript(cfg, source)
 	}
-	@localDependencyScript(cfg, cfg.alpineJS, true)
-	@localDependencyScript(cfg, cfg.htmx, false)
-	<script defer src={ cfg.comboboxURL } { cfg.nonceAttributes()... }></script>
 }
 
-templ localDependencyScript(cfg config, source dependencySource, deferred bool) {
-	if source.enabled {
-		<script defer?={ deferred } src={ source.localURL } { cfg.scriptAttributes(source)... }></script>
-	}
+templ localDependencyScript(cfg config, source runtimeAsset) {
+	<script defer?={ source.Defer } src={ source.LocalURL } { cfg.scriptAttributes(source)... }></script>
 }

--- a/components/head/head_templ.go
+++ b/components/head/head_templ.go
@@ -56,9 +56,9 @@ func dependenciesTemplate(cfg config) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var2 templ.SafeURL
-		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs(cfg.stylesheetURL)
+		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs(cfg.manifest.Stylesheet.PrimaryURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 26, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 26, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -79,9 +79,9 @@ func dependenciesTemplate(cfg config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
-			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.loaderURL)
+			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.manifest.Loader.PrimaryURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 30, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 30, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 			if templ_7745c5c3_Err != nil {
@@ -133,9 +133,9 @@ func dependenciesMinimalTemplate(cfg config) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 templ.SafeURL
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(cfg.stylesheetURL)
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(cfg.manifest.Stylesheet.PrimaryURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 38, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 38, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -156,9 +156,9 @@ func dependenciesMinimalTemplate(cfg config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.loaderURL)
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.manifest.Loader.PrimaryURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 42, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 42, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
 			if templ_7745c5c3_Err != nil {
@@ -202,70 +202,21 @@ func localDependencyScripts(cfg config, minimal bool) templ.Component {
 			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		if !minimal {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<!-- Alpine.js plugins must load before Alpine core. --> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<!-- Alpine.js plugins must load before Alpine core. -->")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		for _, source := range cfg.localDependencies(minimal) {
+			templ_7745c5c3_Err = localDependencyScript(cfg, source).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = localDependencyScript(cfg, cfg.alpineCollapse, true).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = localDependencyScript(cfg, cfg.alpineFocus, true).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = localDependencyScript(cfg, cfg.alpineMask, true).Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = localDependencyScript(cfg, cfg.alpineJS, true).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = localDependencyScript(cfg, cfg.htmx, false).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<script defer src=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.comboboxURL)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 55, Col: 36}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, cfg.nonceAttributes())
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "></script>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
 		}
 		return nil
 	})
 }
 
-func localDependencyScript(cfg config, source dependencySource, deferred bool) templ.Component {
+func localDependencyScript(cfg config, source runtimeAsset) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -281,47 +232,45 @@ func localDependencyScript(cfg config, source dependencySource, deferred bool) t
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		if source.enabled {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<script")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<script")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if source.Defer {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " defer")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if deferred {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, " defer")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, " src=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.ResolveAttributeValue(source.localURL)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 60, Col: 51}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var10)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, cfg.scriptAttributes(source))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "></script>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, " src=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(source.LocalURL)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 54, Col: 54}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, cfg.scriptAttributes(source))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "></script>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
 		}
 		return nil
 	})

--- a/components/head/head_test.go
+++ b/components/head/head_test.go
@@ -3,8 +3,10 @@ package head
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"html"
 	"io"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -141,6 +143,101 @@ func TestDependenciesDefaultsToPinnedCDNWithLocalFallback(t *testing.T) {
 	if !loaderEntry(t, cfg, "htmx").WaitForWindowLoaded {
 		t.Error("HTMX must wait for window load when inserted dynamically so its bootstrap cannot miss DOMContentLoaded")
 	}
+}
+
+func TestDependenciesRenderFromPublicManifestCopy(t *testing.T) {
+	manifest := customRuntimeManifest()
+	cfg := newConfigFromManifest(manifest, []Option{
+		WithDependencyCDNURL(DependencyHTMX, "https://override.example/htmx.js"),
+		WithDependencyIntegrity(DependencyHTMX, "sha384-override"),
+	})
+
+	manifest.Stylesheet.PrimaryURL = "/mutated/styles.css"
+	manifest.Loader.PrimaryURL = "/mutated/loader.js"
+	manifest.Dependencies[0].PrimaryURL = "/mutated/collapse.js"
+
+	out := render(t, dependenciesTemplate(cfg))
+	if !strings.Contains(out, `href="/contract/styles.css"`) {
+		t.Fatalf("stylesheet did not come from copied manifest\n%s", out)
+	}
+	if !strings.Contains(out, `src="/contract/loader.js"`) {
+		t.Fatalf("loader did not come from copied manifest\n%s", out)
+	}
+
+	loader := parseLoaderConfig(t, out)
+	if got := loaderEntry(t, loader, "alpine-collapse"); got.PrimaryURL != "https://primary.example/alpine-collapse.js" || got.FallbackURL != "/contract/alpine-collapse.js" {
+		t.Fatalf("collapse entry = %#v", got)
+	}
+	if got := loaderEntry(t, loader, "htmx"); got.PrimaryURL != "https://override.example/htmx.js" || got.FallbackURL != "/contract/htmx.js" || got.Integrity != "sha384-override" || !got.WaitForWindowLoaded {
+		t.Fatalf("option-adjusted HTMX entry = %#v", got)
+	}
+}
+
+func TestDependenciesMinimalFiltersPublicManifestOrder(t *testing.T) {
+	manifest := customRuntimeManifest()
+	manifest.Dependencies[0].IncludeInMinimal = true
+	manifest.Dependencies[3].IncludeInMinimal = false
+	cfg := newConfigFromManifest(manifest, nil)
+	loader := parseLoaderConfig(t, render(t, dependenciesMinimalTemplate(cfg)))
+
+	want := []string{"alpine-collapse", "htmx", "combobox"}
+	got := make([]string, 0, len(loader.Dependencies))
+	for _, dependency := range loader.Dependencies {
+		got = append(got, dependency.Name)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("minimal order = %v, want %v", got, want)
+	}
+}
+
+func TestDependenciesLocalRuntimeUsesPublicManifestOrderAndDefer(t *testing.T) {
+	manifest := customRuntimeManifest()
+	manifest.Stylesheet.PrimaryURL = "https://primary.example/styles.css"
+	manifest.Loader.PrimaryURL = "https://primary.example/loader.js"
+	cfg := newConfigFromManifest(manifest, []Option{WithLocalRuntime()})
+	out := render(t, dependenciesTemplate(cfg))
+
+	if !strings.Contains(out, `href="/contract/styles.css"`) || strings.Contains(out, manifest.Stylesheet.PrimaryURL) {
+		t.Fatalf("local runtime must use manifest stylesheet local URL\n%s", out)
+	}
+	previous := -1
+	for _, dependency := range manifest.Dependencies {
+		index := strings.Index(out, `src="`+dependency.LocalURL+`"`)
+		if index < 0 {
+			t.Fatalf("local rendering missing %s at %s\n%s", dependency.Role, dependency.LocalURL, out)
+		}
+		if index <= previous {
+			t.Fatalf("local rendering order changed at %s\n%s", dependency.Role, out)
+		}
+		previous = index
+	}
+	if strings.Contains(out, manifest.Loader.LocalURL) {
+		t.Fatalf("local runtime must not execute bootstrap loader\n%s", out)
+	}
+	if !strings.Contains(out, `<script src="/contract/htmx.js"`) {
+		t.Fatalf("HTMX must preserve non-deferred direct tag semantics\n%s", out)
+	}
+	if !strings.Contains(out, `<script defer src="/contract/alpine.js"`) {
+		t.Fatalf("Alpine must preserve deferred direct tag semantics\n%s", out)
+	}
+}
+
+func customRuntimeManifest() assets.RuntimeManifest {
+	manifest := assets.DefaultRuntimeManifest()
+	manifest.Stylesheet.PrimaryURL = "/contract/styles.css"
+	manifest.Stylesheet.LocalURL = "/contract/styles.css"
+	manifest.Loader.PrimaryURL = "/contract/loader.js"
+	manifest.Loader.LocalURL = "/contract/loader.js"
+	for index := range manifest.Dependencies {
+		dependency := &manifest.Dependencies[index]
+		dependency.PrimaryURL = fmt.Sprintf("https://primary.example/%s.js", dependency.Role)
+		dependency.LocalURL = fmt.Sprintf("/contract/%s.js", dependency.Role)
+		dependency.Integrity = fmt.Sprintf("sha384-%s", dependency.Role)
+	}
+	manifest.Dependencies[len(manifest.Dependencies)-1].PrimaryURL = assets.ComboboxURL
+	manifest.Dependencies[len(manifest.Dependencies)-1].LocalURL = assets.ComboboxURL
+	manifest.Dependencies[len(manifest.Dependencies)-1].Integrity = ""
+	return manifest
 }
 
 func TestDependenciesFunctionalOptionsOverrideIndividualSources(t *testing.T) {

--- a/components/head/types.go
+++ b/components/head/types.go
@@ -23,27 +23,15 @@ const (
 	DependencyHTMX Dependency = "htmx"
 )
 
-type dependencySource struct {
-	cdnURL    string
-	localURL  string
-	integrity string
-	enabled   bool
+type config struct {
+	initialized   bool
+	manifest      assets.RuntimeManifest
+	nonce         string
+	localFallback bool
+	localRuntime  bool
 }
 
-type config struct {
-	initialized    bool
-	stylesheetURL  string
-	comboboxURL    string
-	loaderURL      string
-	nonce          string
-	localFallback  bool
-	localRuntime   bool
-	alpineJS       dependencySource
-	alpineCollapse dependencySource
-	alpineFocus    dependencySource
-	alpineMask     dependencySource
-	htmx           dependencySource
-}
+type runtimeAsset = assets.RuntimeAsset
 
 // Option configures the dependency set emitted by Dependencies or
 // DependenciesMinimal.
@@ -66,7 +54,7 @@ func WithDependencyCDNURL(dependency Dependency, url string) Option {
 			return
 		}
 		if source := cfg.source(dependency); source != nil {
-			source.cdnURL = url
+			source.PrimaryURL = url
 		}
 	})
 }
@@ -79,7 +67,7 @@ func WithDependencyLocalURL(dependency Dependency, url string) Option {
 			return
 		}
 		if source := cfg.source(dependency); source != nil {
-			source.localURL = url
+			source.LocalURL = url
 		}
 	})
 }
@@ -89,7 +77,7 @@ func WithDependencyLocalURL(dependency Dependency, url string) Option {
 func WithDependencyIntegrity(dependency Dependency, integrity string) Option {
 	return optionFunc(func(cfg *config) {
 		if source := cfg.source(dependency); source != nil {
-			source.integrity = integrity
+			source.Integrity = integrity
 		}
 	})
 }
@@ -114,7 +102,7 @@ func WithLocalRuntime() Option {
 func WithoutDependency(dependency Dependency) Option {
 	return optionFunc(func(cfg *config) {
 		if source := cfg.source(dependency); source != nil {
-			source.enabled = false
+			source.Enabled = false
 		}
 	})
 }
@@ -123,7 +111,8 @@ func WithoutDependency(dependency Dependency) Option {
 func WithStylesheetURL(url string) Option {
 	return optionFunc(func(cfg *config) {
 		if url != "" {
-			cfg.stylesheetURL = url
+			cfg.manifest.Stylesheet.PrimaryURL = url
+			cfg.manifest.Stylesheet.LocalURL = url
 		}
 	})
 }
@@ -132,7 +121,10 @@ func WithStylesheetURL(url string) Option {
 func WithComboboxURL(url string) Option {
 	return optionFunc(func(cfg *config) {
 		if url != "" {
-			cfg.comboboxURL = url
+			if source := cfg.asset(assets.RuntimeRoleCombobox); source != nil {
+				source.PrimaryURL = url
+				source.LocalURL = url
+			}
 		}
 	})
 }
@@ -142,48 +134,22 @@ func WithComboboxURL(url string) Option {
 func WithLoaderURL(url string) Option {
 	return optionFunc(func(cfg *config) {
 		if url != "" {
-			cfg.loaderURL = url
+			cfg.manifest.Loader.PrimaryURL = url
+			cfg.manifest.Loader.LocalURL = url
 		}
 	})
 }
 
 func newConfig(options []Option) config {
+	return newConfigFromManifest(assets.DefaultRuntimeManifest(), options)
+}
+
+func newConfigFromManifest(manifest assets.RuntimeManifest, options []Option) config {
+	manifest.Dependencies = append([]assets.RuntimeAsset(nil), manifest.Dependencies...)
 	cfg := config{
 		initialized:   true,
-		stylesheetURL: "/assets/styles.css",
-		comboboxURL:   "/assets/js/combobox.js",
-		loaderURL:     "/assets/js/dependency-loader.js",
+		manifest:      manifest,
 		localFallback: true,
-		alpineJS: dependencySource{
-			cdnURL:    assets.AlpineJSCDNURL,
-			localURL:  assets.AlpineJSURL,
-			integrity: assets.AlpineJSIntegrity,
-			enabled:   true,
-		},
-		alpineCollapse: dependencySource{
-			cdnURL:    assets.AlpineCollapseCDNURL,
-			localURL:  assets.AlpineCollapseURL,
-			integrity: assets.AlpineCollapseIntegrity,
-			enabled:   true,
-		},
-		alpineFocus: dependencySource{
-			cdnURL:    assets.AlpineFocusCDNURL,
-			localURL:  assets.AlpineFocusURL,
-			integrity: assets.AlpineFocusIntegrity,
-			enabled:   true,
-		},
-		alpineMask: dependencySource{
-			cdnURL:    assets.AlpineMaskCDNURL,
-			localURL:  assets.AlpineMaskURL,
-			integrity: assets.AlpineMaskIntegrity,
-			enabled:   true,
-		},
-		htmx: dependencySource{
-			cdnURL:    assets.HTMXCDNURL,
-			localURL:  assets.HTMXURL,
-			integrity: assets.HTMXIntegrity,
-			enabled:   true,
-		},
 	}
 	for _, option := range options {
 		if option != nil {
@@ -191,39 +157,43 @@ func newConfig(options []Option) config {
 		}
 	}
 	if cfg.localRuntime {
-		for _, source := range cfg.sources() {
-			source.cdnURL = source.localURL
+		cfg.manifest.Stylesheet.PrimaryURL = cfg.manifest.Stylesheet.LocalURL
+		cfg.manifest.Loader.PrimaryURL = cfg.manifest.Loader.LocalURL
+		for index := range cfg.manifest.Dependencies {
+			source := &cfg.manifest.Dependencies[index]
+			source.PrimaryURL = source.LocalURL
 		}
 		cfg.localFallback = false
 	}
 	return cfg
 }
 
-func (cfg *config) source(dependency Dependency) *dependencySource {
+func (cfg *config) source(dependency Dependency) *assets.RuntimeAsset {
+	var role assets.RuntimeAssetRole
 	switch dependency {
 	case DependencyAlpineJS:
-		return &cfg.alpineJS
+		role = assets.RuntimeRoleAlpineJS
 	case DependencyAlpineCollapse:
-		return &cfg.alpineCollapse
+		role = assets.RuntimeRoleAlpineCollapse
 	case DependencyAlpineFocus:
-		return &cfg.alpineFocus
+		role = assets.RuntimeRoleAlpineFocus
 	case DependencyAlpineMask:
-		return &cfg.alpineMask
+		role = assets.RuntimeRoleAlpineMask
 	case DependencyHTMX:
-		return &cfg.htmx
+		role = assets.RuntimeRoleHTMX
 	default:
 		return nil
 	}
+	return cfg.asset(role)
 }
 
-func (cfg *config) sources() []*dependencySource {
-	return []*dependencySource{
-		&cfg.alpineCollapse,
-		&cfg.alpineFocus,
-		&cfg.alpineMask,
-		&cfg.alpineJS,
-		&cfg.htmx,
+func (cfg *config) asset(role assets.RuntimeAssetRole) *assets.RuntimeAsset {
+	for index := range cfg.manifest.Dependencies {
+		if cfg.manifest.Dependencies[index].Role == role {
+			return &cfg.manifest.Dependencies[index]
+		}
 	}
+	return nil
 }
 
 type loaderDependency struct {
@@ -240,33 +210,21 @@ type loaderConfig struct {
 
 func (cfg config) loaderAttributes(minimal bool) templ.Attributes {
 	dependencies := make([]loaderDependency, 0, 6)
-	appendSource := func(name string, source dependencySource, waitForWindowLoaded bool) {
-		if !source.enabled {
-			return
+	for _, source := range cfg.manifest.Dependencies {
+		if !source.Enabled || minimal && !source.IncludeInMinimal {
+			continue
 		}
 		entry := loaderDependency{
-			Name:                name,
-			PrimaryURL:          source.cdnURL,
-			Integrity:           source.integrity,
-			WaitForWindowLoaded: waitForWindowLoaded,
+			Name:                string(source.Role),
+			PrimaryURL:          source.PrimaryURL,
+			Integrity:           source.Integrity,
+			WaitForWindowLoaded: source.WaitForWindowLoaded,
 		}
-		if cfg.localFallback && source.cdnURL != source.localURL {
-			entry.FallbackURL = source.localURL
+		if cfg.localFallback && source.PrimaryURL != source.LocalURL {
+			entry.FallbackURL = source.LocalURL
 		}
 		dependencies = append(dependencies, entry)
 	}
-
-	if !minimal {
-		appendSource("alpine-collapse", cfg.alpineCollapse, false)
-		appendSource("alpine-focus", cfg.alpineFocus, false)
-		appendSource("alpine-mask", cfg.alpineMask, false)
-	}
-	appendSource("alpine", cfg.alpineJS, false)
-	appendSource("htmx", cfg.htmx, true)
-	dependencies = append(dependencies, loaderDependency{
-		Name:       "combobox",
-		PrimaryURL: cfg.comboboxURL,
-	})
 
 	payload, err := json.Marshal(loaderConfig{Dependencies: dependencies})
 	if err != nil {
@@ -279,21 +237,24 @@ func (cfg config) loaderAttributes(minimal bool) templ.Attributes {
 	return attrs
 }
 
-func (cfg config) scriptAttributes(source dependencySource) templ.Attributes {
+func (cfg config) localDependencies(minimal bool) []runtimeAsset {
+	dependencies := make([]runtimeAsset, 0, len(cfg.manifest.Dependencies))
+	for _, source := range cfg.manifest.Dependencies {
+		if source.Enabled && (!minimal || source.IncludeInMinimal) {
+			dependencies = append(dependencies, source)
+		}
+	}
+	return dependencies
+}
+
+func (cfg config) scriptAttributes(source runtimeAsset) templ.Attributes {
 	attrs := templ.Attributes{}
-	if source.integrity != "" {
+	if source.Integrity != "" {
 		attrs["crossorigin"] = "anonymous"
-		attrs["integrity"] = source.integrity
+		attrs["integrity"] = source.Integrity
 	}
 	if cfg.nonce != "" {
 		attrs["nonce"] = cfg.nonce
 	}
 	return attrs
-}
-
-func (cfg config) nonceAttributes() templ.Attributes {
-	if cfg.nonce == "" {
-		return nil
-	}
-	return templ.Attributes{"nonce": cfg.nonce}
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -108,6 +108,54 @@ the embedded bytes. When a custom CDN or local URL changes the bytes, pass its
 matching hash with `WithDependencyIntegrity`; pass an empty hash only when the
 application deliberately disables SRI for that dependency.
 
+#### Runtime manifest and exact library identity
+
+Consumers that cache Goshtoso for offline use, publish an asset inventory, or
+need to validate their rendered shell can use the public assets contract instead
+of copying paths from generated files or the Go module cache:
+
+```go
+import (
+    "fmt"
+
+    "github.com/araihu/goshtoso/assets"
+)
+
+identity := assets.GoshtosoVersion()
+if identity.Status != assets.VersionExact {
+    // Fail closed: development, replaced, and unavailable builds do not expose
+    // identity.Version as if it were the bytes of a released dependency.
+    return fmt.Errorf("goshtoso identity is %s", identity.Status)
+}
+
+runtime := assets.DefaultRuntimeManifest()
+// runtime.Stylesheet.LocalURL and runtime.Loader.LocalURL are served by Handler.
+// runtime.Dependencies is caller-owned and ordered for execution.
+for _, dependency := range runtime.Dependencies {
+    cache(dependency.Role, dependency.LocalURL, dependency.Integrity)
+}
+```
+
+`RuntimeManifest.Stylesheet` is the compiled CSS. `Loader` is the external
+bootstrap rendered by the CDN-first default. `Dependencies` contains Alpine
+Collapse, Alpine Focus, Alpine Mask, Alpine core, HTMX, and combobox in exact
+execution order, with explicit roles, primary and local URLs, SRI, enabled,
+minimal-set membership, direct-tag defer, and loader-readiness semantics.
+Direct local rendering uses the dependency slice and does not execute the
+loader again.
+
+Each `DefaultRuntimeManifest` call owns its value and dependency slice; caller
+mutation cannot change later results or `head.Dependencies()` rendering. Every
+declared local URL uses the `/assets/` mount and is served by `assets.Handler()`.
+
+`GoshtosoVersion` reads Go build information. `VersionExact` covers an
+unreplaced versioned module, including immutable pseudo-versions. A local or
+module replacement reports `VersionReplaced`; its requested and replacement
+records remain available as metadata, but `VersionInfo.Version` stays empty so
+the requested release cannot be mistaken for replacement bytes. Unversioned
+main-module builds report `VersionDevelopment`; missing build metadata reports
+`VersionUnavailable`.
+
 Skip the rest of this section unless you maintain your own Tailwind build.
 
 ### 2b. Extract Goshtoso CSS (only for a custom Tailwind build)

--- a/docs/audits/2026-07-27-public-runtime-manifest.md
+++ b/docs/audits/2026-07-27-public-runtime-manifest.md
@@ -1,0 +1,391 @@
+# Public Runtime Manifest and Library Version Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish a deterministic, caller-owned Goshtoso runtime/fallback
+manifest plus fail-closed build-version identity, and make `head.Dependencies`
+render from that contract.
+
+**Architecture:** Package `assets` owns public immutable value types and builds
+a fresh default manifest on every call from the same generated URL and SRI
+constants used by embedded files. Package `head` copies that manifest into its
+per-render config, applies existing functional options to the copy, and derives
+both loader JSON and local-only tags from the ordered dependency slice. Version
+identity reads Go build information, exposes an exact version only for an
+unreplaced module, and reports development, replacement, or unavailable states
+without pretending they are a release.
+
+**Tech Stack:** Go 1.26.5, `runtime/debug`, `net/http/httptest`, templ,
+Playwright, generated vendorgen constants.
+
+## Global Constraints
+
+- Frozen base: `7576710844cf2e60a5e928c837df534ef5878c04` for both `HEAD`
+  and fetched `origin/main` before edits.
+- Worktree: isolated Codex worktree on `codex/public-runtime-manifest`;
+  primary checkout and other worktrees are read-only and out of scope.
+- No Manja-specific API, Manja edits, module-cache scraping, runtime network
+  access, exposed `embed.FS`, mutable global manifest, CSP/SRI weakening, or
+  future release version hardcode.
+- Runtime dependency order: compiled CSS; Alpine Collapse; Alpine Focus;
+  Alpine Mask; Alpine core; HTMX; combobox. The default bootstrap loader is
+  separately explicit because it is rendered by CDN-first mode but is not a
+  runtime dependency to execute twice.
+- All declared local URLs must resolve through `assets.Handler()`; every
+  non-empty SRI must match the exact served bytes.
+- Caller mutation must not affect later manifest calls, functional options, or
+  rendering.
+- Brand SVGs at `araihu/assets@81300f5`, Goshtoso logos, favicons, themes, and
+  unrelated site recipe work remain untouched.
+- No push, PR, merge, tag, release, deployment, or Manja mutation.
+
+## Pre-code audit and decisions
+
+- [x] Read repository `AGENTS.md` completely.
+- [x] Fetched `origin`; verified clean detached base and exact frozen SHA;
+  created only `codex/public-runtime-manifest` in the supplied worktree.
+- [x] Read approved Manja design lines 57-90 and 190-240 plus complete rollout
+  and acceptance sections. Contract requires public version identity, public
+  ordered fallback data, same-version `assets.Handler()` bytes, and fail-closed
+  handling when identity is not exact.
+- [x] Read `docs/audits/2026-07-26-head-dependency-fallback.md`. Existing
+  v0.0.13 loader is sequential, creates a fresh fallback script, waits for
+  `window.load` before dynamic HTMX insertion, and keeps combobox first-party.
+- [x] Inspected `assets`, `components/head`, vendorgen inputs/outputs, loader,
+  unit/E2E tests, `docs/USAGE.md`, `docs/COMPONENT_MODEL.md`, release buildinfo,
+  external examples, and generated using-goshtoso references.
+- [x] Existing code duplicates stylesheet/loader/combobox paths and the five
+  dependency records inside private `head.config`; consumers cannot access the
+  complete ordered contract without reading private/generated code.
+- [x] Existing public URL/SRI constants cover versioned third-party files, but
+  compiled CSS, loader, and combobox URLs have no public constants.
+- [x] Existing `site/internal/buildinfo` is demo-only ldflag metadata and cannot
+  identify the library bytes linked into an arbitrary consumer.
+- [x] API decision: `assets.DefaultRuntimeManifest() RuntimeManifest` returns
+  value fields plus a fresh `Dependencies` slice. `Stylesheet` and `Loader` are
+  explicit top-level assets; ordered runtime dependencies remain one slice so a
+  caller never mistakes the bootstrap loader for an additional runtime script.
+- [x] API decision: `assets.GoshtosoVersion() VersionInfo` returns
+  `VersionExact`, `VersionDevelopment`, `VersionReplaced`, or
+  `VersionUnavailable`. `VersionInfo.Version` stays empty unless status is
+  exact. Replacement request and actual replacement metadata use separate
+  fields, preventing a replaced `v0.0.13` request from being reported as the
+  bytes of release `v0.0.13`.
+
+---
+
+### Task 1: Lock public manifest and handler identity with RED tests
+
+**Files:**
+- Create: `assets/runtime_manifest_test.go`
+- Test: `assets/runtime_manifest_test.go`
+
+**Interfaces:**
+- Consumes: existing public URL/SRI constants and `assets.Handler()`.
+- Produces expected API: `DefaultRuntimeManifest() RuntimeManifest`,
+  `RuntimeAsset`, `RuntimeAssetKind`, and `RuntimeAssetRole`.
+
+- [x] **Step 1: Write failing API/order test**
+
+  Assert literal roles in order: collapse, focus, mask, Alpine, HTMX,
+  combobox. Assert stylesheet and loader roles/kinds/URLs, runtime primary and
+  local URLs, SRI, enabled, defer, and readiness flags.
+
+- [x] **Step 2: Run test and preserve RED**
+
+  Run: `go test ./assets -run 'TestDefaultRuntimeManifest' -count=1`
+
+  Expected: compile failure because public manifest types/functions do not
+  exist.
+
+- [x] **Step 3: Add mutation isolation and Handler/SRI tests while still RED**
+
+  Mutate every field and the dependency slice returned by one call, then assert
+  a later call remains literal-default. Serve every local URL through
+  `httptest.NewServer(Handler())`; assert HTTP 200 and verify SHA-384 for every
+  non-empty integrity value against response bytes.
+
+### Task 2: Lock fail-closed version behavior with RED tests
+
+**Files:**
+- Create: `assets/version.go`
+- Create: `assets/library_version_test.go`
+
+**Interfaces:**
+- Produces: `GoshtosoVersion() VersionInfo`, `VersionStatus`,
+  `VersionReference`, and status constants.
+- Internal test seam: `resolveGoshtosoVersion(*debug.BuildInfo, bool)`.
+
+- [x] **Step 1: Write synthetic build-info table test**
+
+  Cover released dependency `v0.0.13`, exact main-module version, main-module
+  development, absent module, unavailable build info, local-path replacement,
+  and versioned replacement. Only unreplaced exact cases may populate
+  `VersionInfo.Version`.
+
+- [x] **Step 2: Run test and preserve RED**
+
+  Run: `go test ./assets -run 'TestResolveGoshtosoVersion' -count=1`
+
+  Expected: compile failure because version identity API does not exist.
+
+### Task 3: Implement smallest public assets contract
+
+**Files:**
+- Create: `assets/runtime_manifest.go`
+- Create: `assets/version.go`
+- Modify: `assets/embed.go`
+
+**Interfaces:**
+- `func DefaultRuntimeManifest() RuntimeManifest`
+- `func GoshtosoVersion() VersionInfo`
+- Public constants for Goshtoso stylesheet, dependency loader, and combobox URLs.
+
+- [x] **Step 1: Implement public value types and literal fresh manifest**
+
+  Use no package-level slice/map. Construct a new dependency slice per call
+  from vendorgen constants. Document order, ownership, mount behavior, SRI,
+  defer, loader readiness, and local URL semantics.
+
+- [x] **Step 2: Implement build-info resolver**
+
+  Find `github.com/araihu/goshtoso` as main module or dependency. Return
+  replacement status before interpreting requested version. Treat empty,
+  `(devel)`, and `devel` as development. Keep exact version empty for every
+  non-exact status.
+
+- [x] **Step 3: Run focused assets tests GREEN**
+
+  Run: `go test ./assets -count=1`
+
+### Task 4: Make all head render paths derive from public manifest
+
+**Files:**
+- Modify: `components/head/types.go`
+- Modify: `components/head/head.templ`
+- Modify: `components/head/head_test.go`
+- Modify: `components/head/head_coverage_test.go`
+- Generate: `components/head/head_templ.go`
+
+**Interfaces:**
+- Consumes: `assets.DefaultRuntimeManifest()` and its value-owned fields.
+- Preserves: every existing `head.Option`, dependency constant, nonce behavior,
+  loader JSON/event names, local-only tags, zero-value instance behavior, and
+  full/minimal public constructors.
+
+- [x] **Step 1: Write failing manifest/render parity tests**
+
+  Assert default loader JSON matches manifest runtime order and values;
+  local-only markup matches manifest local URLs and defer order; minimal omits
+  only the three plugin roles; functional options alter only their manifest
+  copy; mutation of a public result cannot alter rendering.
+
+- [x] **Step 2: Run focused RED**
+
+  Run: `go test ./components/head -run 'TestDependencies.*Manifest' -count=1`
+
+  Expected: failure because existing private config is not driven by the public
+  manifest and does not expose parity helpers.
+
+- [x] **Step 3: Refactor config and templates minimally**
+
+  Store one `assets.RuntimeManifest` per config. Map existing public dependency
+  identifiers to roles, apply options to copied asset entries, filter minimal
+  roles from the same slice, and range local scripts from that slice.
+
+- [x] **Step 4: Generate and run GREEN**
+
+  Run: `templ generate && go test ./components/head -count=1`
+
+### Task 5: Update public consumer guidance and generated references
+
+**Files:**
+- Modify: `docs/USAGE.md`
+- Modify: `.agents/skills/using-goshtoso/SKILL.md`
+- Generate if changed: `.agents/skills/using-goshtoso/references/components-reference.md`
+- Generate if changed: `.claude/skills/using-goshtoso/components-reference.md`
+- Modify: this audit record
+
+**Interfaces:**
+- Documents exact API, fail-closed status check, immutable result ownership,
+  direct `/assets/` mount, loader separation, and replacement behavior.
+
+- [x] **Step 1: Add concise consumer examples and caveats**
+
+  Show caching every declared local URL, checking `VersionExact`, and rejecting
+  development/replaced/unavailable identity for same-version offline readiness.
+
+- [x] **Step 2: Run `go run ./cmd/skillgen`**
+
+  Preserve generated reference parity. Record zero drift if new API does not
+  change component package declarations.
+
+- [x] **Step 3: Record all snags and API tradeoffs**
+
+  Append exact source dives, loader-order distinction, build-info replacement
+  hazard, generator behavior, and any deferred gate receipt to this document.
+
+### Task 6: Progressive assurance and delivery
+
+**Files:**
+- Verify all owned paths only.
+- Commit all intended changes locally.
+
+- [x] **Step 1: Focused and generator gates**
+
+  Run assets/head tests, `templ generate`, `go run ./cmd/vendorgen -check`,
+  `go run ./cmd/skillgen`, and a second full generation/check pass. Require zero
+  second-pass drift.
+
+- [x] **Step 2: Standalone external consumer gate**
+
+  Create a temporary module outside the repository, require Goshtoso, replace
+  it with this worktree, and run a real compile/test under `GOWORK=off`. Assert
+  manifest use and `VersionReplaced` behavior.
+
+- [x] **Step 3: Root and site gates**
+
+  Run root and site `go test`, `go vet`, build, `go fix`, and `golangci-lint`
+  against the in-repo workspace. Confirm `go fix` causes no unexplained drift.
+
+- [x] **Step 4: Browser fallback gate**
+
+  Run
+  `go test ./site/tests/e2e/... -count=1 -timeout 5m -run TestDependenciesCDNFailureLoadsOrderedLocalFallback`
+  and require forced primary failures, ordered local readiness, and all runtime
+  behaviors.
+
+- [x] **Step 5: Review, determinism, ownership, and commit**
+
+  Review public API and security/current-path behavior; correct confirmed
+  findings; rerun affected gates. Run `git diff --check`, inspect literal diff
+  and changed paths, commit locally, then prove clean worktree and exact base
+  ancestry. No push.
+
+## Evidence log
+
+RED/GREEN outputs, exact gate results, review findings, commit SHA, snags, and
+any permitted assurance receipts are appended here during execution.
+
+- RED 1, missing public manifest API:
+  `go test ./assets -run TestDefaultRuntimeManifestHasCompleteOrderedContract -count=1`
+  failed to compile with `undefined: DefaultRuntimeManifest`,
+  `undefined: RuntimeAsset`, and missing public role/kind/URL constants.
+- GREEN 1: the same focused order/API test passed after the smallest public
+  value contract was added.
+- RED 2, Handler/SRI identity:
+  `go test ./assets -run 'TestDefaultRuntimeManifest(IsCallerOwned|LocalURLsMatchHandlerBytesAndSRI)' -count=1`
+  reached every declared local URL through `Handler()` but failed with
+  `manifest SRI count = 0, want 5 version-matched third-party dependencies`.
+  Caller-mutation isolation already passed because the minimal constructor
+  returns a fresh value-owned slice rather than a package global.
+- GREEN 2: all declared local URLs returned HTTP 200; all five public SRI
+  values matched SHA-384 of exact Handler response bytes; mutation isolation
+  remained green.
+- RED 3, fail-closed library version identity:
+  `go test ./assets -run TestResolveGoshtosoVersionDistinguishesExactDevelopmentUnavailableAndReplaced -count=1`
+  failed to compile with missing `VersionInfo`, `GoshtosoModulePath`, and
+  status constants. The table already covered released dependency,
+  development, unavailable, local replacement, and versioned replacement.
+- GREEN 3: all version-resolution table cases passed. Non-exact cases exposed
+  no `Version` or `Sum`; replacement request and selected replacement metadata
+  remained separate.
+- RED 4, rendered source parity and copy isolation:
+  `go test ./components/head -run 'TestDependencies(RenderFromPublicManifestCopy|MinimalFiltersPublicManifestOrder|LocalRuntimeUsesPublicManifestOrderAndDefer)' -count=1`
+  failed to compile with `undefined: newConfigFromManifest`, proving the
+  existing private config had no path from the public contract.
+- GREEN 4: injected-manifest tests passed for CDN-first loader JSON, minimal
+  filtering, option application, local direct-tag order/defer, and mutation
+  after config construction. Full `go test ./components/head -count=1` passed.
+- External-consumer first run exposed a test-harness snag:
+  `GoshtosoVersion status = "unavailable", want "replaced"`. `go version -m`
+  confirmed the test binary omitted test-only dependency records, while a
+  normal `cmd/probe` binary included `dep github.com/araihu/goshtoso v0.0.13`
+  and `=> ../../.. (devel)` and returned `VersionReplaced`.
+- Primary CodeRabbit review (`0.7.0`, uncommitted scope) reported four items.
+  Accepted missing `fmt` import in the consumer snippet and local-only
+  stylesheet localization. Rejected the empty-integrity guard because empty is
+  the documented/tested SRI-disable escape hatch. Rejected arbitrary manifest
+  reorder handling because no public head API accepts a caller manifest;
+  `DefaultRuntimeManifest` order and rendered parity are already locked.
+- RED 5, review correction:
+  `go test ./components/head -run TestDependenciesLocalRuntimeUsesPublicManifestOrderAndDefer -count=1`
+  rendered `href="https://primary.example/styles.css"` in local-only mode
+  instead of the manifest local URL.
+- GREEN 5: local-only stylesheet regression and full head/docs suites passed;
+  scoped CodeRabbit re-review returned zero findings.
+- RED 6, literal self-review correction:
+  `go test ./assets ./components/head -run 'Test(DefaultRuntimeManifestHasCompleteOrderedContract|DependenciesMinimalFiltersPublicManifestOrder)' -count=1`
+  failed to compile because `RuntimeAsset.IncludeInMinimal` did not exist.
+  Private role filtering meant the public manifest was not yet the sole source
+  of truth for `DependenciesMinimal` membership.
+- GREEN 6: public manifest now owns minimal-set membership; custom-manifest
+  parity and full assets/head suites passed with no private role switch.
+- Generator assurance: two consecutive runs of `templ generate`,
+  `go run ./cmd/vendorgen`, `go run ./cmd/vendorgen -check`, and
+  `go run ./cmd/skillgen` preserved identical SHA-256 values for generated
+  templ, vendorgen, and both skill reference outputs. Final generator pass also
+  reported zero templ updates. CSS inputs/utilities did not change, so
+  `just css` was not applicable.
+- External consumer: `GOWORK=off go test ./... -count=1` passed in
+  `tests/external/runtime-manifest`. Its normal executable reported requested
+  `v0.0.13`, local replacement metadata, empty exact version, and
+  `VersionReplaced`; public manifest and Handler use compiled without private
+  imports.
+- Root and site: `go fix ./...`, `go test`, `go vet`, `go build`, and
+  `golangci-lint run` all passed against the in-repo workspace; both lints
+  reported `0 issues`.
+- Browser: representative
+  `TestDependenciesCDNFailureLoadsOrderedLocalFallback` passed after final
+  corrections. Full E2E also passed: `ok .../site/tests/e2e 342.020s`.
+- Review: primary CodeRabbit review produced two accepted and two rejected
+  findings as recorded above; correction tests passed; scoped re-review
+  returned zero findings. Literal self-review then moved minimal membership
+  into the public manifest and reran all affected gates.
+- `git diff --check` passed. No deferrable gate was skipped; no quality-debt
+  receipt is required.
+- Staged-scope CodeRabbit closure reviewed all 15 owned paths, including new
+  assets API and external fixture files. Accepted two audit-only findings:
+  remove machine-specific worktree layout and synchronize completed
+  checkboxes. Rejected mandatory-checksum findings because Go build information
+  can omit `Sum` for an exact versioned main module and the contract requires an
+  exact unreplaced version; `Sum` remains supplementary when present. Rejected
+  extra external loader-body/Content-Type assertions because Handler body/SRI
+  identity is already exhaustive in assets unit tests and those loader headers
+  are not public contract. No further assurance-only review wave is scheduled.
+
+## Snags and API tradeoffs
+
+- Rendered CDN-first HTML contains stylesheet plus one bootstrap loader tag,
+  while local-only HTML contains stylesheet plus the ordered runtime scripts.
+  A flat list would invite consumers to execute the loader and scripts twice.
+  `RuntimeManifest` therefore exposes `Stylesheet`, `Loader`, and one ordered
+  `Dependencies` slice with explicit roles.
+- Go build information records the requested dependency version even when a
+  `replace` directive selects different bytes. Reporting that requested value
+  as the library version would violate same-version cache identity. Replaced
+  builds therefore expose separate request/replacement records and leave the
+  exact `Version` empty.
+- Stylesheet, loader, and combobox paths were private string literals in
+  `components/head`. They now have public assets constants and appear once in
+  `DefaultRuntimeManifest`; head options mutate only a per-render copy.
+- Vendorgen remains the canonical generator for third-party CDN/local URL and
+  SRI constants from `versions.json` plus embedded bytes. The public manifest
+  references those constants instead of reproducing their values.
+- `skillgen` indexes component packages, not the `assets` package. The public
+  assets API therefore needs explicit consumer-guide and using-goshtoso skill
+  guidance; generated component references should remain unchanged.
+- Previous manual-tag documentation required source-diving and copied versioned
+  paths. It remains a low-level escape hatch; consumers needing an inventory
+  now use the public manifest instead.
+- Go test binaries omit module records for dependencies imported only by
+  external `_test` packages. The first external gate therefore reported
+  `VersionUnavailable` even though a normal consumer binary built from the
+  same module reports the expected replacement metadata. The durable fixture
+  runs a normal `cmd/probe` executable under `GOWORK=off`; unit tests continue
+  to cover synthetic unavailable metadata as a valid fail-closed state.
+- First root lint pass found the now-unused private `config.nonceAttributes`
+  helper after local rendering moved to the manifest loop. Removed the dead
+  helper; nonce behavior remains covered on loader and every local script.

--- a/tests/external/runtime-manifest/cmd/probe/main.go
+++ b/tests/external/runtime-manifest/cmd/probe/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/araihu/goshtoso/assets"
+)
+
+func main() {
+	identity, err := json.Marshal(assets.GoshtosoVersion())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(identity))
+}

--- a/tests/external/runtime-manifest/go.mod
+++ b/tests/external/runtime-manifest/go.mod
@@ -1,0 +1,7 @@
+module example.com/goshtoso-runtime-manifest-contract
+
+go 1.26.5
+
+require github.com/araihu/goshtoso v0.0.13
+
+replace github.com/araihu/goshtoso => ../../..

--- a/tests/external/runtime-manifest/runtime_manifest_test.go
+++ b/tests/external/runtime-manifest/runtime_manifest_test.go
@@ -1,0 +1,56 @@
+package runtimecontract_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/araihu/goshtoso/assets"
+)
+
+func TestExternalConsumerCanBindManifestAndReplacementIdentity(t *testing.T) {
+	command := exec.Command("go", "run", "./cmd/probe")
+	command.Env = append(os.Environ(), "GOWORK=off")
+	output, err := command.Output()
+	if err != nil {
+		t.Fatalf("run external consumer probe: %v", err)
+	}
+	var identity assets.VersionInfo
+	if err := json.Unmarshal(output, &identity); err != nil {
+		t.Fatalf("decode external consumer identity: %v: %s", err, output)
+	}
+	if identity.Status != assets.VersionReplaced {
+		t.Fatalf("GoshtosoVersion status = %q, want %q: %#v", identity.Status, assets.VersionReplaced, identity)
+	}
+	if identity.Version != "" {
+		t.Fatalf("replaced build exposed exact version %q", identity.Version)
+	}
+	if identity.Requested.Path != assets.GoshtosoModulePath || identity.Requested.Version != "v0.0.13" {
+		t.Fatalf("requested module = %#v", identity.Requested)
+	}
+	if identity.Replacement.Path == "" {
+		t.Fatalf("replacement metadata is empty: %#v", identity)
+	}
+
+	manifest := assets.DefaultRuntimeManifest()
+	if len(manifest.Dependencies) != 6 {
+		t.Fatalf("dependency count = %d, want 6", len(manifest.Dependencies))
+	}
+	if manifest.Dependencies[0].Role != assets.RuntimeRoleAlpineCollapse {
+		t.Fatalf("first dependency = %q, want %q", manifest.Dependencies[0].Role, assets.RuntimeRoleAlpineCollapse)
+	}
+
+	server := httptest.NewServer(assets.Handler())
+	t.Cleanup(server.Close)
+	response, err := http.Get(server.URL + manifest.Loader.LocalURL)
+	if err != nil {
+		t.Fatalf("GET loader: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET loader status = %d, want 200", response.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

- expose an immutable ordered runtime/fallback manifest from `assets`
- expose fail-closed linked Goshtoso version identity
- derive default, minimal, option-adjusted, and local `head.Dependencies` rendering from one public source
- add standalone external-consumer and forced-CDN-failure coverage

## Related issue

Required by the Manja hybrid Wasm public-docs integration DAG.

## Type of change

- [ ] Bug fix
- [ ] New component / variant
- [ ] Visual-parity fix
- [x] Docs
- [x] Tests / CI
- [x] Refactor / chore

## Checklist

- [x] Ran `templ generate` after editing `.templ` files
- [x] CSS/Tailwind inputs unchanged; `just css` not applicable
- [x] `golangci-lint run` is clean in root and site
- [x] `go fix ./...` applied in root and site
- [x] Unit and full E2E suites pass
- [x] Demo-page work not applicable; no component variant added
- [x] Ran `go run ./cmd/skillgen`; generated references are stable
- [x] Visual theme matrix not applicable; runtime fallback browser path passed
- [x] Generated templ output came from `templ generate`

## Verification

- focused `assets`, `components/head`, and `docs` tests
- standalone external consumer with `GOWORK=off`
- forced five-CDN-failure Playwright fallback
- full E2E suite: 342.020s
- two stable templ/vendorgen/skillgen passes
- exact committed-scope review across all 15 paths
- parent replay of focused and external-consumer gates on `30c12a2`

## Screenshots

Not applicable; public API and runtime-loading contract change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public runtime manifest for inspecting ordered stylesheets, loaders, dependencies, local asset URLs, and integrity metadata.
  * Added library identity reporting that distinguishes exact, development, replaced, and unavailable builds.
  * Updated head dependency rendering to follow the runtime manifest, including custom and minimal configurations.

* **Documentation**
  * Added guidance for offline deployments, asset caching, runtime identity validation, and local asset serving.

* **Tests**
  * Added coverage for manifest ordering, integrity validation, version detection, replacements, and external consumer integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->