### PR TITLE
fix(card): neutralize pressed motion for reduced motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Goshtoso are documented in this file.
 
+## [v0.1.7] - 2026-08-02
+
+### Reduced-motion pressed cards
+
+- Corrected `card.InteractionPressed` to transition the Tailwind v4 individual
+  `translate` property, so its pressed movement animates as designed.
+- Neutralized hover and active translation when `prefers-reduced-motion` is
+  enabled, keeping pressed cards spatially still for reduced-motion users.
+
+### Upgrade note
+
+- No API changes are required. Consumers using `InteractionPressed` should
+  update their Goshtoso stylesheet and dependency pin together.
+
 ## [v0.1.6] - 2026-08-02
 
 ### Expressive project cards and directional drawers

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,6 +11,7 @@ is retained in this table.
 
 | Goshtoso | Tailwind CSS |
 |----------|--------------|
+| v0.1.7   | 4.3.3        |
 | v0.1.6   | 4.3.3        |
 | v0.1.5   | 4.3.3        |
 | v0.1.4   | 4.3.3        |

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3898,8 +3898,8 @@
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
   }
-  .transition-\[transform\,box-shadow\] {
-    transition-property: transform,box-shadow;
+  .transition-\[translate\,box-shadow\] {
+    transition-property: translate,box-shadow;
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
   }
@@ -4984,9 +4984,6 @@
     }
   }
   @media (prefers-reduced-motion: reduce) {
-    .motion-reduce\:transform-none {
-      transform: none;
-    }
     .motion-reduce\:animate-none {
       animation: none;
     }
@@ -4997,6 +4994,14 @@
     }
     .motion-reduce\:transition-none {
       transition-property: none;
+    }
+    @media (hover: hover) {
+      .motion-reduce\:hover\:translate-none:hover {
+        translate: none;
+      }
+    }
+    .motion-reduce\:active\:translate-none:active {
+      translate: none;
     }
   }
   @media (width >= 40rem) {

--- a/components/card/card_coverage_test.go
+++ b/components/card/card_coverage_test.go
@@ -51,7 +51,7 @@ func TestContainerClasses(t *testing.T) {
 		{
 			name:     "pressed interaction",
 			cfg:      Config{Interaction: InteractionPressed},
-			contains: []string{"hover:translate-y-1.5", "active:translate-y-2", "motion-reduce:transform-none"},
+			contains: []string{"transition-[translate,box-shadow]", "hover:translate-y-1.5", "active:translate-y-2", "motion-reduce:hover:translate-none", "motion-reduce:active:translate-none", "motion-reduce:transition-none"},
 			absent:   []string{"hover:-translate-y"},
 		},
 	}

--- a/components/card/types.go
+++ b/components/card/types.go
@@ -69,7 +69,7 @@ func (cfg Config) containerClasses() string {
 	}
 
 	if cfg.Interaction == InteractionPressed {
-		base += " shadow-lg transition-[transform,box-shadow] duration-150 ease-out hover:translate-y-1.5 hover:shadow-sm active:translate-y-2 active:shadow-none motion-reduce:transform-none motion-reduce:transition-none"
+		base += " shadow-lg transition-[translate,box-shadow] duration-150 ease-out hover:translate-y-1.5 hover:shadow-sm active:translate-y-2 active:shadow-none motion-reduce:hover:translate-none motion-reduce:active:translate-none motion-reduce:transition-none"
 	}
 
 	// Layout


### PR DESCRIPTION
## Summary

- transition the Tailwind v4 individual `translate` property used by pressed Card
- reset that same property under `prefers-reduced-motion`
- regenerate the published stylesheet and tighten the Card class contract test

## Verification

- `go test ./components/card -count=1`
- `just css`
- `go test ./... -count=1`
- `go test ./site/... -count=1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pressed-card movement for Tailwind CSS v4.
  * Improved reduced-motion behavior by disabling hover and active movement when requested.

* **Documentation**
  * Added the v0.1.7 release notes and compatibility information.
  * Documented the required synchronized stylesheet and dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->