### PR TITLE
docs: add v0.1.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Goshtoso are documented in this file.
 
+## [v0.1.2] - 2026-07-30
+
+### Automated Arai Hû fallback assets
+
+- Added a transactional updater for the bundled Arai Hû theme, mark, wordmark,
+  favicon, and release manifest.
+- Added authenticated release-dispatch enrollment so new Assets releases can
+  propose verified fallback updates without personal access tokens.
+- Preserved local bundled files as the server-rendered and no-JavaScript
+  fallback while the optional presentation channel manages live branding.
+- Documented archive-extraction and crash-durability hardening as follow-up
+  technical debt.
+
 ## [v0.1.0] - 2026-07-29
 
 ### Accessible sprite icons and typed catalog


### PR DESCRIPTION
Adds the release-workflow heading for the transactional Arai Hû fallback updater merged in #207. This is the only change required before tagging v0.1.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.1.2.
  * Documented automated fallback asset updates with transactional safeguards.
  * Documented authenticated release-dispatch enrollment without personal access tokens.
  * Clarified that bundled local assets remain available for server-rendered and no-JavaScript experiences.
  * Recorded archive-extraction and crash-durability improvements as follow-up technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->