### PR TITLE
ci: use GitHub-hosted runners and current actions

### DIFF
--- a/.github/workflows/araihu-assets.yml
+++ b/.github/workflows/araihu-assets.yml
@@ -97,7 +97,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.26.5'
           cache: true

--- a/.github/workflows/araihu-assets.yml
+++ b/.github/workflows/araihu-assets.yml
@@ -91,7 +91,7 @@ jobs:
           permission-issues: read
 
       - name: Check out Goshtoso
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: Lint, drift checks, build
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -159,7 +159,7 @@ jobs:
     name: Tests + coverage
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           echo "GOBIN=$tool_bin" >> "$GITHUB_ENV"
           echo "$tool_bin" >> "$GITHUB_PATH"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: |
@@ -50,7 +50,7 @@ jobs:
             site/go.sum
             tests/external/runtime-manifest/go.sum
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -177,7 +177,7 @@ jobs:
           } >> "$GITHUB_ENV"
           echo "$tool_bin" >> "$GITHUB_PATH"
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: |
@@ -185,7 +185,7 @@ jobs:
             site/go.sum
             tests/external/runtime-manifest/go.sum
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -245,7 +245,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload E2E impact decision
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-impact
           path: .e2e-impact.json
@@ -278,7 +278,7 @@ jobs:
 
       - name: Upload E2E artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-results
           path: site/tests/e2e/test-results/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     name: Markdown links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Check links
         uses: lycheeverse/lychee-action@v2.8.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       coverage-percent: ${{ steps.coverage.outputs.percent }}
       coverage-color: ${{ steps.coverage.outputs.color }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
 
@@ -126,7 +126,7 @@ jobs:
     needs: pre-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload authoritative coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-coverage
           path: |
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload E2E artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-e2e-results
           path: site/tests/e2e/test-results/

--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: |

--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -21,7 +21,7 @@ jobs:
     name: Required CI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/runner-smoke-test.yml
+++ b/.github/workflows/runner-smoke-test.yml
@@ -18,7 +18,7 @@ jobs:
           echo "whoami: $(whoami)"
           echo "pwd: $(pwd)"
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Repo checkout sanity
         run: |

--- a/.github/workflows/runner-smoke-test.yml
+++ b/.github/workflows/runner-smoke-test.yml
@@ -1,4 +1,4 @@
-name: Runner Smoke Test
+name: GitHub-hosted Runner Smoke Test
 
 on:
   workflow_dispatch:
@@ -8,8 +8,8 @@ on:
 
 jobs:
   smoke:
-    name: Self-hosted runner smoke test
-    runs-on: araihu
+    name: GitHub-hosted runner smoke test
+    runs-on: ubuntu-24.04
     steps:
       - name: Runner identity
         run: |


### PR DESCRIPTION
Completes the public AraiHu workflow migration by moving the remaining custom-runner smoke workflow from the `araihu` label to `ubuntu-24.04`. Also upgrades `actions/checkout`, `actions/setup-go`, `actions/setup-node`, and `actions/upload-artifact` to their latest v7 releases across Goshtoso workflows, preserving SHA pins where already used. Removes Node 20 action-runtime warnings. Validation: actionlint, git diff --check, org-wide action-version audit, and hosted CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated build, test, documentation, and release workflows to use current action versions.
  - Improved workflow compatibility with updated GitHub-hosted runners.
  - Maintained existing validation, artifact handling, and release behavior while keeping runner smoke tests aligned with the updated environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->