### PR TITLE
ci: gate standalone site dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,10 @@ jobs:
             | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCI_LINT_VERSION}"
           "$(go env GOPATH)/bin/golangci-lint" run --timeout 5m
 
-      # The site module builds against the in-repo library at this commit via a
-      # throwaway workspace (go.work is gitignored — it never lands in the tree).
-      - name: Create dev workspace (root library + site)
+      # Current-source integration: the site builds against the root library at
+      # this commit through a throwaway workspace. The pinned-dependency
+      # deployability contract runs separately in Required CI with GOWORK=off.
+      - name: Current-source integration workspace (root library + site)
         run: go work init . ./site
 
       - name: go vet (site module)
@@ -123,7 +124,7 @@ jobs:
       - name: golangci-lint (site module)
         run: cd site && "$(go env GOPATH)/bin/golangci-lint" run --timeout 5m
 
-      - name: Build server
+      - name: Build server (current-source integration)
         run: |
           GOSHTOSO_DOCS_VERSION="$(cd site && GOWORK=off go list -m -f '{{.Version}}' github.com/araihu/goshtoso)"
           go build \

--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -10,12 +10,25 @@ concurrency:
   group: required-ci-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: '1.26.5'
+
 jobs:
   required:
     name: Required CI
     runs-on: ubuntu-latest
     steps:
-      - name: Check routing
-        run: |
-          echo "Required CI check is present."
-          echo "Code CI runs separately for non-Markdown changes."
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: |
+            go.sum
+            site/go.sum
+
+      - name: Pinned-dependency deployability (site module)
+        run: ./scripts/check-site-module pinned-dependency

--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,16 @@ go test ./site/tests/e2e/... -count=1 -timeout 5m -run TestDropdown
 fresh clones; CI creates a temporary workspace so it builds against the in-repo
 library at the current commit.
 
+Both module contracts are required:
+
+- `just site-current-source-integration` tests the site against this checkout
+  through a throwaway workspace.
+- `just site-pinned-dependency-deployability` forces `GOWORK=off` and tests the
+  standalone site against the public version pinned in `site/go.mod`.
+
+See [`docs/SITE_MODULE_CONTRACTS.md`](docs/SITE_MODULE_CONTRACTS.md) for the
+two-phase sequencing required when the site adopts an unreleased root API.
+
 ## Worktree Isolation (required)
 
 Every unit of work — a feature, an example app, a bugfix, a coverage pass — MUST

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -13,6 +13,8 @@ many of these steps, but the checklist keeps the public release story coherent.
   - `go run ./cmd/vendorgen -check`
   - `npx --yes skills add . --list`
   - `npx --yes skills use . --skill using-goshtoso`
+  - `just site-current-source-integration`
+  - `just site-pinned-dependency-deployability`
   - `go test ./... -count=1`
   - `cd site && go test $(go list ./... | grep -v /tests/e2e) -count=1`
   - `go test ./site/tests/e2e/... -count=1 -timeout 15m`

--- a/docs/SITE_MODULE_CONTRACTS.md
+++ b/docs/SITE_MODULE_CONTRACTS.md
@@ -1,0 +1,61 @@
+# Site Module Contracts
+
+Goshtoso has two Go modules with different dependency contracts. Pull requests
+must keep both green.
+
+## Current-source integration
+
+`site/` must integrate with the root library from the same checkout. This mode
+uses a temporary `go.work`; it proves an atomic root-plus-site change works
+together without committing workspace state.
+
+Run:
+
+```bash
+just site-current-source-integration
+```
+
+Code CI retains this contract for site vet, lint, tests, coverage, E2E, and the
+server build.
+
+## Pinned-dependency deployability
+
+`site/` must also build as a standalone module from the Goshtoso version in
+`site/go.mod`. This mode forces `GOWORK=off`, discovers every site package, runs
+all non-E2E site tests, and builds `site/cmd/server`.
+
+Run:
+
+```bash
+just site-pinned-dependency-deployability
+```
+
+The protected `Required CI` check runs this contract on every pull request. A
+failure ends with a message such as:
+
+```text
+site pinned-dependency deployability failed during package discovery
+site/go.mod must pin a public Goshtoso version containing every API imported by site/.
+Do not mask this contract with go.work or a replace directive; publish or merge root changes first, then pin a reachable tag or pseudo-version.
+```
+
+The gate rejects a `replace` for `github.com/araihu/goshtoso`. A checked
+`replace github.com/araihu/goshtoso => ..` would make the standalone check use
+the sibling checkout, hide stale pins, and make `site/go.mod` non-portable. Pin
+a public tag or exact public pseudo-version instead.
+
+## API-change sequencing
+
+A pull request cannot pin the future squash commit that will result from its
+own merge. When `site/` needs a new root API, use two phases unless the repository
+deliberately changes its module architecture:
+
+1. Merge the root API without making the standalone site depend on it, then
+   publish a tag or wait until the merged commit resolves as a public
+   pseudo-version.
+2. In a follow-up pull request, update `site/go.mod` and `site/go.sum` to that
+   reachable version, adopt the API in `site/`, and run both contracts.
+
+A release tag is preferred for stable documentation. A public pseudo-version is
+acceptable between releases; after the next semantic tag, follow the release
+checklist and pin the site to that tag.

--- a/justfile
+++ b/justfile
@@ -47,6 +47,18 @@ js-check:
     go run ./cmd/jslint
     go run ./cmd/jsbuild -check
 
+# Test the nested site against the root library in this checkout through a
+# throwaway workspace. This is the current-source integration contract.
+site-current-source-integration:
+    ./scripts/check-site-module current-source
+
+# Test the nested site exactly as a standalone consumer of site/go.mod. This is
+# the pinned-dependency deployability contract and always forces GOWORK=off.
+site-pinned-dependency-deployability:
+    ./scripts/check-site-module pinned-dependency
+
+site-module-contracts: site-current-source-integration site-pinned-dependency-deployability
+
 # Run root unit tests, site unit tests, and E2E tests, then merge component
 # coverage data into .coverage/coverage.out and .coverage/coverage.html.
 coverage:

--- a/scripts/check-site-module
+++ b/scripts/check-site-module
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+	cat >&2 <<'EOF'
+usage: scripts/check-site-module <current-source|pinned-dependency>
+
+current-source      Test the site against the root library in this checkout.
+pinned-dependency   Test the standalone site module with GOWORK=off.
+EOF
+}
+
+mode="${1:-}"
+case "$mode" in
+	current-source)
+		contract="current-source integration"
+		;;
+	pinned-dependency)
+		contract="pinned-dependency deployability"
+		;;
+	*)
+		usage
+		exit 2
+		;;
+esac
+
+repo_root="${GOSHTOSO_CONTRACT_ROOT:-$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
+site_dir="${GOSHTOSO_CONTRACT_SITE:-$repo_root/site}"
+dependency_module="${GOSHTOSO_CONTRACT_DEPENDENCY:-github.com/araihu/goshtoso}"
+server_package="${GOSHTOSO_CONTRACT_SERVER_PACKAGE:-./cmd/server}"
+
+if [[ ! -f "$repo_root/go.mod" ]]; then
+	echo "site $contract failed: root go.mod not found at $repo_root" >&2
+	exit 1
+fi
+if [[ ! -f "$site_dir/go.mod" ]]; then
+	echo "site $contract failed: site go.mod not found at $site_dir" >&2
+	exit 1
+fi
+
+tmp_base="${TMPDIR:-/tmp}"
+tmp_base="${tmp_base%/}"
+tmp_dir="$(mktemp -d "$tmp_base/goshtoso-site-contract.XXXXXX")"
+cleanup() {
+	case "$tmp_dir" in
+		"$tmp_base"/goshtoso-site-contract.*) rm -rf -- "$tmp_dir" ;;
+		*) echo "refusing to remove unexpected temporary path: $tmp_dir" >&2 ;;
+	esac
+}
+trap cleanup EXIT
+
+fail() {
+	local stage="$1"
+	local message="site $contract failed during $stage"
+	echo "$message" >&2
+	if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+		echo "::error title=Site module contract failed::$message"
+	fi
+	if [[ "$mode" == "pinned-dependency" ]]; then
+		echo "site/go.mod must pin a public Goshtoso version containing every API imported by site/." >&2
+		echo "Do not mask this contract with go.work or a replace directive; publish or merge root changes first, then pin a reachable tag or pseudo-version." >&2
+	fi
+	exit 1
+}
+
+if [[ "$mode" == "current-source" ]]; then
+	workspace="$tmp_dir/go.work"
+	if ! (cd "$tmp_dir" && GOWORK="$workspace" go work init "$repo_root" "$site_dir"); then
+		fail "temporary workspace creation"
+	fi
+	echo "site current-source integration: root library at $repo_root"
+else
+	workspace="off"
+	replacement="$(cd "$site_dir" && GOWORK=off go list -m -f '{{with .Replace}}{{.Path}} {{.Dir}}{{end}}' "$dependency_module")" \
+		|| fail "dependency resolution"
+	if [[ -n "$replacement" ]]; then
+		echo "pinned dependency resolved through replace: $replacement" >&2
+		fail "dependency resolution (replace directives are forbidden)"
+	fi
+	version="$(cd "$site_dir" && GOWORK=off go list -m -f '{{.Version}}' "$dependency_module")" \
+		|| fail "dependency resolution"
+	if [[ -z "$version" ]]; then
+		fail "dependency resolution (missing module version)"
+	fi
+	echo "site pinned-dependency deployability: $dependency_module@$version (GOWORK=off)"
+fi
+
+packages_file="$tmp_dir/packages.txt"
+if ! (cd "$site_dir" && GOWORK="$workspace" go list ./... > "$packages_file"); then
+	fail "package discovery"
+fi
+
+site_packages=()
+while IFS= read -r package; do
+	case "$package" in
+		*/tests/e2e | */tests/e2e/*) ;;
+		*) site_packages+=("$package") ;;
+	esac
+done < "$packages_file"
+
+if [[ "${#site_packages[@]}" -eq 0 ]]; then
+	fail "package discovery (no non-E2E packages found)"
+fi
+
+if ! (cd "$site_dir" && GOWORK="$workspace" go test "${site_packages[@]}" -count=1); then
+	fail "non-E2E tests"
+fi
+
+if ! (cd "$site_dir" && GOWORK="$workspace" go build -o "$tmp_dir/server" "$server_package"); then
+	fail "server build"
+fi
+
+echo "site $contract: PASS (${#site_packages[@]} non-E2E packages; server built)"

--- a/scripts/site_module_contract_test.go
+++ b/scripts/site_module_contract_test.go
@@ -1,0 +1,141 @@
+package scripts_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSiteModuleContractsSeparateCurrentSourceFromPinnedDependency(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(repoRoot, "scripts", "check-site-module")
+
+	fixture := t.TempDir()
+	rootDir := filepath.Join(fixture, "root")
+	siteDir := filepath.Join(fixture, "site")
+	proxyDir := filepath.Join(fixture, "proxy")
+	modulePath := "example.com/library"
+	version := "v0.0.1"
+
+	writeFile(t, filepath.Join(rootDir, "go.mod"), "module "+modulePath+"\n\ngo 1.26.5\n")
+	writeFile(t, filepath.Join(rootDir, "library.go"), "package library\n\nfunc NewAPI() string { return \"current\" }\n")
+	writeFile(t, filepath.Join(siteDir, "go.mod"), fmt.Sprintf("module example.com/site\n\ngo 1.26.5\n\nrequire %s %s\n", modulePath, version))
+	writeFile(t, filepath.Join(siteDir, "cmd", "server", "main.go"), `package main
+
+import (
+	"fmt"
+	"example.com/library"
+)
+
+func main() { fmt.Println(library.NewAPI()) }
+`)
+	writeProxyModule(t, proxyDir, modulePath, version, "package library\n\nfunc OldAPI() string { return \"pinned\" }\n")
+
+	proxyURL := (&url.URL{Scheme: "file", Path: proxyDir}).String()
+	modCache := filepath.Join(fixture, "modcache")
+	t.Cleanup(func() {
+		_ = filepath.Walk(modCache, func(path string, info os.FileInfo, walkErr error) error {
+			if walkErr != nil {
+				return nil
+			}
+			return os.Chmod(path, info.Mode()|0o200)
+		})
+	})
+	env := append(os.Environ(),
+		"GOSHTOSO_CONTRACT_ROOT="+rootDir,
+		"GOSHTOSO_CONTRACT_SITE="+siteDir,
+		"GOSHTOSO_CONTRACT_DEPENDENCY="+modulePath,
+		"GOPROXY="+proxyURL,
+		"GOSUMDB=off",
+		"GOMODCACHE="+modCache,
+		"GOCACHE="+filepath.Join(fixture, "gocache"),
+	)
+
+	currentOutput, currentErr := runContract(script, "current-source", env)
+	if currentErr != nil {
+		t.Fatalf("current-source contract should pass: %v\n%s", currentErr, currentOutput)
+	}
+	if !bytes.Contains(currentOutput, []byte("site current-source integration: PASS")) {
+		t.Fatalf("current-source output missing success marker:\n%s", currentOutput)
+	}
+
+	pinnedEnv := append(append([]string{}, env...), "GOFLAGS=-mod=mod")
+	pinnedOutput, pinnedErr := runContract(script, "pinned-dependency", pinnedEnv)
+	if pinnedErr == nil {
+		t.Fatalf("pinned-dependency contract should reject unavailable API:\n%s", pinnedOutput)
+	}
+	for _, want := range [][]byte{
+		[]byte("undefined: library.NewAPI"),
+		[]byte("site pinned-dependency deployability failed during non-E2E tests"),
+	} {
+		if !bytes.Contains(pinnedOutput, want) {
+			t.Fatalf("pinned-dependency output missing %q:\n%s", want, pinnedOutput)
+		}
+	}
+}
+
+func runContract(script, mode string, env []string) ([]byte, error) {
+	cmd := exec.Command(script, mode)
+	cmd.Env = env
+	return cmd.CombinedOutput()
+}
+
+func writeProxyModule(t *testing.T, proxyDir, modulePath, version, source string) {
+	t.Helper()
+
+	versionDir := filepath.Join(proxyDir, filepath.FromSlash(modulePath), "@v")
+	writeFile(t, filepath.Join(versionDir, "list"), version+"\n")
+	writeFile(t, filepath.Join(versionDir, version+".info"), fmt.Sprintf(
+		"{\"Version\":%q,\"Time\":%q}\n",
+		version,
+		time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+	))
+	moduleFile := "module " + modulePath + "\n\ngo 1.26.5\n"
+	writeFile(t, filepath.Join(versionDir, version+".mod"), moduleFile)
+
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	zipFile, err := os.Create(filepath.Join(versionDir, version+".zip"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	zipWriter := zip.NewWriter(zipFile)
+	prefix := modulePath + "@" + version + "/"
+	for name, content := range map[string]string{"go.mod": moduleFile, "library.go": source} {
+		entry, createErr := zipWriter.Create(prefix + name)
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		if _, writeErr := entry.Write([]byte(content)); writeErr != nil {
+			t.Fatal(writeErr)
+		}
+	}
+	if err := zipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := zipFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.0.13
+	github.com/araihu/goshtoso v0.0.14-0.20260729045827-a8ab1a09e975
 	github.com/araihu/goshtoso-app-shells v0.0.0-20260728023436-4c4aa5ae787e
 	github.com/coder/websocket v1.8.14
 	github.com/playwright-community/playwright-go v0.5700.1

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6
 github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.0.13 h1:In7mqr8LX/nG+85Fz5xcGre7znyCiaUBGltKJUEnGaI=
-github.com/araihu/goshtoso v0.0.13/go.mod h1:SWdh/AlXnVGgW881NzTAKWk7paNsTlKMH/EGujAJoXY=
+github.com/araihu/goshtoso v0.0.14-0.20260729045827-a8ab1a09e975 h1:cnDqoShQTfghWdMNsfuEIYefMTgxfURf6jWX3bnLUfU=
+github.com/araihu/goshtoso v0.0.14-0.20260729045827-a8ab1a09e975/go.mod h1:mY8kbNpqILeQ2MLW1eh14EIaudanLjAs6bf0sv51NXE=
 github.com/araihu/goshtoso-app-shells v0.0.0-20260728023436-4c4aa5ae787e h1:o8EuGtBscrJfx4PgVTg0OKuLtUO11FdEOf2X7h770VI=
 github.com/araihu/goshtoso-app-shells v0.0.0-20260728023436-4c4aa5ae787e/go.mod h1:Nw6QAzP/ufjO4roQqTW2MePEG7annlRmlt7FQHA3ka0=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=


### PR DESCRIPTION
## Summary

- turn protected `Required CI` from routing-only into a real `GOWORK=off` site deployability gate
- retain and explicitly name existing temporary-workspace current-source integration contract
- repair current ActionGroup mismatch by moving `site/go.mod` from `v0.0.13` to public pseudo-version `v0.0.14-0.20260729045827-a8ab1a09e975`
- reject Goshtoso `replace` directives and document required two-phase sequencing for unreleased root APIs
- add offline local-module-proxy regression proving workspace mode passes while pinned mode catches unavailable API

## Reproduction and verification

Before pin repair:

```text
$ go work init . ./site
$ cd site && go list ./... && go test <non-E2E packages> -count=1
$ go build -o /tmp/goshtoso-current-source-server ./site/cmd/server
current-source packages=17 server=built

$ cd site && GOWORK=off go list ./...
internal/pages/demo/components/actiongroup_templ.go:12:2: no required module provides package github.com/araihu/goshtoso/components/actiongroup
```

Public resolution used an empty module cache plus `GOPROXY=https://proxy.golang.org`; the proxy resolved `a8ab1a09e97597373352574a6de8b2c1c8f07ebf` to `v0.0.14-0.20260729045827-a8ab1a09e975`, with no workspace or replace.

Green gates:

```text
just site-current-source-integration
just site-pinned-dependency-deployability
GOWORK=off go test ./... -count=1
cd site && GOWORK=off go test ./tests/e2e/... -count=1 -timeout 15m
```

Also passed: templ/CSS/theme/skill/vendor/JavaScript drift checks; root and pinned-site `go vet`; root and pinned-site `golangci-lint`; both `go fix` runs; `actionlint` with only known custom runner label ignored; `go mod verify`; clean-cache public-proxy pinned gate. Full pinned E2E: 367.226s.

## Sequencing policy

A PR cannot pin its future squash SHA. If `site/` needs an unreleased root API, merge/publish the root change first, then pin its reachable tag or pseudo-version and adopt it in a follow-up PR. A checked `replace github.com/araihu/goshtoso => ..` is rejected because it hides stale pins and breaks standalone module portability. No tag, release, or deploy is part of this PR.

## Related issue

None.

## Type of change

- [ ] Bug fix
- [ ] New component / variant
- [ ] Visual-parity fix
- [x] Docs
- [x] Tests / CI
- [x] Refactor / chore

## Checklist

- [x] Ran `templ generate` (no drift)
- [x] Rebuilt theme/component CSS with `just css` (no drift)
- [x] `golangci-lint run` is clean for root and standalone site
- [x] `go fix ./...` applied for root and standalone site
- [x] Unit + E2E tests pass
- [x] Component demo/API-reference item is not applicable
- [x] Ran `go run ./cmd/skillgen` (no drift; no component API change)
- [x] Visual theme item is not applicable
- [x] Did not hand-edit generated files

## Screenshots

Not applicable; no visual change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for the site module in both current-source integration and pinned-dependency deployment modes.
  * Added combined site module contract checks for release and CI workflows.
  * CI now verifies Go module caching, pinned dependency checks, and read-only repository permissions.

* **Documentation**
  * Documented site module contracts, required test sequencing, and new release checklist checks.

* **Bug Fixes**
  * Updated the site module to use the latest pinned library version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->