### PR TITLE
Make Arai Hû the default site and demo theme

### DIFF
--- a/examples/getting-started/araihu.css
+++ b/examples/getting-started/araihu.css
@@ -1,0 +1,63 @@
+/*
+ * Arai Hû for Goshtoso
+ *
+ * Load after Goshtoso's stylesheet, then set `data-theme="araihu"` on <html>.
+ * This is an organization theme, deliberately kept outside Goshtoso's base
+ * theme catalogue.
+ */
+@layer base {
+  [data-theme="araihu"] {
+    color-scheme: light;
+    --font-body: "Instrument Sans", ui-sans-serif, system-ui, sans-serif;
+    --font-title: "Instrument Sans", ui-sans-serif, system-ui, sans-serif;
+
+    /* V11 inline SVG contract. External SVGs use their embedded scheme fallback. */
+    --araihu-logo-surface: var(--color-surface);
+    --araihu-logo-ink: var(--color-on-surface-strong);
+    --araihu-logo-signal: #c7ff4a;
+
+    /* Daylight after rain: paper, deep blue, and a restrained acid-green signal. */
+    --color-surface: #f3f2e9;
+    --color-surface-alt: #e4e8eb;
+    --color-on-surface: #243348;
+    --color-on-surface-strong: #07111f;
+    --color-primary: #173b72;
+    --color-on-primary: #ffffff;
+    --color-secondary: #31588f;
+    --color-on-secondary: #ffffff;
+    --color-outline: #a3b0bf;
+    --color-outline-strong: #34465d;
+    --color-control-outline: #64748b;
+
+    /* Arai hû: black cloud, cobalt depth, lime horizon. */
+    --color-surface-dark: #07111f;
+    --color-surface-dark-alt: #10233d;
+    --color-on-surface-dark: #d5ddeb;
+    --color-on-surface-dark-strong: #f7f8f3;
+    --color-primary-dark: #c7ff4a;
+    --color-on-primary-dark: #07111f;
+    --color-secondary-dark: #7aa4df;
+    --color-on-secondary-dark: #07111f;
+    --color-outline-dark: #526981;
+    --color-outline-dark-strong: #c8d5e3;
+    --color-control-outline-dark: #718397;
+
+    --color-info: #1476b8;
+    --color-on-info: #ffffff;
+    --color-success: #258256;
+    --color-on-success: #ffffff;
+    --color-warning: #a85e00;
+    --color-on-warning: #ffffff;
+    --color-danger: #b42c46;
+    --color-on-danger: #ffffff;
+    --radius-radius: var(--radius-lg);
+  }
+
+  [data-theme="araihu"].dark,
+  .dark [data-theme="araihu"] {
+    color-scheme: dark;
+    --araihu-logo-surface: var(--color-surface-dark);
+    --araihu-logo-ink: var(--color-on-surface-dark-strong);
+    --araihu-logo-signal: var(--color-primary-dark);
+  }
+}

--- a/examples/getting-started/main.go
+++ b/examples/getting-started/main.go
@@ -52,6 +52,9 @@ const perPage = 5
 //go:embed assets/dogs/*.webp
 var dogImageFiles embed.FS
 
+//go:embed araihu.css
+var araiHuTheme []byte
+
 // columns defines the table headers
 func columns() []table.Column {
 	return []table.Column{
@@ -154,6 +157,10 @@ func appMux() *http.ServeMux {
 
 	// Serve embedded Goshtoso assets (CSS with themes, Alpine.js, HTMX, fonts)
 	mux.Handle("GET /assets/", assets.Handler())
+	mux.HandleFunc("GET /araihu.css", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/css; charset=utf-8")
+		_, _ = w.Write(araiHuTheme)
+	})
 
 	dogImages, err := fs.Sub(dogImageFiles, "assets/dogs")
 	if err != nil {

--- a/examples/getting-started/main_test.go
+++ b/examples/getting-started/main_test.go
@@ -25,6 +25,22 @@ func TestBreedsAPIUpdatesPaginatorForOnePageFilter(t *testing.T) {
 	}
 }
 
+func TestAraiHuThemeIsServed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/araihu.css", nil)
+	rec := httptest.NewRecorder()
+
+	appMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("theme status = %d, want 200", rec.Code)
+	}
+	for _, want := range []string{`[data-theme="araihu"]`, `--color-primary: #173b72`, `--color-primary-dark: #c7ff4a`} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("theme missing canonical token %q", want)
+		}
+	}
+}
+
 func TestBreedsPageRendersRoundDogPhotos(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -32,6 +48,11 @@ func TestBreedsPageRendersRoundDogPhotos(t *testing.T) {
 	appMux().ServeHTTP(rec, req)
 
 	body := rec.Body.String()
+	for _, want := range []string{`data-theme="araihu"`, `href="/araihu.css"`, `localStorage.getItem('theme') || 'araihu'`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("page missing Arai Hû default theme contract %q:\n%s", want, body)
+		}
+	}
 	if !strings.Contains(body, `/dog-images/australian-shepherd.webp`) {
 		t.Fatalf("page must render dog image cells:\n%s", body)
 	}

--- a/examples/getting-started/page.templ
+++ b/examples/getting-started/page.templ
@@ -13,8 +13,8 @@ import (
 // assets.Handler() — no CDN needed, works fully offline.
 templ Page(cfg table.Config) {
 	<!DOCTYPE html>
-	<html lang="en" x-data x-init="
-		const t = localStorage.getItem('theme') || 'goshtoso';
+	<html lang="en" data-theme="araihu" x-data x-init="
+		const t = localStorage.getItem('theme') || 'araihu';
 		document.documentElement.setAttribute('data-theme', t);
 		if (localStorage.getItem('darkMode') === 'true') document.documentElement.classList.add('dark');
 	">
@@ -25,6 +25,7 @@ templ Page(cfg table.Config) {
 			<!-- Goshtoso runtime assets: CSS (themes) + Alpine + collapse/focus + HTMX.
 			     Served from /assets/ by assets.Handler() (mounted in main.go) — no CDN. -->
 			@head.Dependencies()
+			<link rel="stylesheet" href="/araihu.css"/>
 			<!-- darkmode.js drives the theme/dark toggle; not part of Dependencies(). -->
 			<script src="/assets/js/darkmode.js"></script>
 			<style>[x-cloak] { display: none !important; }</style>

--- a/examples/getting-started/page_templ.go
+++ b/examples/getting-started/page_templ.go
@@ -40,7 +40,7 @@ func Page(cfg table.Config) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<!doctype html><html lang=\"en\" x-data x-init=\"\n\t\tconst t = localStorage.getItem('theme') || 'goshtoso';\n\t\tdocument.documentElement.setAttribute('data-theme', t);\n\t\tif (localStorage.getItem('darkMode') === 'true') document.documentElement.classList.add('dark');\n\t\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>Dog Breeds — Goshtoso Getting Started</title><!-- Goshtoso runtime assets: CSS (themes) + Alpine + collapse/focus + HTMX.\n\t\t\t     Served from /assets/ by assets.Handler() (mounted in main.go) — no CDN. -->")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<!doctype html><html lang=\"en\" data-theme=\"araihu\" x-data x-init=\"\n\t\tconst t = localStorage.getItem('theme') || 'araihu';\n\t\tdocument.documentElement.setAttribute('data-theme', t);\n\t\tif (localStorage.getItem('darkMode') === 'true') document.documentElement.classList.add('dark');\n\t\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>Dog Breeds — Goshtoso Getting Started</title><!-- Goshtoso runtime assets: CSS (themes) + Alpine + collapse/focus + HTMX.\n\t\t\t     Served from /assets/ by assets.Handler() (mounted in main.go) — no CDN. -->")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -48,7 +48,7 @@ func Page(cfg table.Config) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<!-- darkmode.js drives the theme/dark toggle; not part of Dependencies(). --><script src=\"/assets/js/darkmode.js\"></script><style>[x-cloak] { display: none !important; }</style></head><body class=\"min-h-screen bg-surface text-on-surface dark:bg-surface-dark dark:text-on-surface-dark\"><div class=\"max-w-5xl mx-auto px-6 py-12\"><h1 class=\"text-3xl font-bold font-title mb-2 text-on-surface-strong dark:text-on-surface-dark-strong\">Dog Breeds</h1><p class=\"text-on-surface-muted dark:text-on-surface-dark-muted mb-8\">A filterable, sortable, paginated table built with <a href=\"https://github.com/araihu/goshtoso\" class=\"underline text-primary dark:text-primary-dark\">Goshtoso</a> — Go + Alpine.js + Tailwind CSS + Templ + HTMX.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<link rel=\"stylesheet\" href=\"/araihu.css\"><!-- darkmode.js drives the theme/dark toggle; not part of Dependencies(). --><script src=\"/assets/js/darkmode.js\"></script><style>[x-cloak] { display: none !important; }</style></head><body class=\"min-h-screen bg-surface text-on-surface dark:bg-surface-dark dark:text-on-surface-dark\"><div class=\"max-w-5xl mx-auto px-6 py-12\"><h1 class=\"text-3xl font-bold font-title mb-2 text-on-surface-strong dark:text-on-surface-dark-strong\">Dog Breeds</h1><p class=\"text-on-surface-muted dark:text-on-surface-dark-muted mb-8\">A filterable, sortable, paginated table built with <a href=\"https://github.com/araihu/goshtoso\" class=\"underline text-primary dark:text-primary-dark\">Goshtoso</a> — Go + Alpine.js + Tailwind CSS + Templ + HTMX.</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/go.mod
+++ b/site/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/a-h/templ v0.3.1020
 	github.com/araihu/goshtoso v0.0.13
-	github.com/araihu/goshtoso-app-shells v0.0.0-20260728002904-3ca565d36c2d
+	github.com/araihu/goshtoso-app-shells v0.0.0-20260728023436-4c4aa5ae787e
 	github.com/coder/websocket v1.8.14
 	github.com/playwright-community/playwright-go v0.5700.1
 	github.com/stretchr/testify v1.11.1

--- a/site/go.sum
+++ b/site/go.sum
@@ -8,8 +8,8 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/araihu/goshtoso v0.0.13 h1:In7mqr8LX/nG+85Fz5xcGre7znyCiaUBGltKJUEnGaI=
 github.com/araihu/goshtoso v0.0.13/go.mod h1:SWdh/AlXnVGgW881NzTAKWk7paNsTlKMH/EGujAJoXY=
-github.com/araihu/goshtoso-app-shells v0.0.0-20260728002904-3ca565d36c2d h1:tJJEGCMFbHOU9/yoNI/sYwCiQGjVDJ/HgyDoX+5rjwU=
-github.com/araihu/goshtoso-app-shells v0.0.0-20260728002904-3ca565d36c2d/go.mod h1:Nw6QAzP/ufjO4roQqTW2MePEG7annlRmlt7FQHA3ka0=
+github.com/araihu/goshtoso-app-shells v0.0.0-20260728023436-4c4aa5ae787e h1:o8EuGtBscrJfx4PgVTg0OKuLtUO11FdEOf2X7h770VI=
+github.com/araihu/goshtoso-app-shells v0.0.0-20260728023436-4c4aa5ae787e/go.mod h1:Nw6QAzP/ufjO4roQqTW2MePEG7annlRmlt7FQHA3ka0=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/site/internal/pages/demo/componentdocshell.go
+++ b/site/internal/pages/demo/componentdocshell.go
@@ -35,7 +35,7 @@ func componentDocsConfig(persist bool) componentdocshell.Config {
 		Navigation: componentdocshell.Navigation{Items: getSidebarTopItems(""), SectionsTitle: "Components", Sections: sections, SearchPlaceholder: "Search", SearchSlot: sidebarSearchSlot()},
 		Appearance: componentdocshell.AppearanceConfig{
 			Themes:             getThemeOptions(),
-			DefaultTheme:       "goshtoso",
+			DefaultTheme:       "araihu",
 			ThemeSelectorID:    "site-theme",
 			PersistPreferences: persist,
 			DarkModeBinding: &componentdocshell.DarkModeBinding{

--- a/site/internal/pages/demo/components/landing.templ
+++ b/site/internal/pages/demo/components/landing.templ
@@ -51,6 +51,7 @@ type themeChip struct {
 // Curated subset of themes: visually distinct, not the whole set.
 func getThemeChips() []themeChip {
 	return []themeChip{
+		{Key: "araihu", Label: "Arai Hû"},
 		{Key: "goshtoso", Label: "Goshtoso"},
 		{Key: "minimal", Label: "Minimal"},
 		{Key: "modern", Label: "Modern"},
@@ -76,8 +77,9 @@ templ LandingPage() {
 			// lock-step with the rest of the site and avoids a flash of the default
 			// theme on navigation. Shares localStorage key 'theme' / 'darkMode'.
 			@storageConsentScript()
-			@templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!!(c&&c.allowed());var t=canStore?(localStorage.getItem('theme')||'goshtoso'):'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`)
+			@templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!!(c&&c.allowed());var t=canStore?(localStorage.getItem('theme')||'araihu'):'araihu';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`)
 			<link rel="stylesheet" href="/assets/styles.css"/>
+			<link rel="stylesheet" href="/componentdocshell/assets/araihu.css"/>
 			<script defer src={ assets.AlpineJSURL }></script>
 			<script src={ assets.HTMXURL }></script>
 			<style>[x-cloak] { display: none !important; }</style>

--- a/site/internal/pages/demo/components/landing_templ.go
+++ b/site/internal/pages/demo/components/landing_templ.go
@@ -59,6 +59,7 @@ type themeChip struct {
 // Curated subset of themes: visually distinct, not the whole set.
 func getThemeChips() []themeChip {
 	return []themeChip{
+		{Key: "araihu", Label: "Arai Hû"},
 		{Key: "goshtoso", Label: "Goshtoso"},
 		{Key: "minimal", Label: "Minimal"},
 		{Key: "modern", Label: "Modern"},
@@ -103,18 +104,18 @@ func LandingPage() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!!(c&&c.allowed());var t=canStore?(localStorage.getItem('theme')||'goshtoso'):'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!!(c&&c.allowed());var t=canStore?(localStorage.getItem('theme')||'araihu'):'araihu';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<link rel=\"stylesheet\" href=\"/assets/styles.css\"><script defer src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<link rel=\"stylesheet\" href=\"/assets/styles.css\"><link rel=\"stylesheet\" href=\"/componentdocshell/assets/araihu.css\"><script defer src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineJSURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 81, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 83, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var2)
 		if templ_7745c5c3_Err != nil {
@@ -127,7 +128,7 @@ func LandingPage() templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.HTMXURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 82, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 84, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 		if templ_7745c5c3_Err != nil {
@@ -181,7 +182,7 @@ func landingContent() templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(componentCount())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 125, Col: 33}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 127, Col: 33}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -285,7 +286,7 @@ func landingContent() templ.Component {
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(themes.Count())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 215, Col: 150}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 217, Col: 150}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
@@ -381,7 +382,7 @@ func landingContent() templ.Component {
 		var templ_7745c5c3_Var11 templ.SafeURL
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(featured.URL))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 281, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 283, Col: 42}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
@@ -429,7 +430,7 @@ func landingContent() templ.Component {
 			var templ_7745c5c3_Var13 templ.SafeURL
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(a.URL))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 299, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 301, Col: 37}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -476,7 +477,7 @@ func landingContent() templ.Component {
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(componentCount())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 329, Col: 263}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 331, Col: 263}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 		if templ_7745c5c3_Err != nil {
@@ -489,7 +490,7 @@ func landingContent() templ.Component {
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(themes.Count())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 329, Col: 296}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/components/landing.templ`, Line: 331, Col: 296}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {

--- a/site/internal/pages/demo/layout.templ
+++ b/site/internal/pages/demo/layout.templ
@@ -37,7 +37,7 @@ templ Layout(title string, activeComponent string, content templ.Component) {
 templ LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Component) {
 	<!DOCTYPE html>
 	<html lang="en" x-data="{
-		theme: (window.goshtosoStorageConsent && !window.goshtosoStorageConsent.allowed()) ? 'goshtoso' : (localStorage.getItem('theme') || 'goshtoso'),
+		theme: (window.goshtosoStorageConsent && !window.goshtosoStorageConsent.allowed()) ? 'araihu' : (localStorage.getItem('theme') || 'araihu'),
 		sidebarOpen: false,
 		showThemeDropdown: false,
 		setTheme(name) { this.theme = name; document.documentElement.setAttribute('data-theme', name); }
@@ -62,8 +62,9 @@ templ LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compon
 			<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png"/>
 			<link rel="manifest" href="/site.webmanifest"/>
 			@storageConsentScript()
-			@templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!c||c.allowed();var t=canStore?(localStorage.getItem('theme')||'goshtoso'):'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`)
+			@templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!c||c.allowed();var t=canStore?(localStorage.getItem('theme')||'araihu'):'araihu';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`)
 			<link rel="stylesheet" href="/assets/styles.css"/>
+			<link rel="stylesheet" href="/componentdocshell/assets/araihu.css"/>
 			<link rel="preconnect" href="https://fonts.googleapis.com"/>
 			<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 			<link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Montserrat:wght@400;500;600;700&display=swap" rel="stylesheet"/>
@@ -701,7 +702,8 @@ templ siteFooter() {
 
 func getThemeOptions() []selectfield.Option {
 	all := themes.All()
-	options := make([]selectfield.Option, 0, len(all))
+	options := make([]selectfield.Option, 0, len(all)+1)
+	options = append(options, selectfield.Option{Value: "araihu", Label: "Arai Hû"})
 	for _, theme := range all {
 		options = append(options, selectfield.Option{Value: theme.Key, Label: theme.Label})
 	}

--- a/site/internal/pages/demo/layout_templ.go
+++ b/site/internal/pages/demo/layout_templ.go
@@ -247,7 +247,7 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 			templ_7745c5c3_Var14 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<!doctype html><html lang=\"en\" x-data=\"{\n\t\ttheme: (window.goshtosoStorageConsent && !window.goshtosoStorageConsent.allowed()) ? 'goshtoso' : (localStorage.getItem('theme') || 'goshtoso'),\n\t\tsidebarOpen: false,\n\t\tshowThemeDropdown: false,\n\t\tsetTheme(name) { this.theme = name; document.documentElement.setAttribute('data-theme', name); }\n\t}\" x-init=\"\n\t\t$watch('theme', value => {\n\t\t\tif (!window.goshtosoStorageConsent || window.goshtosoStorageConsent.allowed()) {\n\t\t\t\tlocalStorage.setItem('theme', value);\n\t\t\t} else {\n\t\t\t\tlocalStorage.removeItem('theme');\n\t\t\t}\n\t\t\tdocument.documentElement.setAttribute('data-theme', value);\n\t\t});\n\t\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<!doctype html><html lang=\"en\" x-data=\"{\n\t\ttheme: (window.goshtosoStorageConsent && !window.goshtosoStorageConsent.allowed()) ? 'araihu' : (localStorage.getItem('theme') || 'araihu'),\n\t\tsidebarOpen: false,\n\t\tshowThemeDropdown: false,\n\t\tsetTheme(name) { this.theme = name; document.documentElement.setAttribute('data-theme', name); }\n\t}\" x-init=\"\n\t\t$watch('theme', value => {\n\t\t\tif (!window.goshtosoStorageConsent || window.goshtosoStorageConsent.allowed()) {\n\t\t\t\tlocalStorage.setItem('theme', value);\n\t\t\t} else {\n\t\t\t\tlocalStorage.removeItem('theme');\n\t\t\t}\n\t\t\tdocument.documentElement.setAttribute('data-theme', value);\n\t\t});\n\t\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -263,18 +263,18 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!c||c.allowed();var t=canStore?(localStorage.getItem('theme')||'goshtoso'):'goshtoso';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templ.Raw(`<script>(function(){try{var c=window.goshtosoStorageConsent;var canStore=!c||c.allowed();var t=canStore?(localStorage.getItem('theme')||'araihu'):'araihu';document.documentElement.setAttribute('data-theme',t);var d=canStore?localStorage.getItem('darkMode'):null;var on=d!==null?d==='true':window.matchMedia('(prefers-color-scheme: dark)').matches;if(on)document.documentElement.classList.add('dark');document.documentElement.classList.add('boot');addEventListener('DOMContentLoaded',function(){setTimeout(function(){document.documentElement.classList.remove('boot');},600);});}catch(e){}})();</script>`).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<link rel=\"stylesheet\" href=\"/assets/styles.css\"><link rel=\"preconnect\" href=\"https://fonts.googleapis.com\"><link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin><link href=\"https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Montserrat:wght@400;500;600;700&display=swap\" rel=\"stylesheet\"><script src=\"/assets/js/darkmode.js\"></script><script defer src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<link rel=\"stylesheet\" href=\"/assets/styles.css\"><link rel=\"stylesheet\" href=\"/componentdocshell/assets/araihu.css\"><link rel=\"preconnect\" href=\"https://fonts.googleapis.com\"><link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin><link href=\"https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&family=Montserrat:wght@400;500;600;700&display=swap\" rel=\"stylesheet\"><script src=\"/assets/js/darkmode.js\"></script><script defer src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var15 string
 		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineFocusURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 71, Col: 44}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 72, Col: 44}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var15)
 		if templ_7745c5c3_Err != nil {
@@ -287,7 +287,7 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineCollapseURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 72, Col: 47}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 73, Col: 47}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
 		if templ_7745c5c3_Err != nil {
@@ -300,7 +300,7 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineMaskURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 73, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 74, Col: 43}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var17)
 		if templ_7745c5c3_Err != nil {
@@ -313,7 +313,7 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.AlpineJSURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 74, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 75, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
 		if templ_7745c5c3_Err != nil {
@@ -326,7 +326,7 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.HTMXURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 75, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 76, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
 		if templ_7745c5c3_Err != nil {
@@ -339,7 +339,7 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.HTMXExtWSURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 76, Col: 36}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 77, Col: 36}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
 		if templ_7745c5c3_Err != nil {
@@ -352,7 +352,7 @@ func LayoutWithMeta(meta PageMeta, activeComponent string, content templ.Compone
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(assets.HTMXExtSSEURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 77, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 78, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 		if templ_7745c5c3_Err != nil {
@@ -973,7 +973,7 @@ func componentNavFooter(activeComponent string) templ.Component {
 				var templ_7745c5c3_Var36 templ.SafeURL
 				templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(prev.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 633, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 634, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 				if templ_7745c5c3_Err != nil {
@@ -994,7 +994,7 @@ func componentNavFooter(activeComponent string) templ.Component {
 				var templ_7745c5c3_Var37 string
 				templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(prev.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 640, Col: 23}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 641, Col: 23}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 				if templ_7745c5c3_Err != nil {
@@ -1019,7 +1019,7 @@ func componentNavFooter(activeComponent string) templ.Component {
 				var templ_7745c5c3_Var38 templ.SafeURL
 				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(next.Href))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 648, Col: 36}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 649, Col: 36}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 				if templ_7745c5c3_Err != nil {
@@ -1040,7 +1040,7 @@ func componentNavFooter(activeComponent string) templ.Component {
 				var templ_7745c5c3_Var39 string
 				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(next.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 652, Col: 23}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/layout.templ`, Line: 653, Col: 23}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 				if templ_7745c5c3_Err != nil {
@@ -1155,7 +1155,8 @@ func siteFooter() templ.Component {
 
 func getThemeOptions() []selectfield.Option {
 	all := themes.All()
-	options := make([]selectfield.Option, 0, len(all))
+	options := make([]selectfield.Option, 0, len(all)+1)
+	options = append(options, selectfield.Option{Value: "araihu", Label: "Arai Hû"})
 	for _, theme := range all {
 		options = append(options, selectfield.Option{Value: theme.Key, Label: theme.Label})
 	}

--- a/site/internal/pages/demo/theme_inventory_test.go
+++ b/site/internal/pages/demo/theme_inventory_test.go
@@ -20,9 +20,13 @@ func TestThemeOptionsMatchCompiledThemeSelectors(t *testing.T) {
 	}
 
 	options := getThemeOptions()
-	require.Len(t, options, 15)
-	require.Len(t, cssThemes, len(options))
+	require.Len(t, options, 16)
+	require.Equal(t, "araihu", options[0].Value)
+	require.Len(t, cssThemes, len(options)-1)
 	for _, option := range options {
+		if option.Value == "araihu" {
+			continue
+		}
 		require.Truef(t, cssThemes[option.Value], "theme option %q has no CSS selector", option.Value)
 	}
 	require.False(t, cssThemes["totvs"])

--- a/site/tests/e2e/landing_test.go
+++ b/site/tests/e2e/landing_test.go
@@ -124,10 +124,17 @@ func TestLanding_HeroAndStructure(t *testing.T) {
 		require.Equal(t, "dark", colorScheme, "v11 brand SVGs inherit the .dark color scheme")
 	})
 
-	t.Run("DefaultsToGoshtosoTheme", func(t *testing.T) {
+	t.Run("DefaultsToAraiHuTheme", func(t *testing.T) {
 		got, err := page.Evaluate("() => document.documentElement.getAttribute('data-theme')", nil)
 		require.NoError(t, err)
-		require.Equal(t, "goshtoso", got, "homepage should default to the Goshtoso theme")
+		require.Equal(t, "araihu", got, "homepage should default to the Arai Hû theme")
+	})
+
+	t.Run("AraiHuThemeSegmentAvailable", func(t *testing.T) {
+		segment := page.Locator("#home-theme-picker label:has(input[data-theme-key='araihu'])")
+		visible, err := segment.IsVisible()
+		require.NoError(t, err)
+		require.True(t, visible, "Arai Hû should be available in the homepage theme picker")
 	})
 
 	t.Run("GoshtosoThemeSegmentAvailable", func(t *testing.T) {

--- a/site/tests/e2e/theme_test.go
+++ b/site/tests/e2e/theme_test.go
@@ -204,12 +204,11 @@ func TestTheme_Switching(t *testing.T) {
 	themes := []struct {
 		key   string
 		label string
-		index int
 	}{
-		{"arctic", "Arctic", 3},
-		{"neo-brutalism", "Neo Brutalism", 5},
-		{"90s", "90s", 8},
-		{"minimal", "Minimal", 1},
+		{"arctic", "Arctic"},
+		{"neo-brutalism", "Neo Brutalism"},
+		{"90s", "90s"},
+		{"minimal", "Minimal"},
 	}
 
 	for _, theme := range themes {
@@ -218,27 +217,16 @@ func TestTheme_Switching(t *testing.T) {
 			trigger := page.Locator("#site-theme-trigger")
 			clickUntil(t, page, trigger, `() => document.getElementById('site-theme-trigger')?.getAttribute('aria-expanded') === 'true'`)
 
-			// Click the theme option rendered by the Select component.
-			themeOptionID := fmt.Sprintf("site-theme-option-%d", theme.index)
-			themeOption := page.Locator("#" + themeOptionID)
+			// Select by label so adding or reordering themes cannot change the target.
+			themeOption := page.Locator("#site-theme-listbox [role='option']").Filter(playwright.LocatorFilterOptions{
+				HasText: theme.label,
+			})
 			err := themeOption.WaitFor(playwright.LocatorWaitForOptions{
 				State:   playwright.WaitForSelectorStateAttached,
 				Timeout: playwright.Float(2000),
 			})
 			require.NoError(t, err)
-
-			clicked, err := page.Evaluate(
-				`(id) => {
-					const el = document.getElementById(id);
-					if (!el) return false;
-					el.scrollIntoView({ block: 'nearest' });
-					el.click();
-					return true;
-				}`,
-				themeOptionID,
-			)
-			require.NoError(t, err)
-			require.Equal(t, true, clicked)
+			require.NoError(t, themeOption.Click())
 
 			// Verify data-theme attribute changed
 			_, err = page.WaitForFunction(


### PR DESCRIPTION
## Summary
- default fresh site/demo sessions to Arai Hû
- expose Arai Hû first in theme selectors while preserving all base themes
- refresh getting-started demo and app-shell dependency

## Verification
- templ generate
- focused unit and landing E2E suites
- getting-started Go tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Arai Hû theme with light and dark mode styling.
  * Set Arai Hû as the default theme across the getting-started example and component documentation.
  * Added Arai Hû to the theme picker.
  * Added dedicated stylesheet loading for Arai Hû styling.

* **Tests**
  * Added coverage verifying theme stylesheet delivery, default theme rendering, and theme picker behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->