### PR TITLE
chore(site): pin Goshtoso v0.1.7

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.1.6
+	github.com/araihu/goshtoso v0.1.7
 	github.com/araihu/goshtoso-app-shells v0.1.1-0.20260730145401-4f5174eeb1a9
 	github.com/araihu/goshtoso-charts v0.0.2-0.20260730033312-82e67bb7111f
 	github.com/coder/websocket v1.8.14

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/chroma/v2 v2.24.1 h1:m5ffpfZbIb++k8AqFEKy9uVgY12xIQtBsQlc6
 github.com/alecthomas/chroma/v2 v2.24.1/go.mod h1:l+ohZ9xRXIbGe7cIW+YZgOGbvuVLjMps/FYN/CwuabI=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.1.6 h1:f/mwatUbC33eBGV3KNOerAQSE7UqYCxGxR+g2OCHq68=
-github.com/araihu/goshtoso v0.1.6/go.mod h1:EeyGU9+mRCxoWSkton8RqC8l02pBLJlREpt5mwrQjGg=
+github.com/araihu/goshtoso v0.1.7 h1:1ZUaKw4ohx6avDXXLIB82Z5siaEsr1iRXTaom9320bw=
+github.com/araihu/goshtoso v0.1.7/go.mod h1:EeyGU9+mRCxoWSkton8RqC8l02pBLJlREpt5mwrQjGg=
 github.com/araihu/goshtoso-app-shells v0.1.1-0.20260730145401-4f5174eeb1a9 h1:cJP0YtKUfJfgLrmp9rH4rFGqNC0dRQci63zZ3Lh2BWI=
 github.com/araihu/goshtoso-app-shells v0.1.1-0.20260730145401-4f5174eeb1a9/go.mod h1:Nw6QAzP/ufjO4roQqTW2MePEG7annlRmlt7FQHA3ka0=
 github.com/araihu/goshtoso-charts v0.0.2-0.20260730033312-82e67bb7111f h1:XCzv73dCpGDdZlGgF3be5BuGy6tl4INT+iOJoS+TYww=


### PR DESCRIPTION
## Summary

- pin the nested documentation site to Goshtoso v0.1.7
- consume the corrected reduced-motion behavior for pressed Cards

## Verification

- `just site-current-source-integration`
- `just site-pinned-dependency-deployability`