### PR TITLE
fix(css): regenerate landing layout utilities

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -774,6 +774,9 @@
   .z-\[80\] {
     z-index: 80;
   }
+  .col-span-2 {
+    grid-column: span 2 / span 2;
+  }
   .col-span-3 {
     grid-column: span 3 / span 3;
   }
@@ -5636,6 +5639,11 @@
   .sm\:left-auto {
     @media (width >= 40rem) {
       left: auto;
+    }
+  }
+  .sm\:col-auto {
+    @media (width >= 40rem) {
+      grid-column: auto;
     }
   }
   .sm\:col-span-2 {


### PR DESCRIPTION
## Summary

Regenerate `assets/styles.css` after the landing/module layout introduced `col-span-2` and `sm:col-auto`.

## Validation

- `just css`
- `git diff --check`