### PR TITLE
docs(site): pin v0.1.6 and showcase Card/Drawer

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -657,6 +657,9 @@
   .-top-9 {
     top: calc(var(--spacing) * -9);
   }
+  .-top-10 {
+    top: calc(var(--spacing) * -10);
+  }
   .top-0 {
     top: 0px;
   }
@@ -686,6 +689,9 @@
   }
   .-right-0\.5 {
     right: calc(var(--spacing) * -0.5);
+  }
+  .-right-10 {
+    right: calc(var(--spacing) * -10);
   }
   .right-0 {
     right: 0px;
@@ -1033,6 +1039,10 @@
     width: calc(var(--spacing) * 32);
     height: calc(var(--spacing) * 32);
   }
+  .size-40 {
+    width: calc(var(--spacing) * 40);
+    height: calc(var(--spacing) * 40);
+  }
   .size-full {
     width: 100%;
     height: 100%;
@@ -1081,6 +1091,9 @@
   }
   .h-24 {
     height: calc(var(--spacing) * 24);
+  }
+  .h-28 {
+    height: calc(var(--spacing) * 28);
   }
   .h-32 {
     height: calc(var(--spacing) * 32);
@@ -1505,6 +1518,14 @@
     --tw-translate-y: calc(calc(1 / 4 * 100%) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
+  .-translate-y-3 {
+    --tw-translate-y: calc(var(--spacing) * -3);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .-translate-y-8 {
+    --tw-translate-y: calc(var(--spacing) * -8);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
   .-translate-y-20 {
     --tw-translate-y: calc(var(--spacing) * -20);
     translate: var(--tw-translate-x) var(--tw-translate-y);
@@ -1615,6 +1636,9 @@
   }
   .grid-cols-2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
   .flex-col {
     flex-direction: column;
@@ -3722,6 +3746,9 @@
   .line-through {
     text-decoration-line: line-through;
   }
+  .no-underline {
+    text-decoration-line: none;
+  }
   .underline {
     text-decoration-line: underline;
   }
@@ -5214,6 +5241,9 @@
     }
     .md\:h-64 {
       height: calc(var(--spacing) * 64);
+    }
+    .md\:h-72 {
+      height: calc(var(--spacing) * 72);
     }
     .md\:h-full {
       height: 100%;

--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.1.3
+	github.com/araihu/goshtoso v0.1.6
 	github.com/araihu/goshtoso-app-shells v0.1.1-0.20260730145401-4f5174eeb1a9
 	github.com/araihu/goshtoso-charts v0.0.2-0.20260730033312-82e67bb7111f
 	github.com/coder/websocket v1.8.14

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6
 github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.1.3 h1:rCXrswq6q7sf28n4EZ2MipRNTyHlZYdG8s5I0uAU4NY=
-github.com/araihu/goshtoso v0.1.3/go.mod h1:mY8kbNpqILeQ2MLW1eh14EIaudanLjAs6bf0sv51NXE=
+github.com/araihu/goshtoso v0.1.6 h1:f/mwatUbC33eBGV3KNOerAQSE7UqYCxGxR+g2OCHq68=
+github.com/araihu/goshtoso v0.1.6/go.mod h1:EeyGU9+mRCxoWSkton8RqC8l02pBLJlREpt5mwrQjGg=
 github.com/araihu/goshtoso-app-shells v0.1.1-0.20260730145401-4f5174eeb1a9 h1:cJP0YtKUfJfgLrmp9rH4rFGqNC0dRQci63zZ3Lh2BWI=
 github.com/araihu/goshtoso-app-shells v0.1.1-0.20260730145401-4f5174eeb1a9/go.mod h1:Nw6QAzP/ufjO4roQqTW2MePEG7annlRmlt7FQHA3ka0=
 github.com/araihu/goshtoso-charts v0.0.2-0.20260730033312-82e67bb7111f h1:XCzv73dCpGDdZlGgF3be5BuGy6tl4INT+iOJoS+TYww=
@@ -50,8 +50,8 @@ github.com/mxschmitt/playwright-go v0.6100.0/go.mod h1:A7VtrS3j/c8ToGnSVUaOfNtQQ
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
-github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/site/internal/pages/demo/componentpages/card/card.templ
+++ b/site/internal/pages/demo/componentpages/card/card.templ
@@ -62,7 +62,25 @@ templ bookNowButton() {
     Description: "Changes from the last 24 hours.",
     Body:        activityList(),
     Footer:      activityFooter(),
-})`,
+			})`,
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Pressed Card with Custom Media",
+				Description: "Use InteractionPressed for whole-card links that should feel physically pressable. Media accepts any templ component, so project art can cross card regions without turning the Card API into an image-layout DSL.",
+			},
+			cardPressedMediaPreview(),
+			`<a href="/projects/atlas" aria-label="Explore Atlas">
+    @card.Card(card.Config{
+        Media:       projectPreview(),
+        MediaClass:  "h-64",
+        Tag:         "Go UI",
+        Title:       "Atlas",
+        Description: "Server-rendered interfaces for durable applications.",
+        Interaction: card.InteractionPressed,
+    })
+</a>`,
 		)
 
 		@demo.DemoSection(
@@ -205,6 +223,31 @@ templ cardHorizontalPreview() {
 			Title:       "AI-Powered VR Goggles Redefine Reality",
 			Description: "Experience the next level of augmented reality with smart goggles integrating cutting-edge AI for seamless interaction with the world around you.",
 		})
+	</div>
+}
+
+templ cardPressedMediaPreview() {
+	<a id="card-pressed-media" class="block w-full max-w-2xl mx-auto no-underline" href="#card-pressed-media" aria-label="Explore Atlas">
+		@card.Card(card.Config{
+			Media:       projectPreview(),
+			MediaClass:  "h-64 md:h-72",
+			Tag:         "Go UI",
+			Title:       "Atlas",
+			Description: "Server-rendered interfaces for durable applications.",
+			Interaction: card.InteractionPressed,
+			RootClass:   "max-w-2xl",
+		})
+	</a>
+}
+
+templ projectPreview() {
+	<div data-card-media class="relative h-full overflow-hidden bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark">
+		<div class="absolute -right-10 -top-10 size-40 rounded-full bg-secondary opacity-70"></div>
+		<div class="absolute inset-x-8 bottom-8 grid grid-cols-3 gap-3" aria-hidden="true">
+			<span class="h-20 rounded-radius bg-surface shadow-lg"></span>
+			<span class="h-28 -translate-y-8 rounded-radius bg-surface-alt shadow-lg"></span>
+			<span class="h-24 -translate-y-3 rounded-radius bg-surface shadow-lg"></span>
+		</div>
 	</div>
 }
 

--- a/site/internal/pages/demo/componentpages/card/card_templ.go
+++ b/site/internal/pages/demo/componentpages/card/card_templ.go
@@ -122,7 +122,27 @@ templ bookNowButton() {
     Description: "Changes from the last 24 hours.",
     Body:        activityList(),
     Footer:      activityFooter(),
-})`,
+			})`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Pressed Card with Custom Media",
+				Description: "Use InteractionPressed for whole-card links that should feel physically pressable. Media accepts any templ component, so project art can cross card regions without turning the Card API into an image-layout DSL.",
+			},
+			cardPressedMediaPreview(),
+			`<a href="/projects/atlas" aria-label="Explore Atlas">
+    @card.Card(card.Config{
+        Media:       projectPreview(),
+        MediaClass:  "h-64",
+        Tag:         "Go UI",
+        Title:       "Atlas",
+        Description: "Server-rendered interfaces for durable applications.",
+        Interaction: card.InteractionPressed,
+    })
+</a>`,
 		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -471,8 +491,7 @@ func cardHorizontalPreview() templ.Component {
 	})
 }
 
-// cardProductPreview renders the e-commerce product card recipe.
-func cardProductPreview() templ.Component {
+func cardPressedMediaPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -493,7 +512,82 @@ func cardProductPreview() templ.Component {
 			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<div id=\"card-product\" class=\"w-full max-w-sm mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<a id=\"card-pressed-media\" class=\"block w-full max-w-2xl mx-auto no-underline\" href=\"#card-pressed-media\" aria-label=\"Explore Atlas\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = card.Card(card.Config{
+			Media:       projectPreview(),
+			MediaClass:  "h-64 md:h-72",
+			Tag:         "Go UI",
+			Title:       "Atlas",
+			Description: "Server-rendered interfaces for durable applications.",
+			Interaction: card.InteractionPressed,
+			RootClass:   "max-w-2xl",
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</a>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func projectPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div data-card-media class=\"relative h-full overflow-hidden bg-primary text-on-primary dark:bg-primary-dark dark:text-on-primary-dark\"><div class=\"absolute -right-10 -top-10 size-40 rounded-full bg-secondary opacity-70\"></div><div class=\"absolute inset-x-8 bottom-8 grid grid-cols-3 gap-3\" aria-hidden=\"true\"><span class=\"h-20 rounded-radius bg-surface shadow-lg\"></span> <span class=\"h-28 -translate-y-8 rounded-radius bg-surface-alt shadow-lg\"></span> <span class=\"h-24 -translate-y-3 rounded-radius bg-surface shadow-lg\"></span></div></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// cardProductPreview renders the e-commerce product card recipe.
+func cardProductPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<div id=\"card-product\" class=\"w-full max-w-sm mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -501,7 +595,7 @@ func cardProductPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -526,12 +620,12 @@ func cardPricingPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var11 == nil {
-			templ_7745c5c3_Var11 = templ.NopComponent
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"card-pricing\" class=\"w-full max-w-xs mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div id=\"card-pricing\" class=\"w-full max-w-xs mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -539,7 +633,7 @@ func cardPricingPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -564,12 +658,12 @@ func cardTestimonialPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var12 == nil {
-			templ_7745c5c3_Var12 = templ.NopComponent
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<div id=\"card-testimonial\" class=\"w-full max-w-md mx-auto\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<div id=\"card-testimonial\" class=\"w-full max-w-md mx-auto\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -577,7 +671,7 @@ func cardTestimonialPreview() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -602,16 +696,16 @@ func bookNowButton() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var13 == nil {
-			templ_7745c5c3_Var13 = templ.NopComponent
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div class=\"mt-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<div class=\"mt-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var14 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var16 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -623,17 +717,17 @@ func bookNowButton() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "Book Now")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "Book Now")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = button.Button().Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = button.Button().Render(templ.WithChildren(ctx, templ_7745c5c3_Var16), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -658,12 +752,12 @@ func ecommerceProductCard() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var15 == nil {
-			templ_7745c5c3_Var15 = templ.NopComponent
+		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var17 == nil {
+			templ_7745c5c3_Var17 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<article class=\"group flex rounded-radius max-w-sm flex-col overflow-hidden border border-outline bg-surface-alt text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><div class=\"h-44 md:h-64 overflow-hidden\"><img src=\"/assets/images/cards/card-img-3.webp\" class=\"object-cover transition duration-700 ease-out group-hover:scale-105\" alt=\"CASIO G-SHOCK GA2100\"></div><div class=\"flex flex-col gap-4 p-6\"><div class=\"flex flex-col md:flex-row gap-4 md:gap-12 justify-between\"><div class=\"flex flex-col\"><h3 class=\"text-lg lg:text-xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">CASIO G-SHOCK GA2100</h3>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<article class=\"group flex rounded-radius max-w-sm flex-col overflow-hidden border border-outline bg-surface-alt text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><div class=\"h-44 md:h-64 overflow-hidden\"><img src=\"/assets/images/cards/card-img-3.webp\" class=\"object-cover transition duration-700 ease-out group-hover:scale-105\" alt=\"CASIO G-SHOCK GA2100\"></div><div class=\"flex flex-col gap-4 p-6\"><div class=\"flex flex-col md:flex-row gap-4 md:gap-12 justify-between\"><div class=\"flex flex-col\"><h3 class=\"text-lg lg:text-xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">CASIO G-SHOCK GA2100</h3>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -671,11 +765,11 @@ func ecommerceProductCard() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div><span class=\"text-xl font-medium\">$99.99</span></div><p class=\"mb-2 text-pretty text-sm\">The Casio G-Shock GA2100 is simply designed for easy timekeeping, featuring a sleek profile and clear display.</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div><span class=\"text-xl font-medium\">$99.99</span></div><p class=\"mb-2 text-pretty text-sm\">The Casio G-Shock GA2100 is simply designed for easy timekeeping, featuring a sleek profile and clear display.</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var16 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -687,17 +781,17 @@ func ecommerceProductCard() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "Add to Cart")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "Add to Cart")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = button.Button().Render(templ.WithChildren(ctx, templ_7745c5c3_Var16), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = button.Button().Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div></article>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div></article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -722,16 +816,16 @@ func pricingCard() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var17 == nil {
-			templ_7745c5c3_Var17 = templ.NopComponent
+		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var19 == nil {
+			templ_7745c5c3_Var19 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<article class=\"group flex rounded-radius w-full max-w-xs flex-col overflow-hidden border-2 border-primary bg-surface-alt p-6 text-on-surface dark:border-primary-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><span class=\"ml-auto w-fit rounded-radius bg-primary px-2 py-1 text-xs font-medium text-on-primary dark:bg-primary-dark dark:text-on-primary-dark\">TOP CHOICE</span><h3 class=\"text-xl text-balance md:text-2xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">Premium</h3><p class=\"mt-2 text-pretty text-xs font-medium\">Best tools for productivity</p><span class=\"mt-8 text-balance text-3xl md:text-4xl font-medium text-on-surface dark:text-on-surface-dark\">$8.99</span> <span class=\"mt-2 text-pretty text-xs font-medium\">Per month</span><h4 class=\"mt-12 font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Features</h4><ul class=\"mt-4 list-inside list-disc space-y-2 text-sm font-medium marker:text-lg marker:text-primary dark:marker:text-primary-dark\"><li>Unlimited access to all courses</li><li>Personalized learning plan</li><li>Offline viewing</li><li>No ads</li><li>High quality video</li><li>Cancel anytime</li></ul><div class=\"mt-12\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<article class=\"group flex rounded-radius w-full max-w-xs flex-col overflow-hidden border-2 border-primary bg-surface-alt p-6 text-on-surface dark:border-primary-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><span class=\"ml-auto w-fit rounded-radius bg-primary px-2 py-1 text-xs font-medium text-on-primary dark:bg-primary-dark dark:text-on-primary-dark\">TOP CHOICE</span><h3 class=\"text-xl text-balance md:text-2xl font-bold text-on-surface-strong dark:text-on-surface-dark-strong\">Premium</h3><p class=\"mt-2 text-pretty text-xs font-medium\">Best tools for productivity</p><span class=\"mt-8 text-balance text-3xl md:text-4xl font-medium text-on-surface dark:text-on-surface-dark\">$8.99</span> <span class=\"mt-2 text-pretty text-xs font-medium\">Per month</span><h4 class=\"mt-12 font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Features</h4><ul class=\"mt-4 list-inside list-disc space-y-2 text-sm font-medium marker:text-lg marker:text-primary dark:marker:text-primary-dark\"><li>Unlimited access to all courses</li><li>Personalized learning plan</li><li>Offline viewing</li><li>No ads</li><li>High quality video</li><li>Cancel anytime</li></ul><div class=\"mt-12\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var20 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -743,17 +837,17 @@ func pricingCard() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "Start your free trial")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "Start your free trial")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = button.Button(button.WithRootClass("w-full")).Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = button.Button(button.WithRootClass("w-full")).Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div></article>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div></article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -778,12 +872,12 @@ func testimonialCard() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var19 == nil {
-			templ_7745c5c3_Var19 = templ.NopComponent
+		templ_7745c5c3_Var21 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var21 == nil {
+			templ_7745c5c3_Var21 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<article class=\"group rounded-radius flex max-w-md flex-col border border-outline bg-surface-alt p-6 text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 16 16\" fill=\"currentColor\" class=\"size-12 text-on-surface-strong dark:text-on-surface-dark-strong group-hover:scale-105 transition duration-500 ease-out\" aria-hidden=\"true\"><path d=\"M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z\"></path></svg><p class=\"mt-2 text-pretty text-sm\">Simply put, this software transformed my workflow! Its intuitive interface and powerful features make tasks a breeze. A game-changer for productivity!</p><div class=\"flex flex-col-reverse md:flex-row md:items-center mt-8 justify-between gap-6\"><div class=\"flex items-center gap-2\"><img src=\"/assets/images/avatars/avatar-1.webp\" class=\"size-10 rounded-full object-cover\" alt=\"Bob Johnson\"><div class=\"flex flex-col gap-1\"><h3 class=\"font-bold leading-4 text-on-surface-strong dark:text-on-surface-dark-strong\">Bob Johnson</h3><span class=\"text-xs\">CEO - TechNova</span></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<article class=\"group rounded-radius flex max-w-md flex-col border border-outline bg-surface-alt p-6 text-on-surface dark:border-outline-dark dark:bg-surface-dark-alt dark:text-on-surface-dark\"><svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 16 16\" fill=\"currentColor\" class=\"size-12 text-on-surface-strong dark:text-on-surface-dark-strong group-hover:scale-105 transition duration-500 ease-out\" aria-hidden=\"true\"><path d=\"M12 12a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1h-1.388q0-.527.062-1.054.093-.558.31-.992t.559-.683q.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 9 7.558V11a1 1 0 0 0 1 1zm-6 0a1 1 0 0 0 1-1V8.558a1 1 0 0 0-1-1H4.612q0-.527.062-1.054.094-.558.31-.992.217-.434.559-.683.34-.279.868-.279V3q-.868 0-1.52.372a3.3 3.3 0 0 0-1.085.992 4.9 4.9 0 0 0-.62 1.458A7.7 7.7 0 0 0 3 7.558V11a1 1 0 0 0 1 1z\"></path></svg><p class=\"mt-2 text-pretty text-sm\">Simply put, this software transformed my workflow! Its intuitive interface and powerful features make tasks a breeze. A game-changer for productivity!</p><div class=\"flex flex-col-reverse md:flex-row md:items-center mt-8 justify-between gap-6\"><div class=\"flex items-center gap-2\"><img src=\"/assets/images/avatars/avatar-1.webp\" class=\"size-10 rounded-full object-cover\" alt=\"Bob Johnson\"><div class=\"flex flex-col gap-1\"><h3 class=\"font-bold leading-4 text-on-surface-strong dark:text-on-surface-dark-strong\">Bob Johnson</h3><span class=\"text-xs\">CEO - TechNova</span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -791,7 +885,7 @@ func testimonialCard() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div></article>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</div></article>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/pages/demo/componentpages/card/card_test.go
+++ b/site/internal/pages/demo/componentpages/card/card_test.go
@@ -1,0 +1,28 @@
+package cardpage
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestPressedMediaPreviewUsesReleasedCardComposition(t *testing.T) {
+	t.Parallel()
+	var buffer bytes.Buffer
+	if err := cardPressedMediaPreview().Render(context.Background(), &buffer); err != nil {
+		t.Fatalf("render preview: %v", err)
+	}
+	body := buffer.String()
+	for _, want := range []string{
+		`id="card-pressed-media"`,
+		`data-card-media`,
+		`hover:translate-y-1.5`,
+		`motion-reduce:transition-none`,
+		`Atlas`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("pressed media preview missing %q", want)
+		}
+	}
+}

--- a/site/internal/pages/demo/componentpages/drawer/drawer.templ
+++ b/site/internal/pages/demo/componentpages/drawer/drawer.templ
@@ -39,10 +39,26 @@ templ drawerDemoContent() {
     Title: "Filters",
     Side:  drawer.SideLeft,
     Width: drawer.WidthSM,
-}) {
+			}) {
     <div id="filtersDrawer-body">...</div>
 }`,
-			)
+		)
+
+		@demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Top and Bottom",
+				Description: "Use SideTop or SideBottom for navigation drawers, command surfaces, and mobile action trays. Height controls the vertical extent.",
+			},
+			drawerVerticalPreview(),
+			`@drawer.Drawer(drawer.Config{
+    ID:     "mobileNavigation",
+    Title:  "Navigation",
+    Side:   drawer.SideTop,
+    Height: drawer.HeightMD,
+}) {
+    <nav>...</nav>
+}`,
+		)
 
 			@demo.DemoSection(
 				demo.DemoSectionProps{
@@ -81,6 +97,50 @@ templ drawerDemoContent() {
 </button>`,
 			)
 		</div>
+}
+
+templ drawerVerticalPreview() {
+	<div id="drawer-vertical" class="flex w-full max-w-2xl flex-wrap gap-3 mx-auto">
+		<button
+			type="button"
+			x-data
+			x-on:click="$dispatch('drawer:open', { id: 'topNavigation' })"
+			class="inline-flex items-center justify-center rounded-radius border border-outline px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:text-on-surface-dark dark:hover:bg-surface-dark-alt"
+		>
+			Open top drawer
+		</button>
+		<button
+			type="button"
+			x-data
+			x-on:click="$dispatch('drawer:open', { id: 'bottomActions' })"
+			class="inline-flex items-center justify-center rounded-radius border border-outline px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:text-on-surface-dark dark:hover:bg-surface-dark-alt"
+		>
+			Open bottom drawer
+		</button>
+		@drawer.Drawer(drawer.Config{
+			ID:     "topNavigation",
+			Title:  "Navigation",
+			Side:   drawer.SideTop,
+			Height: drawer.HeightMD,
+		}) {
+			<nav class="grid gap-2 p-4" aria-label="Example navigation">
+				<a class="rounded-radius px-3 py-2 hover:bg-surface-alt dark:hover:bg-surface-dark-alt" href="#drawer-vertical">Overview</a>
+				<a class="rounded-radius px-3 py-2 hover:bg-surface-alt dark:hover:bg-surface-dark-alt" href="#drawer-vertical">Components</a>
+				<a class="rounded-radius px-3 py-2 hover:bg-surface-alt dark:hover:bg-surface-dark-alt" href="#drawer-vertical">Examples</a>
+			</nav>
+		}
+		@drawer.Drawer(drawer.Config{
+			ID:     "bottomActions",
+			Title:  "Quick actions",
+			Side:   drawer.SideBottom,
+			Height: drawer.HeightSM,
+		}) {
+			<div class="flex flex-wrap gap-2 p-4">
+				<button type="button" class="rounded-radius bg-primary px-4 py-2 text-sm font-medium text-on-primary dark:bg-primary-dark dark:text-on-primary-dark">Create project</button>
+				<button type="button" class="rounded-radius border border-outline px-4 py-2 text-sm font-medium dark:border-outline-dark">Open settings</button>
+			</div>
+		}
+	</div>
 }
 
 templ drawerDefaultPreview() {

--- a/site/internal/pages/demo/componentpages/drawer/drawer_templ.go
+++ b/site/internal/pages/demo/componentpages/drawer/drawer_templ.go
@@ -97,8 +97,26 @@ func drawerDemoContent() templ.Component {
     Title: "Filters",
     Side:  drawer.SideLeft,
     Width: drawer.WidthSM,
-}) {
+			}) {
     <div id="filtersDrawer-body">...</div>
+}`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
+				Title:       "Top and Bottom",
+				Description: "Use SideTop or SideBottom for navigation drawers, command surfaces, and mobile action trays. Height controls the vertical extent.",
+			},
+			drawerVerticalPreview(),
+			`@drawer.Drawer(drawer.Config{
+    ID:     "mobileNavigation",
+    Title:  "Navigation",
+    Side:   drawer.SideTop,
+    Height: drawer.HeightMD,
+}) {
+    <nav>...</nav>
 }`,
 		).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
@@ -153,7 +171,7 @@ func drawerDemoContent() templ.Component {
 	})
 }
 
-func drawerDefaultPreview() templ.Component {
+func drawerVerticalPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -174,7 +192,7 @@ func drawerDefaultPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"drawer-default\" class=\"w-full max-w-2xl mx-auto\"><button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'projectDetails' })\" class=\"inline-flex items-center justify-center rounded-radius bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:bg-primary-dark dark:text-on-primary-dark dark:hover:bg-primary-dark/90\">Open details</button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"drawer-vertical\" class=\"flex w-full max-w-2xl flex-wrap gap-3 mx-auto\"><button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'topNavigation' })\" class=\"inline-flex items-center justify-center rounded-radius border border-outline px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:text-on-surface-dark dark:hover:bg-surface-dark-alt\">Open top drawer</button> <button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'bottomActions' })\" class=\"inline-flex items-center justify-center rounded-radius border border-outline px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:text-on-surface-dark dark:hover:bg-surface-dark-alt\">Open bottom drawer</button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -190,7 +208,94 @@ func drawerDefaultPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"space-y-4 p-4\"><div><p class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Deployment target</p><p class=\"mt-1 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Production cluster, rolling update, two approvals required.</p></div><div class=\"rounded-radius border border-outline p-3 text-sm dark:border-outline-dark\"><p class=\"font-medium\">Current status</p><p class=\"mt-1 text-on-surface-muted dark:text-on-surface-dark-muted\">Ready for review</p></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<nav class=\"grid gap-2 p-4\" aria-label=\"Example navigation\"><a class=\"rounded-radius px-3 py-2 hover:bg-surface-alt dark:hover:bg-surface-dark-alt\" href=\"#drawer-vertical\">Overview</a> <a class=\"rounded-radius px-3 py-2 hover:bg-surface-alt dark:hover:bg-surface-dark-alt\" href=\"#drawer-vertical\">Components</a> <a class=\"rounded-radius px-3 py-2 hover:bg-surface-alt dark:hover:bg-surface-dark-alt\" href=\"#drawer-vertical\">Examples</a></nav>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = drawer.Drawer(drawer.Config{
+			ID:     "topNavigation",
+			Title:  "Navigation",
+			Side:   drawer.SideTop,
+			Height: drawer.HeightMD,
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var5 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div class=\"flex flex-wrap gap-2 p-4\"><button type=\"button\" class=\"rounded-radius bg-primary px-4 py-2 text-sm font-medium text-on-primary dark:bg-primary-dark dark:text-on-primary-dark\">Create project</button> <button type=\"button\" class=\"rounded-radius border border-outline px-4 py-2 text-sm font-medium dark:border-outline-dark\">Open settings</button></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = drawer.Drawer(drawer.Config{
+			ID:     "bottomActions",
+			Title:  "Quick actions",
+			Side:   drawer.SideBottom,
+			Height: drawer.HeightSM,
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var5), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func drawerDefaultPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"drawer-default\" class=\"w-full max-w-2xl mx-auto\"><button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'projectDetails' })\" class=\"inline-flex items-center justify-center rounded-radius bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:bg-primary-dark dark:text-on-primary-dark dark:hover:bg-primary-dark/90\">Open details</button>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"space-y-4 p-4\"><div><p class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Deployment target</p><p class=\"mt-1 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Production cluster, rolling update, two approvals required.</p></div><div class=\"rounded-radius border border-outline p-3 text-sm dark:border-outline-dark\"><p class=\"font-medium\">Current status</p><p class=\"mt-1 text-on-surface-muted dark:text-on-surface-dark-muted\">Ready for review</p></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -201,11 +306,11 @@ func drawerDefaultPreview() templ.Component {
 			Title: "Project details",
 			Side:  drawer.SideRight,
 			Width: drawer.WidthLG,
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -229,16 +334,16 @@ func drawerLeftPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var5 == nil {
-			templ_7745c5c3_Var5 = templ.NopComponent
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div id=\"drawer-left\" class=\"w-full max-w-2xl mx-auto\"><button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'filtersDrawer' })\" class=\"inline-flex items-center justify-center rounded-radius border border-outline px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:text-on-surface-dark dark:hover:bg-surface-dark-alt\">Open filters</button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div id=\"drawer-left\" class=\"w-full max-w-2xl mx-auto\"><button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'filtersDrawer' })\" class=\"inline-flex items-center justify-center rounded-radius border border-outline px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:text-on-surface-dark dark:hover:bg-surface-dark-alt\">Open filters</button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var6 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var9 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -250,7 +355,7 @@ func drawerLeftPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"space-y-3 p-4 text-sm\"><label class=\"flex items-center gap-2\"><input type=\"checkbox\" class=\"size-4 rounded border-outline text-primary dark:border-outline-dark\"> <span>Only active records</span></label> <label class=\"flex items-center gap-2\"><input type=\"checkbox\" class=\"size-4 rounded border-outline text-primary dark:border-outline-dark\"> <span>Needs attention</span></label></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"space-y-3 p-4 text-sm\"><label class=\"flex items-center gap-2\"><input type=\"checkbox\" class=\"size-4 rounded border-outline text-primary dark:border-outline-dark\"> <span>Only active records</span></label> <label class=\"flex items-center gap-2\"><input type=\"checkbox\" class=\"size-4 rounded border-outline text-primary dark:border-outline-dark\"> <span>Needs attention</span></label></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -261,11 +366,11 @@ func drawerLeftPreview() templ.Component {
 			Title: "Filters",
 			Side:  drawer.SideLeft,
 			Width: drawer.WidthSM,
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var6), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var9), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -289,16 +394,16 @@ func drawerPersistentPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"drawer-persistent\" class=\"w-full max-w-2xl mx-auto\"><button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'editProfile' })\" class=\"inline-flex items-center justify-center rounded-radius border border-outline px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:text-on-surface-dark dark:hover:bg-surface-dark-alt\">Open persistent drawer</button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"drawer-persistent\" class=\"w-full max-w-2xl mx-auto\"><button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'editProfile' })\" class=\"inline-flex items-center justify-center rounded-radius border border-outline px-4 py-2 text-sm font-medium text-on-surface hover:bg-surface-alt focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-outline-dark dark:text-on-surface-dark dark:hover:bg-surface-dark-alt\">Open persistent drawer</button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var8 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var11 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -310,7 +415,7 @@ func drawerPersistentPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<form class=\"space-y-4 p-4\"><div><label for=\"drawer-name\" class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Display name</label> <input id=\"drawer-name\" name=\"name\" value=\"Goshtoso\" class=\"mt-1 w-full rounded-radius border border-outline bg-surface px-3 py-2 text-sm text-on-surface dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark\"></div><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Backdrop clicks and Escape are ignored while this form is open.</p></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<form class=\"space-y-4 p-4\"><div><label for=\"drawer-name\" class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Display name</label> <input id=\"drawer-name\" name=\"name\" value=\"Goshtoso\" class=\"mt-1 w-full rounded-radius border border-outline bg-surface px-3 py-2 text-sm text-on-surface dark:border-outline-dark dark:bg-surface-dark dark:text-on-surface-dark\"></div><p class=\"text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">Backdrop clicks and Escape are ignored while this form is open.</p></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -320,11 +425,11 @@ func drawerPersistentPreview() templ.Component {
 			ID:         "editProfile",
 			Title:      "Edit profile",
 			Persistent: true,
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var8), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -348,16 +453,16 @@ func drawerHTMXPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var12 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var12 == nil {
+			templ_7745c5c3_Var12 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div id=\"drawer-htmx\" class=\"w-full max-w-2xl mx-auto\"><button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'orderDrawer' })\" class=\"inline-flex items-center justify-center rounded-radius bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:bg-primary-dark dark:text-on-primary-dark dark:hover:bg-primary-dark/90\">Open order drawer</button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<div id=\"drawer-htmx\" class=\"w-full max-w-2xl mx-auto\"><button type=\"button\" x-data x-on:click=\"$dispatch('drawer:open', { id: 'orderDrawer' })\" class=\"inline-flex items-center justify-center rounded-radius bg-primary px-4 py-2 text-sm font-medium text-on-primary hover:bg-primary/90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:bg-primary-dark dark:text-on-primary-dark dark:hover:bg-primary-dark/90\">Open order drawer</button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var10 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var13 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -369,7 +474,7 @@ func drawerHTMXPreview() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div id=\"orderDrawerBody\" class=\"space-y-4 p-4\"><div><p class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Order #42</p><p class=\"mt-1 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">This body has a stable id so an HTMX response can replace only the drawer content.</p></div><div class=\"rounded-radius border border-outline p-3 text-sm dark:border-outline-dark\"><p class=\"font-medium\">Swap target</p><p class=\"mt-1 font-mono text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">#orderDrawerBody</p></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<div id=\"orderDrawerBody\" class=\"space-y-4 p-4\"><div><p class=\"text-sm font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Order #42</p><p class=\"mt-1 text-sm text-on-surface-muted dark:text-on-surface-dark-muted\">This body has a stable id so an HTMX response can replace only the drawer content.</p></div><div class=\"rounded-radius border border-outline p-3 text-sm dark:border-outline-dark\"><p class=\"font-medium\">Swap target</p><p class=\"mt-1 font-mono text-xs text-on-surface-muted dark:text-on-surface-dark-muted\">#orderDrawerBody</p></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -380,11 +485,11 @@ func drawerHTMXPreview() templ.Component {
 			Title:  "Order details",
 			BodyID: "orderDrawerBody",
 			Width:  drawer.WidthLG,
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var13), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- pin the nested site module to Goshtoso v0.1.6
- demonstrate pressed Card composition in the Card catalog
- demonstrate top and bottom directional Drawer APIs
- regenerate embedded site CSS and templ output

## Verification

- `just site-current-source-integration`
- `just site-pinned-dependency-deployability`
- `GOWORK=off go test -tags="e2e,card,drawer" ./tests/e2e -run "Test(Card|Drawer)" -count=1 -timeout 8m` (from `site/`)
