### PR TITLE
ci: use ARC persistent build caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,27 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Isolate Go caches
+      - name: Configure ARC persistent caches
         run: |
           set -euo pipefail
+          # The araihu ARC runner mounts its shared RWX cache at these paths.
+          # Go's module and build cache are content-addressed (the latter also
+          # keys entries by toolchain), so concurrent lint/test jobs can safely
+          # share them. Keep executable outputs job-local: two jobs installing
+          # the same tool must not race while replacing GOPATH/bin/templ.
+          cache_root="$HOME/.cache"
+          go_mod_cache="$HOME/go/pkg/mod/goshtoso-go${GO_VERSION}"
+          go_build_cache="$cache_root/go-build/goshtoso-go${GO_VERSION}"
+          tool_bin="$RUNNER_TEMP/go-bin"
+          mkdir -p "$go_mod_cache" "$go_build_cache" \
+            "$cache_root/ms-playwright" "$tool_bin"
           {
-            echo "GOMODCACHE=${RUNNER_TEMP}/go-mod-cache/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-lint-build"
-            echo "GOCACHE=${RUNNER_TEMP}/go-build-cache/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-lint-build"
+            echo "GOMODCACHE=$go_mod_cache"
+            echo "GOCACHE=$go_build_cache"
+            echo "GOBIN=$tool_bin"
+            echo "PLAYWRIGHT_BROWSERS_PATH=$cache_root/ms-playwright"
           } >> "$GITHUB_ENV"
+          echo "$tool_bin" >> "$GITHUB_PATH"
 
       - uses: actions/setup-go@v5
         with:
@@ -45,6 +59,21 @@ jobs:
           # same tree to the GHA cache backend on every go.sum change — a ~9min
           # post-job step that buys nothing here. Disable it.
           cache: false
+
+      - name: Verify ARC persistent caches
+        run: |
+          set -euo pipefail
+          for path in "$GOMODCACHE" "$GOCACHE" "$PLAYWRIGHT_BROWSERS_PATH"; do
+            test -d "$path"
+            test -w "$path"
+            printf '%s: ' "$path"
+            df -T "$path" | tail -n 1
+          done
+          test "$(go env GOMODCACHE)" = "$GOMODCACHE"
+          test "$(go env GOCACHE)" = "$GOCACHE"
+          echo "GOMODCACHE=$(go env GOMODCACHE)"
+          echo "GOCACHE=$(go env GOCACHE)"
+          echo "PLAYWRIGHT_BROWSERS_PATH=$PLAYWRIGHT_BROWSERS_PATH"
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}
@@ -109,8 +138,8 @@ jobs:
         run: |
           set -euo pipefail
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
-            | sh -s -- -b "$(go env GOPATH)/bin" "${GOLANGCI_LINT_VERSION}"
-          "$(go env GOPATH)/bin/golangci-lint" run --timeout 5m
+            | sh -s -- -b "$GOBIN" "${GOLANGCI_LINT_VERSION}"
+          "$GOBIN/golangci-lint" run --timeout 5m
 
       # The site module builds against the in-repo library at this commit via a
       # throwaway workspace (go.work is gitignored — it never lands in the tree).
@@ -121,7 +150,7 @@ jobs:
         run: cd site && go vet ./...
 
       - name: golangci-lint (site module)
-        run: cd site && "$(go env GOPATH)/bin/golangci-lint" run --timeout 5m
+        run: cd site && "$GOBIN/golangci-lint" run --timeout 5m
 
       - name: Build server
         run: |
@@ -140,13 +169,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Isolate Go caches
+      - name: Configure ARC persistent caches
         run: |
           set -euo pipefail
+          # See the matching lint-build step for sharing and concurrency
+          # rationale. Browser binaries live under the same RWX cache mount.
+          cache_root="$HOME/.cache"
+          go_mod_cache="$HOME/go/pkg/mod/goshtoso-go${GO_VERSION}"
+          go_build_cache="$cache_root/go-build/goshtoso-go${GO_VERSION}"
+          tool_bin="$RUNNER_TEMP/go-bin"
+          mkdir -p "$go_mod_cache" "$go_build_cache" \
+            "$cache_root/ms-playwright" "$tool_bin"
           {
-            echo "GOMODCACHE=${RUNNER_TEMP}/go-mod-cache/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-test"
-            echo "GOCACHE=${RUNNER_TEMP}/go-build-cache/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-test"
+            echo "GOMODCACHE=$go_mod_cache"
+            echo "GOCACHE=$go_build_cache"
+            echo "GOBIN=$tool_bin"
+            echo "PLAYWRIGHT_BROWSERS_PATH=$cache_root/ms-playwright"
           } >> "$GITHUB_ENV"
+          echo "$tool_bin" >> "$GITHUB_PATH"
 
       - uses: actions/setup-go@v5
         with:
@@ -156,6 +196,21 @@ jobs:
           # same tree to the GHA cache backend on every go.sum change — a ~9min
           # post-job step that buys nothing here. Disable it.
           cache: false
+
+      - name: Verify ARC persistent caches
+        run: |
+          set -euo pipefail
+          for path in "$GOMODCACHE" "$GOCACHE" "$PLAYWRIGHT_BROWSERS_PATH"; do
+            test -d "$path"
+            test -w "$path"
+            printf '%s: ' "$path"
+            df -T "$path" | tail -n 1
+          done
+          test "$(go env GOMODCACHE)" = "$GOMODCACHE"
+          test "$(go env GOCACHE)" = "$GOCACHE"
+          echo "GOMODCACHE=$(go env GOMODCACHE)"
+          echo "GOCACHE=$(go env GOCACHE)"
+          echo "PLAYWRIGHT_BROWSERS_PATH=$PLAYWRIGHT_BROWSERS_PATH"
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}


### PR DESCRIPTION
Restores the ARC runner persistent cache contract without touching PR #198.

- uses mounted ~/go/pkg/mod, ~/.cache/go-build, and ~/.cache/ms-playwright
- keeps executable installs job-local to avoid lint/test races
- adds non-secret path, mount, and writability evidence
- retains setup-go cache:false because the NFS mounts are authoritative

Playwright Chromium archives now persist; runner image system dependencies remain a separate follow-up because --with-deps still invokes apt on fresh pods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Go and Playwright caching across continuous integration jobs.
  * Added cache validation checks to confirm required directories are available and writable.
  * Improved consistency when installing and running linting tools during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->