### PR TITLE
docs: prepare v0.1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,7 +179,6 @@ before upgrading.
   complete component catalog plus a representative light/dark Goshtoso/Minimal
   theme matrix.
 
-[v0.1.3]: https://github.com/araihu/goshtoso/compare/v0.1.2...v0.1.3
 [v0.1.2]: https://github.com/araihu/goshtoso/compare/v0.1.1...v0.1.2
 [v0.1.1]: https://github.com/araihu/goshtoso/compare/v0.1.0...v0.1.1
 [v0.1.0]: https://github.com/araihu/goshtoso/compare/v0.0.13...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 All notable changes to Goshtoso are documented in this file.
 
-## Pending release: canonical runtime manifest
+## [v0.1.3] - 2026-08-02
 
 ### Canonical embedded runtime manifest
 
 - Made `assets/js/runtime/manifest.json` the ordered source of truth for
   embedded JavaScript pins, CDN URLs, SRI, local paths, loader defaults,
   attribution data, package provenance, and retained license notices.
+- Added `head.WithRuntimeManifest` for typed ownership of dependency URLs,
+  integrity, enablement, minimal-mode membership, and safe execution order.
+  Existing per-dependency options remain supported and apply after the custom
+  manifest snapshot.
 - Added generated, caller-owned `assets.DefaultRuntimeMetadata()` for runtime
   identity and licensing. `assets.RuntimeAsset` remains the supported loading
   and override contract, with its original nine-field layout preserved for
@@ -20,6 +24,14 @@ All notable changes to Goshtoso are documented in this file.
 - Made the demo site select and order local runtime assets from the Goshtoso
   module linked into its binary, with explicit site-only enablement and
   v0.1.0-compatible fallbacks for optional roles.
+
+### Upgrade note
+
+- No migration is required for existing `head.Dependencies` or
+  `head.DependenciesMinimal` consumers. Default full, minimal, CDN-first, and
+  local-only rendering remain compatible. The manifest pins are the tested
+  runtime combination; overriding versions configures loading but does not
+  guarantee compatibility with arbitrary combinations.
 
 ## [v0.1.2] - 2026-07-30
 
@@ -167,6 +179,9 @@ before upgrading.
   complete component catalog plus a representative light/dark Goshtoso/Minimal
   theme matrix.
 
+[v0.1.3]: https://github.com/araihu/goshtoso/compare/v0.1.2...v0.1.3
+[v0.1.2]: https://github.com/araihu/goshtoso/compare/v0.1.1...v0.1.2
+[v0.1.1]: https://github.com/araihu/goshtoso/compare/v0.1.0...v0.1.1
 [v0.1.0]: https://github.com/araihu/goshtoso/compare/v0.0.13...v0.1.0
 [v0.0.13]: https://github.com/araihu/goshtoso/compare/v0.0.12...v0.0.13
 [v0.0.12]: https://github.com/araihu/goshtoso/compare/v0.0.11...v0.0.12

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -10,6 +10,10 @@ record the pin directly in the release source.
 
 | Goshtoso | Tailwind CSS |
 |----------|--------------|
+| v0.1.3   | 4.3.0        |
+| v0.1.2   | 4.3.0        |
+| v0.1.1   | 4.3.0        |
+| v0.1.0   | 4.3.0        |
 | v0.0.13  | 4.3.0        |
 | v0.0.12  | 4.3.0        |
 | v0.0.11  | 4.3.0        |


### PR DESCRIPTION
Prepares patch release v0.1.3 for canonical runtime manifest work.\n\nChanges:\n- date v0.1.3 changelog section\n- document WithRuntimeManifest and compatibility boundary\n- add v0.1.0 through v0.1.3 Tailwind compatibility rows\n- restore missing compare links\n\nLocal release preflight:\n- generators and CSS drift: PASS\n- vendorgen check plus remote verification: PASS\n- consumer skill discovery/use: PASS\n- current-source and pinned site module contracts: PASS\n- full Playwright release coverage: PASS (366.529s, 74.6%)