### PR TITLE
feat(head): add validated social metadata

### DIFF
--- a/.agents/skills/using-goshtoso/SKILL.md
+++ b/.agents/skills/using-goshtoso/SKILL.md
@@ -77,9 +77,10 @@ templ Layout() {
 `head.Metadata()` emits the document title and description, canonical URL,
 required Open Graph properties, structured image metadata and alt text, plus
 explicit X/Twitter Card tags. Title, description, canonical URL, image URL,
-image MIME type, positive dimensions, and image alt text are required. Both URLs
-must be absolute HTTPS. `Render` validates the whole configuration before
-writing and returns an error instead of emitting partial or mixed metadata.
+parameter-free image MIME type, positive dimensions, and image alt text are
+required. Both URLs must be absolute HTTPS. `Render` validates the whole
+configuration before writing and returns an error instead of emitting partial
+or mixed metadata.
 Open Graph type defaults to `website`; X/Twitter Card defaults to
 `summary_large_image`. Give every indexable route distinct values and do not
 reuse homepage metadata for subpages. A 1280x640 JPEG or PNG under 1 MB is the

--- a/.agents/skills/using-goshtoso/SKILL.md
+++ b/.agents/skills/using-goshtoso/SKILL.md
@@ -76,8 +76,12 @@ templ Layout() {
 
 `head.Metadata()` emits the document title and description, canonical URL,
 required Open Graph properties, structured image metadata and alt text, plus
-explicit X/Twitter Card tags. Use absolute public HTTPS URLs. Give every
-indexable route its own title, description, canonical URL, and `og:url`; do not
+explicit X/Twitter Card tags. Title, description, canonical URL, image URL,
+image MIME type, positive dimensions, and image alt text are required. Both URLs
+must be absolute HTTPS. `Render` validates the whole configuration before
+writing and returns an error instead of emitting partial or mixed metadata.
+Open Graph type defaults to `website`; X/Twitter Card defaults to
+`summary_large_image`. Give every indexable route distinct values and do not
 reuse homepage metadata for subpages. A 1280x640 JPEG or PNG under 1 MB is the
 safe default social image. Render metadata in initial HTML, not through client
 JavaScript or HTMX fragments.

--- a/.agents/skills/using-goshtoso/SKILL.md
+++ b/.agents/skills/using-goshtoso/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: using-goshtoso
-description: Use when building, designing, redesigning, integrating, or updating an external Go/templ application with Goshtoso, including application shells, dashboards, operations lists, detail pages, settings, onboarding, workflows, public content, component selection, visual direction, state design, installing github.com/araihu/goshtoso, serving bundled assets, wiring head.Dependencies, Tailwind CSS strategy, or debugging Goshtoso styles, Alpine.js, HTMX, and component APIs.
+description: Use when building, designing, redesigning, integrating, or updating an external Go/templ application with Goshtoso, including application shells, dashboards, operations lists, detail pages, settings, onboarding, workflows, public content, page metadata, Open Graph and X/Twitter Cards, social previews, component selection, visual direction, state design, installing github.com/araihu/goshtoso, serving bundled assets, wiring head.Metadata and head.Dependencies, Tailwind CSS strategy, or debugging Goshtoso styles, Alpine.js, HTMX, and component APIs.
 ---
 
 # Using Goshtoso
@@ -54,12 +54,33 @@ import "github.com/araihu/goshtoso/components/head"
 templ Layout() {
 	<html>
 		<head>
+			@head.Metadata(head.MetadataConfig{
+				Title:        "Page title",
+				Description:  "Route-specific description",
+				CanonicalURL: "https://example.com/route",
+				SiteName:     "Product name",
+				Image: head.SocialImage{
+					URL:      "https://example.com/og.jpg",
+					MIMEType: "image/jpeg",
+					Width:    1280,
+					Height:   640,
+					Alt:      "Useful description of the preview",
+				},
+			})
 			@head.Dependencies()
 		</head>
 		<body>{ children... }</body>
 	</html>
 }
 ```
+
+`head.Metadata()` emits the document title and description, canonical URL,
+required Open Graph properties, structured image metadata and alt text, plus
+explicit X/Twitter Card tags. Use absolute public HTTPS URLs. Give every
+indexable route its own title, description, canonical URL, and `og:url`; do not
+reuse homepage metadata for subpages. A 1280x640 JPEG or PNG under 1 MB is the
+safe default social image. Render metadata in initial HTML, not through client
+JavaScript or HTMX fragments.
 
 `head.Dependencies()` emits Goshtoso CSS and an ordered loader for Alpine.js,
 its collapse/focus/mask plugins, HTMX, and the first-party

--- a/.agents/skills/using-goshtoso/SKILL.md
+++ b/.agents/skills/using-goshtoso/SKILL.md
@@ -77,10 +77,10 @@ templ Layout() {
 `head.Metadata()` emits the document title and description, canonical URL,
 required Open Graph properties, structured image metadata and alt text, plus
 explicit X/Twitter Card tags. Title, description, canonical URL, image URL,
-parameter-free image MIME type, positive dimensions, and image alt text are
-required. Both URLs must be absolute HTTPS. `Render` validates the whole
-configuration before writing and returns an error instead of emitting partial
-or mixed metadata.
+parameter-free RFC 6838 image MIME type, positive dimensions, and image alt
+text are required. Both URLs must be absolute HTTPS. `Render` validates the
+whole configuration before writing and returns an error instead of emitting
+partial or mixed metadata.
 Open Graph type defaults to `website`; X/Twitter Card defaults to
 `summary_large_image`. Give every indexable route distinct values and do not
 reuse homepage metadata for subpages. A 1280x640 JPEG or PNG under 1 MB is the

--- a/.agents/skills/using-goshtoso/references/components-reference.md
+++ b/.agents/skills/using-goshtoso/references/components-reference.md
@@ -904,11 +904,37 @@ import "github.com/araihu/goshtoso/components/form/validation"  // package valid
 import "github.com/araihu/goshtoso/components/head"  // package head
 ```
 
-**Entry points:** `Dependencies(options ...Option)` · `DependenciesMinimal(options ...Option)`
+**Entry points:** `Dependencies(options ...Option)` · `DependenciesMinimal(options ...Option)` · `Metadata(metadata MetadataConfig)`
 
 **Options:** `WithActionGroupURL(url string)` · `WithComboboxURL(url string)` · `WithDependencyCDNURL(dependency Dependency, url string)` · `WithDependencyIntegrity(dependency Dependency, integrity string)` · `WithDependencyLocalURL(dependency Dependency, url string)` · `WithLoaderURL(url string)` · `WithLocalRuntime()` · `WithRuntimeManifest(manifest assets.RuntimeManifest)` · `WithStylesheetURL(url string)` · `WithoutDependency(dependency Dependency)` · `WithoutLocalFallback()`
 
 - **Dependency** — DependencyAlpineJS = "alpinejs", DependencyAlpineCollapse = "alpinejs-collapse", DependencyAlpineFocus = "alpinejs-focus", DependencyAlpineMask = "alpinejs-mask", DependencyHTMX = "htmx"
+- **OpenGraphType** — OpenGraphTypeWebsite = "website"
+- **TwitterCard** — TwitterCardSummary = "summary", TwitterCardSummaryLargeImage = "summary_large_image"
+
+**MetadataConfig**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Title` | `string` |  |
+| `Description` | `string` |  |
+| `CanonicalURL` | `string` |  |
+| `OpenGraphType` | `OpenGraphType` |  |
+| `SiteName` | `string` |  |
+| `Locale` | `string` |  |
+| `Image` | `SocialImage` |  |
+| `TwitterCard` | `TwitterCard` |  |
+| `TwitterSite` | `string` |  |
+
+**SocialImage**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `URL` | `string` |  |
+| `MIMEType` | `string` |  |
+| `Width` | `int` |  |
+| `Height` | `int` |  |
+| `Alt` | `string` |  |
 
 ## icon
 

--- a/.agents/skills/using-goshtoso/references/components-reference.md
+++ b/.agents/skills/using-goshtoso/references/components-reference.md
@@ -931,7 +931,7 @@ import "github.com/araihu/goshtoso/components/head"  // package head
 | Field | Type | Description |
 |-------|------|-------------|
 | `URL` | `string` | URL is the absolute HTTPS URL crawlers use to fetch the image. |
-| `MIMEType` | `string` | MIMEType is a parameter-free image media type, such as image/jpeg or image/png. |
+| `MIMEType` | `string` | MIMEType is a parameter-free RFC 6838 image type, such as image/jpeg. |
 | `Width` | `int` | Width is the image width in pixels and must be positive. |
 | `Height` | `int` | Height is the image height in pixels and must be positive. |
 | `Alt` | `string` | Alt describes the image for accessible social clients and must be non-empty. |

--- a/.agents/skills/using-goshtoso/references/components-reference.md
+++ b/.agents/skills/using-goshtoso/references/components-reference.md
@@ -916,25 +916,25 @@ import "github.com/araihu/goshtoso/components/head"  // package head
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `Title` | `string` |  |
-| `Description` | `string` |  |
-| `CanonicalURL` | `string` |  |
-| `OpenGraphType` | `OpenGraphType` |  |
-| `SiteName` | `string` |  |
-| `Locale` | `string` |  |
-| `Image` | `SocialImage` |  |
-| `TwitterCard` | `TwitterCard` |  |
-| `TwitterSite` | `string` |  |
+| `Title` | `string` | Title is the non-empty route-specific document and social title. |
+| `Description` | `string` | Description is the non-empty route-specific document and social summary. |
+| `CanonicalURL` | `string` | CanonicalURL is the route's absolute HTTPS canonical and Open Graph URL. |
+| `OpenGraphType` | `OpenGraphType` | OpenGraphType is the Open Graph object type and defaults to website. |
+| `SiteName` | `string` | SiteName is the optional Open Graph site name. |
+| `Locale` | `string` | Locale is the optional Open Graph locale, such as en_US. |
+| `Image` | `SocialImage` | Image is the required social-preview image and structured metadata. |
+| `TwitterCard` | `TwitterCard` | TwitterCard selects the X/Twitter presentation and defaults to summary_large_image. |
+| `TwitterSite` | `string` | TwitterSite is the optional real project account handle, including @. |
 
 **SocialImage**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `URL` | `string` |  |
-| `MIMEType` | `string` |  |
-| `Width` | `int` |  |
-| `Height` | `int` |  |
-| `Alt` | `string` |  |
+| `URL` | `string` | URL is the absolute HTTPS URL crawlers use to fetch the image. |
+| `MIMEType` | `string` | MIMEType is the image media type, such as image/jpeg or image/png. |
+| `Width` | `int` | Width is the image width in pixels and must be positive. |
+| `Height` | `int` | Height is the image height in pixels and must be positive. |
+| `Alt` | `string` | Alt describes the image for accessible social clients and must be non-empty. |
 
 ## icon
 

--- a/.agents/skills/using-goshtoso/references/components-reference.md
+++ b/.agents/skills/using-goshtoso/references/components-reference.md
@@ -931,7 +931,7 @@ import "github.com/araihu/goshtoso/components/head"  // package head
 | Field | Type | Description |
 |-------|------|-------------|
 | `URL` | `string` | URL is the absolute HTTPS URL crawlers use to fetch the image. |
-| `MIMEType` | `string` | MIMEType is the image media type, such as image/jpeg or image/png. |
+| `MIMEType` | `string` | MIMEType is a parameter-free image media type, such as image/jpeg or image/png. |
 | `Width` | `int` | Width is the image width in pixels and must be positive. |
 | `Height` | `int` | Height is the image height in pixels and must be positive. |
 | `Alt` | `string` | Alt describes the image for accessible social clients and must be non-empty. |

--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -904,11 +904,37 @@ import "github.com/araihu/goshtoso/components/form/validation"  // package valid
 import "github.com/araihu/goshtoso/components/head"  // package head
 ```
 
-**Entry points:** `Dependencies(options ...Option)` · `DependenciesMinimal(options ...Option)`
+**Entry points:** `Dependencies(options ...Option)` · `DependenciesMinimal(options ...Option)` · `Metadata(metadata MetadataConfig)`
 
 **Options:** `WithActionGroupURL(url string)` · `WithComboboxURL(url string)` · `WithDependencyCDNURL(dependency Dependency, url string)` · `WithDependencyIntegrity(dependency Dependency, integrity string)` · `WithDependencyLocalURL(dependency Dependency, url string)` · `WithLoaderURL(url string)` · `WithLocalRuntime()` · `WithRuntimeManifest(manifest assets.RuntimeManifest)` · `WithStylesheetURL(url string)` · `WithoutDependency(dependency Dependency)` · `WithoutLocalFallback()`
 
 - **Dependency** — DependencyAlpineJS = "alpinejs", DependencyAlpineCollapse = "alpinejs-collapse", DependencyAlpineFocus = "alpinejs-focus", DependencyAlpineMask = "alpinejs-mask", DependencyHTMX = "htmx"
+- **OpenGraphType** — OpenGraphTypeWebsite = "website"
+- **TwitterCard** — TwitterCardSummary = "summary", TwitterCardSummaryLargeImage = "summary_large_image"
+
+**MetadataConfig**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Title` | `string` |  |
+| `Description` | `string` |  |
+| `CanonicalURL` | `string` |  |
+| `OpenGraphType` | `OpenGraphType` |  |
+| `SiteName` | `string` |  |
+| `Locale` | `string` |  |
+| `Image` | `SocialImage` |  |
+| `TwitterCard` | `TwitterCard` |  |
+| `TwitterSite` | `string` |  |
+
+**SocialImage**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `URL` | `string` |  |
+| `MIMEType` | `string` |  |
+| `Width` | `int` |  |
+| `Height` | `int` |  |
+| `Alt` | `string` |  |
 
 ## icon
 

--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -931,7 +931,7 @@ import "github.com/araihu/goshtoso/components/head"  // package head
 | Field | Type | Description |
 |-------|------|-------------|
 | `URL` | `string` | URL is the absolute HTTPS URL crawlers use to fetch the image. |
-| `MIMEType` | `string` | MIMEType is a parameter-free image media type, such as image/jpeg or image/png. |
+| `MIMEType` | `string` | MIMEType is a parameter-free RFC 6838 image type, such as image/jpeg. |
 | `Width` | `int` | Width is the image width in pixels and must be positive. |
 | `Height` | `int` | Height is the image height in pixels and must be positive. |
 | `Alt` | `string` | Alt describes the image for accessible social clients and must be non-empty. |

--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -916,25 +916,25 @@ import "github.com/araihu/goshtoso/components/head"  // package head
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `Title` | `string` |  |
-| `Description` | `string` |  |
-| `CanonicalURL` | `string` |  |
-| `OpenGraphType` | `OpenGraphType` |  |
-| `SiteName` | `string` |  |
-| `Locale` | `string` |  |
-| `Image` | `SocialImage` |  |
-| `TwitterCard` | `TwitterCard` |  |
-| `TwitterSite` | `string` |  |
+| `Title` | `string` | Title is the non-empty route-specific document and social title. |
+| `Description` | `string` | Description is the non-empty route-specific document and social summary. |
+| `CanonicalURL` | `string` | CanonicalURL is the route's absolute HTTPS canonical and Open Graph URL. |
+| `OpenGraphType` | `OpenGraphType` | OpenGraphType is the Open Graph object type and defaults to website. |
+| `SiteName` | `string` | SiteName is the optional Open Graph site name. |
+| `Locale` | `string` | Locale is the optional Open Graph locale, such as en_US. |
+| `Image` | `SocialImage` | Image is the required social-preview image and structured metadata. |
+| `TwitterCard` | `TwitterCard` | TwitterCard selects the X/Twitter presentation and defaults to summary_large_image. |
+| `TwitterSite` | `string` | TwitterSite is the optional real project account handle, including @. |
 
 **SocialImage**
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `URL` | `string` |  |
-| `MIMEType` | `string` |  |
-| `Width` | `int` |  |
-| `Height` | `int` |  |
-| `Alt` | `string` |  |
+| `URL` | `string` | URL is the absolute HTTPS URL crawlers use to fetch the image. |
+| `MIMEType` | `string` | MIMEType is the image media type, such as image/jpeg or image/png. |
+| `Width` | `int` | Width is the image width in pixels and must be positive. |
+| `Height` | `int` | Height is the image height in pixels and must be positive. |
+| `Alt` | `string` | Alt describes the image for accessible social clients and must be non-empty. |
 
 ## icon
 

--- a/.claude/skills/using-goshtoso/components-reference.md
+++ b/.claude/skills/using-goshtoso/components-reference.md
@@ -931,7 +931,7 @@ import "github.com/araihu/goshtoso/components/head"  // package head
 | Field | Type | Description |
 |-------|------|-------------|
 | `URL` | `string` | URL is the absolute HTTPS URL crawlers use to fetch the image. |
-| `MIMEType` | `string` | MIMEType is the image media type, such as image/jpeg or image/png. |
+| `MIMEType` | `string` | MIMEType is a parameter-free image media type, such as image/jpeg or image/png. |
 | `Width` | `int` | Width is the image width in pixels and must be positive. |
 | `Height` | `int` | Height is the image height in pixels and must be positive. |
 | `Alt` | `string` | Alt describes the image for accessible social clients and must be non-empty. |

--- a/components/head/component.go
+++ b/components/head/component.go
@@ -14,9 +14,26 @@ type Instance struct {
 }
 
 // Metadata renders route-specific title, description, canonical, Open Graph,
-// and X/Twitter Card tags from one config.
+// and X/Twitter Card tags from one complete config. Render returns an error and
+// writes no tags when required text, image metadata, or absolute HTTPS URLs are
+// missing or invalid.
 func Metadata(metadata MetadataConfig) templ.Component {
-	return metadataTemplate(metadata.normalized())
+	return metadataComponent{config: metadata}
+}
+
+type metadataComponent struct {
+	config MetadataConfig
+}
+
+func (component metadataComponent) Render(ctx context.Context, w io.Writer) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	metadata, err := component.config.validated()
+	if err != nil {
+		return err
+	}
+	return metadataTemplate(metadata).Render(ctx, w)
 }
 
 // Dependencies returns the full Goshtoso runtime dependency set.

--- a/components/head/component.go
+++ b/components/head/component.go
@@ -13,6 +13,12 @@ type Instance struct {
 	config config
 }
 
+// Metadata renders route-specific title, description, canonical, Open Graph,
+// and X/Twitter Card tags from one config.
+func Metadata(metadata MetadataConfig) templ.Component {
+	return metadataTemplate(metadata.normalized())
+}
+
 // Dependencies returns the full Goshtoso runtime dependency set.
 func Dependencies(options ...Option) Instance {
 	return Instance{config: newConfig(options)}

--- a/components/head/head.templ
+++ b/components/head/head.templ
@@ -1,8 +1,8 @@
 package head
 
 // Metadata renders route-specific document, Open Graph, and X/Twitter Card
-// metadata. Render it inside <head> before Dependencies. Supply absolute public
-// URLs for CanonicalURL and Image.URL, plus image Alt text.
+// metadata. Render it inside <head> before Dependencies. The caller-facing
+// component validates the complete contract before this template writes tags.
 templ metadataTemplate(metadata MetadataConfig) {
 	if metadata.Title != "" {
 		<title>{ metadata.Title }</title>

--- a/components/head/head.templ
+++ b/components/head/head.templ
@@ -1,5 +1,69 @@
 package head
 
+// Metadata renders route-specific document, Open Graph, and X/Twitter Card
+// metadata. Render it inside <head> before Dependencies. Supply absolute public
+// URLs for CanonicalURL and Image.URL, plus image Alt text.
+templ metadataTemplate(metadata MetadataConfig) {
+	if metadata.Title != "" {
+		<title>{ metadata.Title }</title>
+	}
+	if metadata.Description != "" {
+		<meta name="description" content={ metadata.Description }/>
+	}
+	if metadata.CanonicalURL != "" {
+		<link rel="canonical" href={ templ.URL(metadata.CanonicalURL) }/>
+		<meta property="og:url" content={ metadata.CanonicalURL }/>
+	}
+	if metadata.OpenGraphType != "" {
+		<meta property="og:type" content={ string(metadata.OpenGraphType) }/>
+	}
+	if metadata.Title != "" {
+		<meta property="og:title" content={ metadata.Title }/>
+	}
+	if metadata.Description != "" {
+		<meta property="og:description" content={ metadata.Description }/>
+	}
+	if metadata.SiteName != "" {
+		<meta property="og:site_name" content={ metadata.SiteName }/>
+	}
+	if metadata.Locale != "" {
+		<meta property="og:locale" content={ metadata.Locale }/>
+	}
+	if metadata.Image.URL != "" {
+		<meta property="og:image" content={ metadata.Image.URL }/>
+		if metadata.Image.MIMEType != "" {
+			<meta property="og:image:type" content={ metadata.Image.MIMEType }/>
+		}
+		if metadata.Image.Width > 0 {
+			<meta property="og:image:width" content={ metadata.Image.widthContent() }/>
+		}
+		if metadata.Image.Height > 0 {
+			<meta property="og:image:height" content={ metadata.Image.heightContent() }/>
+		}
+		if metadata.Image.Alt != "" {
+			<meta property="og:image:alt" content={ metadata.Image.Alt }/>
+		}
+	}
+	if metadata.TwitterCard != "" {
+		<meta name="twitter:card" content={ string(metadata.TwitterCard) }/>
+	}
+	if metadata.Title != "" {
+		<meta name="twitter:title" content={ metadata.Title }/>
+	}
+	if metadata.Description != "" {
+		<meta name="twitter:description" content={ metadata.Description }/>
+	}
+	if metadata.Image.URL != "" {
+		<meta name="twitter:image" content={ metadata.Image.URL }/>
+		if metadata.Image.Alt != "" {
+			<meta name="twitter:image:alt" content={ metadata.Image.Alt }/>
+		}
+	}
+	if metadata.TwitterSite != "" {
+		<meta name="twitter:site" content={ metadata.TwitterSite }/>
+	}
+}
+
 // Dependencies renders the <script>/<link> tags for every Goshtoso runtime
 // asset: the Tailwind-compiled CSS (which carries the theme tokens — bg-primary,
 // text-on-primary, etc.), Alpine core + collapse/focus/mask plugins, HTMX, and the

--- a/components/head/head_coverage_test.go
+++ b/components/head/head_coverage_test.go
@@ -25,6 +25,18 @@ func entryPoints() []struct {
 		name string
 		comp templ.Component
 	}{
+		{"Metadata", Metadata(MetadataConfig{
+			Title:        "Example",
+			Description:  "Example page.",
+			CanonicalURL: "https://example.com/",
+			Image: SocialImage{
+				URL:      "https://example.com/og.jpg",
+				MIMEType: "image/jpeg",
+				Width:    1280,
+				Height:   640,
+				Alt:      "Example preview",
+			},
+		})},
 		{"Dependencies", Dependencies()},
 		{"DependenciesMinimal", DependenciesMinimal()},
 	}

--- a/components/head/head_templ.go
+++ b/components/head/head_templ.go
@@ -9,8 +9,8 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 // Metadata renders route-specific document, Open Graph, and X/Twitter Card
-// metadata. Render it inside <head> before Dependencies. Supply absolute public
-// URLs for CanonicalURL and Image.URL, plus image Alt text.
+// metadata. Render it inside <head> before Dependencies. The caller-facing
+// component validates the complete contract before this template writes tags.
 func metadataTemplate(metadata MetadataConfig) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context

--- a/components/head/head_templ.go
+++ b/components/head/head_templ.go
@@ -8,6 +8,420 @@ package head
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
+// Metadata renders route-specific document, Open Graph, and X/Twitter Card
+// metadata. Render it inside <head> before Dependencies. Supply absolute public
+// URLs for CanonicalURL and Image.URL, plus image Alt text.
+func metadataTemplate(metadata MetadataConfig) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var1 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var1 == nil {
+			templ_7745c5c3_Var1 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		if metadata.Title != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<title>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var2 string
+			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(metadata.Title)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 8, Col: 25}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</title>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if metadata.Description != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<meta name=\"description\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var3 string
+			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Description)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 11, Col: 57}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if metadata.CanonicalURL != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<link rel=\"canonical\" href=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var4 templ.SafeURL
+			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(metadata.CanonicalURL))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 14, Col: 63}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\"><meta property=\"og:url\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var5 string
+			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.CanonicalURL)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 15, Col: 57}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if metadata.OpenGraphType != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<meta property=\"og:type\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var6 string
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(string(metadata.OpenGraphType))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 18, Col: 67}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if metadata.Title != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<meta property=\"og:title\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var7 string
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Title)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 21, Col: 52}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var7)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if metadata.Description != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<meta property=\"og:description\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Description)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 24, Col: 64}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if metadata.SiteName != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<meta property=\"og:site_name\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var9 string
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.SiteName)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 27, Col: 59}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if metadata.Locale != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<meta property=\"og:locale\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var10 string
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Locale)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 30, Col: 54}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var10)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if metadata.Image.URL != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<meta property=\"og:image\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Image.URL)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 33, Col: 56}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if metadata.Image.MIMEType != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<meta property=\"og:image:type\" content=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var12 string
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Image.MIMEType)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 35, Col: 67}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var12)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if metadata.Image.Width > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<meta property=\"og:image:width\" content=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var13 string
+				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Image.widthContent())
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 38, Col: 74}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var13)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if metadata.Image.Height > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<meta property=\"og:image:height\" content=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var14 string
+				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Image.heightContent())
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 41, Col: 76}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var14)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if metadata.Image.Alt != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<meta property=\"og:image:alt\" content=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var15 string
+				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Image.Alt)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 44, Col: 61}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var15)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+		}
+		if metadata.TwitterCard != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<meta name=\"twitter:card\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var16 string
+			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(string(metadata.TwitterCard))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 48, Col: 66}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if metadata.Title != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<meta name=\"twitter:title\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var17 string
+			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Title)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 51, Col: 53}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var17)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if metadata.Description != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<meta name=\"twitter:description\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var18 string
+			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Description)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 54, Col: 65}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if metadata.Image.URL != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<meta name=\"twitter:image\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var19 string
+			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Image.URL)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 57, Col: 57}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var19)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if metadata.Image.Alt != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<meta name=\"twitter:image:alt\" content=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var20 string
+				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.Image.Alt)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 59, Col: 62}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+		}
+		if metadata.TwitterSite != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<meta name=\"twitter:site\" content=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var21 string
+			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(metadata.TwitterSite)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 63, Col: 58}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		return nil
+	})
+}
+
 // Dependencies renders the <script>/<link> tags for every Goshtoso runtime
 // asset: the Tailwind-compiled CSS (which carries the theme tokens — bg-primary,
 // text-on-primary, etc.), Alpine core + collapse/focus/mask plugins, HTMX, and the
@@ -49,26 +463,26 @@ func dependenciesTemplate(cfg config) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var1 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var1 == nil {
-			templ_7745c5c3_Var1 = templ.NopComponent
+		templ_7745c5c3_Var22 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var22 == nil {
+			templ_7745c5c3_Var22 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if cfg.includes(cfg.manifest.Stylesheet, false) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<link rel=\"stylesheet\" href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<link rel=\"stylesheet\" href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var2 templ.SafeURL
-			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs(cfg.manifest.Stylesheet.PrimaryURL)
+			var templ_7745c5c3_Var23 templ.SafeURL
+			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinURLErrs(cfg.manifest.Stylesheet.PrimaryURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 30, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 94, Col: 66}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -76,7 +490,7 @@ func dependenciesTemplate(cfg config) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, ">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, ">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -87,30 +501,30 @@ func dependenciesTemplate(cfg config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else if cfg.includes(cfg.manifest.Loader, false) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<script")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<script")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if cfg.manifest.Loader.Defer {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, " defer")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, " defer")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, " src=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, " src=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var3 string
-			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.manifest.Loader.PrimaryURL)
+			var templ_7745c5c3_Var24 string
+			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.manifest.Loader.PrimaryURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 35, Col: 83}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 99, Col: 83}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var24)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -118,7 +532,7 @@ func dependenciesTemplate(cfg config) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "></script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "></script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -147,26 +561,26 @@ func dependenciesMinimalTemplate(cfg config) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var4 == nil {
-			templ_7745c5c3_Var4 = templ.NopComponent
+		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var25 == nil {
+			templ_7745c5c3_Var25 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if cfg.includes(cfg.manifest.Stylesheet, true) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<link rel=\"stylesheet\" href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<link rel=\"stylesheet\" href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var5 templ.SafeURL
-			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(cfg.manifest.Stylesheet.PrimaryURL)
+			var templ_7745c5c3_Var26 templ.SafeURL
+			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinURLErrs(cfg.manifest.Stylesheet.PrimaryURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 45, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 109, Col: 66}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -174,7 +588,7 @@ func dependenciesMinimalTemplate(cfg config) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, ">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, ">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -185,30 +599,30 @@ func dependenciesMinimalTemplate(cfg config) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else if cfg.includes(cfg.manifest.Loader, true) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<script")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<script")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if cfg.manifest.Loader.Defer {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " defer")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, " defer")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, " src=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, " src=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.manifest.Loader.PrimaryURL)
+			var templ_7745c5c3_Var27 string
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(cfg.manifest.Loader.PrimaryURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 50, Col: 83}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 114, Col: 83}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -216,7 +630,7 @@ func dependenciesMinimalTemplate(cfg config) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "></script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "></script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -241,12 +655,12 @@ func localDependencyScripts(cfg config, minimal bool) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var28 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var28 == nil {
+			templ_7745c5c3_Var28 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<!-- Alpine.js plugins must load before Alpine core. -->")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<!-- Alpine.js plugins must load before Alpine core. -->")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -276,35 +690,35 @@ func localDependencyScript(cfg config, source runtimeAsset) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var29 == nil {
+			templ_7745c5c3_Var29 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<script")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "<script")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if source.Defer {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, " defer")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, " defer")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, " src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, " src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.ResolveAttributeValue(source.LocalURL)
+		var templ_7745c5c3_Var30 string
+		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.ResolveAttributeValue(source.LocalURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 62, Col: 54}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/head/head.templ`, Line: 126, Col: 54}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var30)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -312,7 +726,7 @@ func localDependencyScript(cfg config, source runtimeAsset) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "></script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "></script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/head/metadata_test.go
+++ b/components/head/metadata_test.go
@@ -1,0 +1,105 @@
+package head
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMetadataRendersCompleteSocialContract(t *testing.T) {
+	out := render(t, Metadata(MetadataConfig{
+		Title:         "Muamba · Trust remote files once",
+		Description:   "Language-agnostic TOFU vendoring and integrity verification.",
+		CanonicalURL:  "https://muamba.araihu.com/docs",
+		OpenGraphType: "article",
+		SiteName:      "Muamba",
+		Locale:        "en_US",
+		Image: SocialImage{
+			URL:      "https://muamba.araihu.com/og.jpg",
+			MIMEType: "image/jpeg",
+			Width:    1280,
+			Height:   640,
+			Alt:      "Muamba — Trust remote files once. Verify them forever.",
+		},
+		TwitterCard: TwitterCardSummaryLargeImage,
+		TwitterSite: "@araihu",
+	}))
+
+	wants := []string{
+		`<title>Muamba · Trust remote files once</title>`,
+		`<meta name="description" content="Language-agnostic TOFU vendoring and integrity verification.">`,
+		`<link rel="canonical" href="https://muamba.araihu.com/docs">`,
+		`<meta property="og:url" content="https://muamba.araihu.com/docs">`,
+		`<meta property="og:type" content="article">`,
+		`<meta property="og:title" content="Muamba · Trust remote files once">`,
+		`<meta property="og:description" content="Language-agnostic TOFU vendoring and integrity verification.">`,
+		`<meta property="og:site_name" content="Muamba">`,
+		`<meta property="og:locale" content="en_US">`,
+		`<meta property="og:image" content="https://muamba.araihu.com/og.jpg">`,
+		`<meta property="og:image:type" content="image/jpeg">`,
+		`<meta property="og:image:width" content="1280">`,
+		`<meta property="og:image:height" content="640">`,
+		`<meta property="og:image:alt" content="Muamba — Trust remote files once. Verify them forever.">`,
+		`<meta name="twitter:card" content="summary_large_image">`,
+		`<meta name="twitter:title" content="Muamba · Trust remote files once">`,
+		`<meta name="twitter:description" content="Language-agnostic TOFU vendoring and integrity verification.">`,
+		`<meta name="twitter:image" content="https://muamba.araihu.com/og.jpg">`,
+		`<meta name="twitter:image:alt" content="Muamba — Trust remote files once. Verify them forever.">`,
+		`<meta name="twitter:site" content="@araihu">`,
+	}
+	for _, want := range wants {
+		if !strings.Contains(out, want) {
+			t.Errorf("Metadata() missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestMetadataDefaultsAndEscapesValues(t *testing.T) {
+	out := render(t, Metadata(MetadataConfig{
+		Title:        `<unsafe> & title`,
+		Description:  `quoted "description"`,
+		CanonicalURL: "https://example.com/docs?a=1&b=2",
+		Image: SocialImage{
+			URL: "https://example.com/og.png?a=1&b=2",
+			Alt: `Diagram "with labels"`,
+		},
+	}))
+
+	wants := []string{
+		`<title>&lt;unsafe&gt; &amp; title</title>`,
+		`content="quoted &#34;description&#34;"`,
+		`href="https://example.com/docs?a=1&amp;b=2"`,
+		`<meta property="og:type" content="website">`,
+		`content="https://example.com/og.png?a=1&amp;b=2"`,
+		`<meta name="twitter:card" content="summary_large_image">`,
+		`content="Diagram &#34;with labels&#34;"`,
+	}
+	for _, want := range wants {
+		if !strings.Contains(out, want) {
+			t.Errorf("Metadata() missing escaped/default value %q\n%s", want, out)
+		}
+	}
+}
+
+func TestMetadataOmitsUnavailableOptionalValues(t *testing.T) {
+	out := render(t, Metadata(MetadataConfig{
+		Title:        "Status",
+		Description:  "Current service status.",
+		CanonicalURL: "https://status.example.com/",
+		TwitterCard:  TwitterCardSummary,
+	}))
+
+	for _, absent := range []string{
+		`og:image`,
+		`og:site_name`,
+		`og:locale`,
+		`twitter:image`,
+		`twitter:site`,
+	} {
+		if strings.Contains(out, absent) {
+			t.Errorf("Metadata() unexpectedly rendered %q\n%s", absent, out)
+		}
+	}
+	if !strings.Contains(out, `<meta name="twitter:card" content="summary">`) {
+		t.Fatalf("Metadata() missing explicit summary card\n%s", out)
+	}
+}

--- a/components/head/metadata_test.go
+++ b/components/head/metadata_test.go
@@ -217,3 +217,47 @@ func TestMetadataRejectsIncompleteSocialContractWithoutOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestMetadataValidatesAndCanonicalizesImageMIMEType(t *testing.T) {
+	valid := map[string]string{
+		"image/jpeg":    "image/jpeg",
+		"IMAGE/JPEG":    "image/jpeg",
+		"image/svg+xml": "image/svg+xml",
+	}
+	for input, canonical := range valid {
+		t.Run("valid/"+input, func(t *testing.T) {
+			cfg := completeMetadataConfig()
+			cfg.Image.MIMEType = input
+			out, err := renderMetadata(cfg)
+			if err != nil {
+				t.Fatalf("Metadata() rejected valid image media type %q: %v", input, err)
+			}
+			want := `property="og:image:type" content="` + canonical + `"`
+			if !strings.Contains(out, want) {
+				t.Fatalf("Metadata() did not emit canonical media type %q:\n%s", canonical, out)
+			}
+		})
+	}
+
+	invalid := []string{
+		"image/",
+		"image",
+		"image/jp eg",
+		"text/html",
+		"image/jpeg; charset=utf-8",
+		"image/jpeg; charset=",
+	}
+	for _, input := range invalid {
+		t.Run("invalid/"+input, func(t *testing.T) {
+			cfg := completeMetadataConfig()
+			cfg.Image.MIMEType = input
+			out, err := renderMetadata(cfg)
+			if err == nil {
+				t.Fatalf("Metadata() accepted invalid or parameterized image media type %q", input)
+			}
+			if out != "" {
+				t.Fatalf("Metadata() wrote partial tags before rejecting media type %q:\n%s", input, out)
+			}
+		})
+	}
+}

--- a/components/head/metadata_test.go
+++ b/components/head/metadata_test.go
@@ -220,9 +220,11 @@ func TestMetadataRejectsIncompleteSocialContractWithoutOutput(t *testing.T) {
 
 func TestMetadataValidatesAndCanonicalizesImageMIMEType(t *testing.T) {
 	valid := map[string]string{
-		"image/jpeg":    "image/jpeg",
-		"IMAGE/JPEG":    "image/jpeg",
-		"image/svg+xml": "image/svg+xml",
+		"image/jpeg":             "image/jpeg",
+		"IMAGE/JPEG":             "image/jpeg",
+		"image/svg+xml":          "image/svg+xml",
+		"image/vnd.example+json": "image/vnd.example+json",
+		"image/prs.example":      "image/prs.example",
 	}
 	for input, canonical := range valid {
 		t.Run("valid/"+input, func(t *testing.T) {
@@ -246,6 +248,11 @@ func TestMetadataValidatesAndCanonicalizesImageMIMEType(t *testing.T) {
 		"text/html",
 		"image/jpeg; charset=utf-8",
 		"image/jpeg; charset=",
+		"image/*",
+		"image/.",
+		"image/-jpeg",
+		"image/+xml",
+		"image/" + strings.Repeat("a", 128),
 	}
 	for _, input := range invalid {
 		t.Run("invalid/"+input, func(t *testing.T) {

--- a/components/head/metadata_test.go
+++ b/components/head/metadata_test.go
@@ -1,9 +1,31 @@
 package head
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
+
+func completeMetadataConfig() MetadataConfig {
+	return MetadataConfig{
+		Title:        "Example page",
+		Description:  "A complete route-specific description.",
+		CanonicalURL: "https://example.com/docs",
+		Image: SocialImage{
+			URL:      "https://example.com/social/docs.jpg",
+			MIMEType: "image/jpeg",
+			Width:    1280,
+			Height:   640,
+			Alt:      "Example documentation preview",
+		},
+	}
+}
+
+func renderMetadata(cfg MetadataConfig) (string, error) {
+	var output strings.Builder
+	err := Metadata(cfg).Render(context.Background(), &output)
+	return output.String(), err
+}
 
 func TestMetadataRendersCompleteSocialContract(t *testing.T) {
 	out := render(t, Metadata(MetadataConfig{
@@ -59,8 +81,11 @@ func TestMetadataDefaultsAndEscapesValues(t *testing.T) {
 		Description:  `quoted "description"`,
 		CanonicalURL: "https://example.com/docs?a=1&b=2",
 		Image: SocialImage{
-			URL: "https://example.com/og.png?a=1&b=2",
-			Alt: `Diagram "with labels"`,
+			URL:      "https://example.com/og.png?a=1&b=2",
+			MIMEType: "image/png",
+			Width:    1280,
+			Height:   640,
+			Alt:      `Diagram "with labels"`,
 		},
 	}))
 
@@ -81,18 +106,13 @@ func TestMetadataDefaultsAndEscapesValues(t *testing.T) {
 }
 
 func TestMetadataOmitsUnavailableOptionalValues(t *testing.T) {
-	out := render(t, Metadata(MetadataConfig{
-		Title:        "Status",
-		Description:  "Current service status.",
-		CanonicalURL: "https://status.example.com/",
-		TwitterCard:  TwitterCardSummary,
-	}))
+	cfg := completeMetadataConfig()
+	cfg.TwitterCard = TwitterCardSummary
+	out := render(t, Metadata(cfg))
 
 	for _, absent := range []string{
-		`og:image`,
 		`og:site_name`,
 		`og:locale`,
-		`twitter:image`,
 		`twitter:site`,
 	} {
 		if strings.Contains(out, absent) {
@@ -101,5 +121,99 @@ func TestMetadataOmitsUnavailableOptionalValues(t *testing.T) {
 	}
 	if !strings.Contains(out, `<meta name="twitter:card" content="summary">`) {
 		t.Fatalf("Metadata() missing explicit summary card\n%s", out)
+	}
+}
+
+func TestMetadataRejectsInvalidURLsWithoutWritingPartialTags(t *testing.T) {
+	invalidURLs := map[string]string{
+		"relative":        "/docs",
+		"scheme-relative": "//example.com/docs",
+		"http":            "http://example.com/docs",
+		"javascript":      "javascript:alert(1)",
+		"data":            "data:text/plain,preview",
+		"missing-host":    "https:///docs",
+		"malformed":       "https://example.com/%zz",
+	}
+
+	for name, invalidURL := range invalidURLs {
+		for _, field := range []string{"canonical", "image"} {
+			t.Run(name+"/"+field, func(t *testing.T) {
+				cfg := completeMetadataConfig()
+				if field == "canonical" {
+					cfg.CanonicalURL = invalidURL
+				} else {
+					cfg.Image.URL = invalidURL
+				}
+
+				out, err := renderMetadata(cfg)
+				if err == nil {
+					t.Fatalf("Metadata() accepted invalid %s URL %q", field, invalidURL)
+				}
+				if out != "" {
+					t.Fatalf("Metadata() wrote partial tags before rejecting %s URL %q:\n%s", field, invalidURL, out)
+				}
+			})
+		}
+	}
+}
+
+func TestMetadataRejectsIncompleteSocialContractWithoutOutput(t *testing.T) {
+	tests := map[string]MetadataConfig{
+		"empty":      {},
+		"title-only": {Title: "Only a title"},
+		"url-only":   {CanonicalURL: "https://example.com/docs"},
+		"image-only": {Image: completeMetadataConfig().Image},
+		"missing-title": func() MetadataConfig {
+			cfg := completeMetadataConfig()
+			cfg.Title = ""
+			return cfg
+		}(),
+		"missing-description": func() MetadataConfig {
+			cfg := completeMetadataConfig()
+			cfg.Description = ""
+			return cfg
+		}(),
+		"missing-canonical": func() MetadataConfig {
+			cfg := completeMetadataConfig()
+			cfg.CanonicalURL = ""
+			return cfg
+		}(),
+		"missing-image": func() MetadataConfig {
+			cfg := completeMetadataConfig()
+			cfg.Image = SocialImage{}
+			return cfg
+		}(),
+		"missing-image-type": func() MetadataConfig {
+			cfg := completeMetadataConfig()
+			cfg.Image.MIMEType = ""
+			return cfg
+		}(),
+		"missing-image-width": func() MetadataConfig {
+			cfg := completeMetadataConfig()
+			cfg.Image.Width = 0
+			return cfg
+		}(),
+		"missing-image-height": func() MetadataConfig {
+			cfg := completeMetadataConfig()
+			cfg.Image.Height = 0
+			return cfg
+		}(),
+		"missing-image-alt": func() MetadataConfig {
+			cfg := completeMetadataConfig()
+			cfg.Image.Alt = ""
+			return cfg
+		}(),
+	}
+
+	for name, cfg := range tests {
+		t.Run(name, func(t *testing.T) {
+			out, err := renderMetadata(cfg)
+			if err == nil {
+				t.Fatal("Metadata() accepted an incomplete social contract")
+			}
+			if out != "" {
+				t.Fatalf("Metadata() wrote partial tags before rejecting config:\n%s", out)
+			}
+		})
 	}
 }

--- a/components/head/types.go
+++ b/components/head/types.go
@@ -35,7 +35,7 @@ const (
 type SocialImage struct {
 	// URL is the absolute HTTPS URL crawlers use to fetch the image.
 	URL string
-	// MIMEType is a parameter-free image media type, such as image/jpeg or image/png.
+	// MIMEType is a parameter-free RFC 6838 image type, such as image/jpeg.
 	MIMEType string
 	// Width is the image width in pixels and must be positive.
 	Width int
@@ -141,13 +141,38 @@ func imageMIMEType(value string) (string, error) {
 		return "", fmt.Errorf("head.Metadata: Image.MIMEType must be a valid image media type: %w", err)
 	}
 	parts := strings.SplitN(mediaType, "/", 2)
-	if len(parts) != 2 || !strings.EqualFold(parts[0], "image") || parts[1] == "" {
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "image") ||
+		!validRestrictedMediaName(parts[1]) {
 		return "", errors.New("head.Metadata: Image.MIMEType must be an image media type")
 	}
 	if len(parameters) != 0 {
 		return "", errors.New("head.Metadata: Image.MIMEType parameters are not supported")
 	}
 	return strings.ToLower(mediaType), nil
+}
+
+func validRestrictedMediaName(value string) bool {
+	if len(value) == 0 || len(value) > 127 || !isASCIIAlphaNumeric(value[0]) {
+		return false
+	}
+	for index := 1; index < len(value); index++ {
+		character := value[index]
+		if isASCIIAlphaNumeric(character) {
+			continue
+		}
+		switch character {
+		case '!', '#', '$', '&', '-', '^', '_', '.', '+':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isASCIIAlphaNumeric(character byte) bool {
+	return character >= 'a' && character <= 'z' ||
+		character >= 'A' && character <= 'Z' ||
+		character >= '0' && character <= '9'
 }
 
 func (image SocialImage) widthContent() string {

--- a/components/head/types.go
+++ b/components/head/types.go
@@ -5,11 +5,85 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/a-h/templ"
 	"github.com/araihu/goshtoso/assets"
 )
+
+// OpenGraphType identifies the Open Graph object type for a page.
+type OpenGraphType string
+
+const (
+	// OpenGraphTypeWebsite is the default type for site and documentation pages.
+	OpenGraphTypeWebsite OpenGraphType = "website"
+)
+
+// TwitterCard identifies the X/Twitter Card presentation for a page.
+type TwitterCard string
+
+const (
+	// TwitterCardSummary renders a compact summary card.
+	TwitterCardSummary TwitterCard = "summary"
+	// TwitterCardSummaryLargeImage renders a wide image-led summary card.
+	TwitterCardSummaryLargeImage TwitterCard = "summary_large_image"
+)
+
+// SocialImage defines one absolute social-preview image and its structured
+// metadata. Use a public HTTPS URL and provide Alt whenever URL is set.
+type SocialImage struct {
+	URL      string
+	MIMEType string
+	Width    int
+	Height   int
+	Alt      string
+}
+
+// MetadataConfig defines route-specific document, Open Graph, and X/Twitter
+// Card metadata. CanonicalURL and Image.URL should be absolute public URLs.
+type MetadataConfig struct {
+	Title         string
+	Description   string
+	CanonicalURL  string
+	OpenGraphType OpenGraphType
+	SiteName      string
+	Locale        string
+	Image         SocialImage
+	TwitterCard   TwitterCard
+	TwitterSite   string
+}
+
+func (cfg MetadataConfig) normalized() MetadataConfig {
+	if !cfg.hasContent() {
+		return cfg
+	}
+	if cfg.OpenGraphType == "" {
+		cfg.OpenGraphType = OpenGraphTypeWebsite
+	}
+	if cfg.TwitterCard == "" {
+		if cfg.Image.URL == "" {
+			cfg.TwitterCard = TwitterCardSummary
+		} else {
+			cfg.TwitterCard = TwitterCardSummaryLargeImage
+		}
+	}
+	return cfg
+}
+
+func (cfg MetadataConfig) hasContent() bool {
+	return cfg.Title != "" || cfg.Description != "" || cfg.CanonicalURL != "" ||
+		cfg.SiteName != "" || cfg.Locale != "" || cfg.Image.URL != "" ||
+		cfg.TwitterCard != "" || cfg.TwitterSite != ""
+}
+
+func (image SocialImage) widthContent() string {
+	return strconv.Itoa(image.Width)
+}
+
+func (image SocialImage) heightContent() string {
+	return strconv.Itoa(image.Height)
+}
 
 // Dependency identifies a third-party runtime managed by Dependencies.
 type Dependency string

--- a/components/head/types.go
+++ b/components/head/types.go
@@ -30,51 +30,108 @@ const (
 	TwitterCardSummaryLargeImage TwitterCard = "summary_large_image"
 )
 
-// SocialImage defines one absolute social-preview image and its structured
-// metadata. Use a public HTTPS URL and provide Alt whenever URL is set.
+// SocialImage defines the required image portion of a complete social preview.
 type SocialImage struct {
-	URL      string
+	// URL is the absolute HTTPS URL crawlers use to fetch the image.
+	URL string
+	// MIMEType is the image media type, such as image/jpeg or image/png.
 	MIMEType string
-	Width    int
-	Height   int
-	Alt      string
+	// Width is the image width in pixels and must be positive.
+	Width int
+	// Height is the image height in pixels and must be positive.
+	Height int
+	// Alt describes the image for accessible social clients and must be non-empty.
+	Alt string
 }
 
 // MetadataConfig defines route-specific document, Open Graph, and X/Twitter
-// Card metadata. CanonicalURL and Image.URL should be absolute public URLs.
+// Card metadata. Render fails without a complete social contract.
 type MetadataConfig struct {
-	Title         string
-	Description   string
-	CanonicalURL  string
+	// Title is the non-empty route-specific document and social title.
+	Title string
+	// Description is the non-empty route-specific document and social summary.
+	Description string
+	// CanonicalURL is the route's absolute HTTPS canonical and Open Graph URL.
+	CanonicalURL string
+	// OpenGraphType is the Open Graph object type and defaults to website.
 	OpenGraphType OpenGraphType
-	SiteName      string
-	Locale        string
-	Image         SocialImage
-	TwitterCard   TwitterCard
-	TwitterSite   string
+	// SiteName is the optional Open Graph site name.
+	SiteName string
+	// Locale is the optional Open Graph locale, such as en_US.
+	Locale string
+	// Image is the required social-preview image and structured metadata.
+	Image SocialImage
+	// TwitterCard selects the X/Twitter presentation and defaults to summary_large_image.
+	TwitterCard TwitterCard
+	// TwitterSite is the optional real project account handle, including @.
+	TwitterSite string
 }
 
-func (cfg MetadataConfig) normalized() MetadataConfig {
-	if !cfg.hasContent() {
-		return cfg
+func (cfg MetadataConfig) validated() (MetadataConfig, error) {
+	cfg.Title = strings.TrimSpace(cfg.Title)
+	if cfg.Title == "" {
+		return MetadataConfig{}, errors.New("head.Metadata: Title is required")
 	}
+	cfg.Description = strings.TrimSpace(cfg.Description)
+	if cfg.Description == "" {
+		return MetadataConfig{}, errors.New("head.Metadata: Description is required")
+	}
+
+	var err error
+	cfg.CanonicalURL, err = absoluteHTTPSURL("CanonicalURL", cfg.CanonicalURL)
+	if err != nil {
+		return MetadataConfig{}, err
+	}
+	cfg.Image.URL, err = absoluteHTTPSURL("Image.URL", cfg.Image.URL)
+	if err != nil {
+		return MetadataConfig{}, err
+	}
+
+	cfg.Image.MIMEType = strings.TrimSpace(cfg.Image.MIMEType)
+	if !strings.HasPrefix(cfg.Image.MIMEType, "image/") {
+		return MetadataConfig{}, errors.New("head.Metadata: Image.MIMEType must be an image media type")
+	}
+	if cfg.Image.Width <= 0 {
+		return MetadataConfig{}, errors.New("head.Metadata: Image.Width must be positive")
+	}
+	if cfg.Image.Height <= 0 {
+		return MetadataConfig{}, errors.New("head.Metadata: Image.Height must be positive")
+	}
+	cfg.Image.Alt = strings.TrimSpace(cfg.Image.Alt)
+	if cfg.Image.Alt == "" {
+		return MetadataConfig{}, errors.New("head.Metadata: Image.Alt is required")
+	}
+
+	cfg.OpenGraphType = OpenGraphType(strings.TrimSpace(string(cfg.OpenGraphType)))
 	if cfg.OpenGraphType == "" {
 		cfg.OpenGraphType = OpenGraphTypeWebsite
 	}
+	cfg.TwitterCard = TwitterCard(strings.TrimSpace(string(cfg.TwitterCard)))
 	if cfg.TwitterCard == "" {
-		if cfg.Image.URL == "" {
-			cfg.TwitterCard = TwitterCardSummary
-		} else {
-			cfg.TwitterCard = TwitterCardSummaryLargeImage
-		}
+		cfg.TwitterCard = TwitterCardSummaryLargeImage
 	}
-	return cfg
+	if cfg.TwitterCard != TwitterCardSummary && cfg.TwitterCard != TwitterCardSummaryLargeImage {
+		return MetadataConfig{}, fmt.Errorf("head.Metadata: unsupported TwitterCard %q", cfg.TwitterCard)
+	}
+
+	cfg.SiteName = strings.TrimSpace(cfg.SiteName)
+	cfg.Locale = strings.TrimSpace(cfg.Locale)
+	cfg.TwitterSite = strings.TrimSpace(cfg.TwitterSite)
+	return cfg, nil
 }
 
-func (cfg MetadataConfig) hasContent() bool {
-	return cfg.Title != "" || cfg.Description != "" || cfg.CanonicalURL != "" ||
-		cfg.SiteName != "" || cfg.Locale != "" || cfg.Image.URL != "" ||
-		cfg.TwitterCard != "" || cfg.TwitterSite != ""
+func absoluteHTTPSURL(field, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return "", fmt.Errorf("head.Metadata: %s must be an absolute HTTPS URL: %w", field, err)
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") || parsed.Host == "" ||
+		parsed.Hostname() == "" || parsed.Opaque != "" || parsed.User != nil {
+		return "", fmt.Errorf("head.Metadata: %s must be an absolute HTTPS URL", field)
+	}
+	parsed.Scheme = "https"
+	return parsed.String(), nil
 }
 
 func (image SocialImage) widthContent() string {

--- a/components/head/types.go
+++ b/components/head/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"mime"
 	"net/url"
 	"strconv"
 	"strings"
@@ -34,7 +35,7 @@ const (
 type SocialImage struct {
 	// URL is the absolute HTTPS URL crawlers use to fetch the image.
 	URL string
-	// MIMEType is the image media type, such as image/jpeg or image/png.
+	// MIMEType is a parameter-free image media type, such as image/jpeg or image/png.
 	MIMEType string
 	// Width is the image width in pixels and must be positive.
 	Width int
@@ -87,9 +88,9 @@ func (cfg MetadataConfig) validated() (MetadataConfig, error) {
 		return MetadataConfig{}, err
 	}
 
-	cfg.Image.MIMEType = strings.TrimSpace(cfg.Image.MIMEType)
-	if !strings.HasPrefix(cfg.Image.MIMEType, "image/") {
-		return MetadataConfig{}, errors.New("head.Metadata: Image.MIMEType must be an image media type")
+	cfg.Image.MIMEType, err = imageMIMEType(cfg.Image.MIMEType)
+	if err != nil {
+		return MetadataConfig{}, err
 	}
 	if cfg.Image.Width <= 0 {
 		return MetadataConfig{}, errors.New("head.Metadata: Image.Width must be positive")
@@ -132,6 +133,21 @@ func absoluteHTTPSURL(field, value string) (string, error) {
 	}
 	parsed.Scheme = "https"
 	return parsed.String(), nil
+}
+
+func imageMIMEType(value string) (string, error) {
+	mediaType, parameters, err := mime.ParseMediaType(strings.TrimSpace(value))
+	if err != nil {
+		return "", fmt.Errorf("head.Metadata: Image.MIMEType must be a valid image media type: %w", err)
+	}
+	parts := strings.SplitN(mediaType, "/", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "image") || parts[1] == "" {
+		return "", errors.New("head.Metadata: Image.MIMEType must be an image media type")
+	}
+	if len(parameters) != 0 {
+		return "", errors.New("head.Metadata: Image.MIMEType parameters are not supported")
+	}
+	return strings.ToLower(mediaType), nil
 }
 
 func (image SocialImage) widthContent() string {

--- a/components/public_renderable_inventory_test.go
+++ b/components/public_renderable_inventory_test.go
@@ -181,6 +181,7 @@ func TestPublicFunctionSurfaceMatchesContract(t *testing.T) {
 	}
 
 	allowedMethods := map[string]struct{}{
+		"head.metadataComponent.Render":          {},
 		"combobox.Config.Validate":               {},
 		"combobox.Config.InitialState":           {},
 		"combobox.comboHandler.ServeHTTP":        {},

--- a/components/public_renderable_inventory_test.go
+++ b/components/public_renderable_inventory_test.go
@@ -74,6 +74,7 @@ func TestPublicFunctionSurfaceMatchesContract(t *testing.T) {
 		"form.FormErrors":                 {},
 		"head.Dependencies":               {},
 		"head.DependenciesMinimal":        {},
+		"head.Metadata":                   {},
 		"head.WithComboboxURL":            {},
 		"head.WithActionGroupURL":         {},
 		"head.WithDependencyCDNURL":       {},

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -57,6 +57,19 @@ import "github.com/araihu/goshtoso/components/head"
 templ Layout() {
     <html>
         <head>
+            @head.Metadata(head.MetadataConfig{
+                Title:        "Page title",
+                Description:  "Route-specific description",
+                CanonicalURL: "https://example.com/route",
+                SiteName:     "Product name",
+                Image: head.SocialImage{
+                    URL:      "https://example.com/og.jpg",
+                    MIMEType: "image/jpeg",
+                    Width:    1280,
+                    Height:   640,
+                    Alt:      "Useful description of the preview",
+                },
+            })
             @head.Dependencies()        // CSS + Alpine + plugins + HTMX + first-party helpers
             // or @head.DependenciesMinimal() — no Alpine plugins
         </head>
@@ -64,6 +77,13 @@ templ Layout() {
     </html>
 }
 ```
+
+`head.Metadata()` emits route-specific document, canonical, Open Graph, and
+X/Twitter Card metadata in initial server-rendered HTML. Use absolute public
+HTTPS canonical and image URLs. Give each indexable route distinct values and
+provide image MIME type, dimensions, and alt text; 1280x640 JPEG or PNG under
+1 MB is the safe default. Do not inject share metadata through JavaScript or an
+HTMX fragment because link-preview crawlers may not execute either.
 
 The served `styles.css` already carries every component style + the theme system
 (16 themes). **Stock CDN Tailwind will not work** — the theme tokens

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -80,11 +80,11 @@ templ Layout() {
 
 `head.Metadata()` emits route-specific document, canonical, Open Graph, and
 X/Twitter Card metadata in initial server-rendered HTML. Title, description,
-canonical URL, image URL, parameter-free image MIME type, positive dimensions,
-and image alt text are required; both URLs must be absolute HTTPS. `Render`
-validates the whole configuration before writing and returns an error rather
-than partial metadata. Open Graph type defaults to `website`; X/Twitter Card
-defaults to `summary_large_image`. Give each indexable route distinct values;
+canonical URL, image URL, parameter-free RFC 6838 image MIME type, positive
+dimensions, and image alt text are required; both URLs must be absolute HTTPS.
+`Render` validates the whole configuration before writing and returns an error
+rather than partial metadata. Open Graph type defaults to `website`; X/Twitter
+Card defaults to `summary_large_image`. Give each indexable route distinct values;
 1280x640 JPEG or PNG under 1 MB is the safe default. Do not inject share
 metadata through JavaScript or an HTMX fragment because link-preview crawlers
 may not execute either.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -79,11 +79,15 @@ templ Layout() {
 ```
 
 `head.Metadata()` emits route-specific document, canonical, Open Graph, and
-X/Twitter Card metadata in initial server-rendered HTML. Use absolute public
-HTTPS canonical and image URLs. Give each indexable route distinct values and
-provide image MIME type, dimensions, and alt text; 1280x640 JPEG or PNG under
-1 MB is the safe default. Do not inject share metadata through JavaScript or an
-HTMX fragment because link-preview crawlers may not execute either.
+X/Twitter Card metadata in initial server-rendered HTML. Title, description,
+canonical URL, image URL, image MIME type, positive dimensions, and image alt
+text are required; both URLs must be absolute HTTPS. `Render` validates the
+whole configuration before writing and returns an error rather than partial
+metadata. Open Graph type defaults to `website`; X/Twitter Card defaults to
+`summary_large_image`. Give each indexable route distinct values; 1280x640 JPEG
+or PNG under 1 MB is the safe default. Do not inject share metadata through
+JavaScript or an HTMX fragment because link-preview crawlers may not execute
+either.
 
 The served `styles.css` already carries every component style + the theme system
 (16 themes). **Stock CDN Tailwind will not work** — the theme tokens

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -80,14 +80,14 @@ templ Layout() {
 
 `head.Metadata()` emits route-specific document, canonical, Open Graph, and
 X/Twitter Card metadata in initial server-rendered HTML. Title, description,
-canonical URL, image URL, image MIME type, positive dimensions, and image alt
-text are required; both URLs must be absolute HTTPS. `Render` validates the
-whole configuration before writing and returns an error rather than partial
-metadata. Open Graph type defaults to `website`; X/Twitter Card defaults to
-`summary_large_image`. Give each indexable route distinct values; 1280x640 JPEG
-or PNG under 1 MB is the safe default. Do not inject share metadata through
-JavaScript or an HTMX fragment because link-preview crawlers may not execute
-either.
+canonical URL, image URL, parameter-free image MIME type, positive dimensions,
+and image alt text are required; both URLs must be absolute HTTPS. `Render`
+validates the whole configuration before writing and returns an error rather
+than partial metadata. Open Graph type defaults to `website`; X/Twitter Card
+defaults to `summary_large_image`. Give each indexable route distinct values;
+1280x640 JPEG or PNG under 1 MB is the safe default. Do not inject share
+metadata through JavaScript or an HTMX fragment because link-preview crawlers
+may not execute either.
 
 The served `styles.css` already carries every component style + the theme system
 (16 themes). **Stock CDN Tailwind will not work** — the theme tokens

--- a/site/internal/pages/demo/componentpages/head/dependencies.templ
+++ b/site/internal/pages/demo/componentpages/head/dependencies.templ
@@ -23,6 +23,28 @@ templ dependenciesDemoContent() {
 		)
 		@demo.DemoSection(
 			demo.DemoSectionProps{
+				Title:       "Social Metadata",
+				Description: "Emit route-specific title, description, canonical, Open Graph, and X/Twitter Card tags in the initial HTML response.",
+			},
+			metadataPreview(),
+			`<head>
+    @head.Metadata(head.MetadataConfig{
+        Title:        "Product documentation",
+        Description:  "Learn how to use the product.",
+        CanonicalURL: "https://example.com/docs",
+        SiteName:     "Example",
+        Locale:       "en_US",
+        Image: head.SocialImage{
+            URL: "https://example.com/social/docs-v1.jpg",
+            MIMEType: "image/jpeg", Width: 1280, Height: 640,
+            Alt: "Example product documentation",
+        },
+    })
+    @head.Dependencies()
+</head>`,
+		)
+		@demo.DemoSection(
+			demo.DemoSectionProps{
 				Title:       "Minimal Runtime",
 				Description: "Use DependenciesMinimal when the page does not need the Alpine collapse, focus, or mask plugins.",
 			},
@@ -75,6 +97,15 @@ runtime.Dependencies = append(runtime.Dependencies, assets.RuntimeAsset{
 
 @head.Dependencies(head.WithRuntimeManifest(runtime))`,
 		)
+	</div>
+}
+
+templ metadataPreview() {
+	<div id="head-metadata" class="w-full max-w-2xl mx-auto">
+		<div class="rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt">
+			<p class="font-medium text-on-surface-strong dark:text-on-surface-dark-strong">One route config, complete social contract</p>
+			<p class="mt-2 text-on-surface-muted dark:text-on-surface-dark-muted">Metadata defaults to website plus a summary card, or a large-image card when a preview image is present.</p>
+		</div>
 	</div>
 }
 

--- a/site/internal/pages/demo/componentpages/head/dependencies.templ
+++ b/site/internal/pages/demo/componentpages/head/dependencies.templ
@@ -104,7 +104,7 @@ templ metadataPreview() {
 	<div id="head-metadata" class="w-full max-w-2xl mx-auto">
 		<div class="rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt">
 			<p class="font-medium text-on-surface-strong dark:text-on-surface-dark-strong">One route config, complete social contract</p>
-			<p class="mt-2 text-on-surface-muted dark:text-on-surface-dark-muted">Metadata defaults to website plus a summary card, or a large-image card when a preview image is present.</p>
+			<p class="mt-2 text-on-surface-muted dark:text-on-surface-dark-muted">Metadata defaults to website plus a large-image card and rejects incomplete or non-HTTPS configurations before writing tags.</p>
 		</div>
 	</div>
 }

--- a/site/internal/pages/demo/componentpages/head/dependencies_templ.go
+++ b/site/internal/pages/demo/componentpages/head/dependencies_templ.go
@@ -82,6 +82,31 @@ func dependenciesDemoContent() templ.Component {
 		}
 		templ_7745c5c3_Err = demo.DemoSection(
 			demo.DemoSectionProps{
+				Title:       "Social Metadata",
+				Description: "Emit route-specific title, description, canonical, Open Graph, and X/Twitter Card tags in the initial HTML response.",
+			},
+			metadataPreview(),
+			`<head>
+    @head.Metadata(head.MetadataConfig{
+        Title:        "Product documentation",
+        Description:  "Learn how to use the product.",
+        CanonicalURL: "https://example.com/docs",
+        SiteName:     "Example",
+        Locale:       "en_US",
+        Image: head.SocialImage{
+            URL: "https://example.com/social/docs-v1.jpg",
+            MIMEType: "image/jpeg", Width: 1280, Height: 640,
+            Alt: "Example product documentation",
+        },
+    })
+    @head.Dependencies()
+</head>`,
+		).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = demo.DemoSection(
+			demo.DemoSectionProps{
 				Title:       "Minimal Runtime",
 				Description: "Use DependenciesMinimal when the page does not need the Alpine collapse, focus, or mask plugins.",
 			},
@@ -154,7 +179,7 @@ runtime.Dependencies = append(runtime.Dependencies, assets.RuntimeAsset{
 	})
 }
 
-func dependenciesFullPreview() templ.Component {
+func metadataPreview() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -175,20 +200,49 @@ func dependenciesFullPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"dependencies-full\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Full runtime helper</p><pre class=\"mt-3 overflow-x-auto rounded-radius bg-surface p-3 text-xs text-on-surface dark:bg-surface-dark dark:text-on-surface-dark\"><code>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"head-metadata\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">One route config, complete social contract</p><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">Metadata defaults to website plus a summary card, or a large-image card when a preview image is present.</p></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs("@head.Dependencies()\n\nCDN: pinned Alpine + HTMX\nFallback: /assets/js/runtime/*\nLoader: /assets/js/dependency-loader.js")
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/componentpages/head/dependencies.templ`, Line: 85, Col: 270}
+		return nil
+	})
+}
+
+func dependenciesFullPreview() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var4 == nil {
+			templ_7745c5c3_Var4 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div id=\"dependencies-full\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Full runtime helper</p><pre class=\"mt-3 overflow-x-auto rounded-radius bg-surface p-3 text-xs text-on-surface dark:bg-surface-dark dark:text-on-surface-dark\"><code>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</code></pre></div></div>")
+		var templ_7745c5c3_Var5 string
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs("@head.Dependencies()\n\nCDN: pinned Alpine + HTMX\nFallback: /assets/js/runtime/*\nLoader: /assets/js/dependency-loader.js")
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `site/internal/pages/demo/componentpages/head/dependencies.templ`, Line: 116, Col: 270}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</code></pre></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -212,12 +266,12 @@ func dependenciesOptionsPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var5 == nil {
-			templ_7745c5c3_Var5 = templ.NopComponent
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<div id=\"dependencies-options\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Strong defaults, explicit escape hatches</p><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">The default falls back to embedded assets with SHA-384 integrity. Local-only mode supports offline PWAs and WebViews; per-dependency options keep version ownership visible.</p><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">Custom URLs configure loading only. Goshtoso guarantees compatibility for its pinned, tested dependency combination—not arbitrary versions.</p></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div id=\"dependencies-options\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Strong defaults, explicit escape hatches</p><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">The default falls back to embedded assets with SHA-384 integrity. Local-only mode supports offline PWAs and WebViews; per-dependency options keep version ownership visible.</p><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">Custom URLs configure loading only. Goshtoso guarantees compatibility for its pinned, tested dependency combination—not arbitrary versions.</p></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -241,12 +295,12 @@ func dependenciesManifestPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div id=\"dependencies-manifest\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">One typed, ordered baseline</p><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">WithRuntimeManifest snapshots caller data and validates roles, URLs, loader availability, known runtime order, and first-party conflicts before writing HTML.</p></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"dependencies-manifest\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">One typed, ordered baseline</p><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">WithRuntimeManifest snapshots caller data and validates roles, URLs, loader availability, known runtime order, and first-party conflicts before writing HTML.</p></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -270,12 +324,12 @@ func dependenciesMinimalPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div id=\"dependencies-minimal\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">DependenciesMinimal</p><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">CSS, the combined first-party bundle, Alpine core, and HTMX. Optional manifest entries still follow their IncludeInMinimal setting.</p></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div id=\"dependencies-minimal\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">DependenciesMinimal</p><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">CSS, the combined first-party bundle, Alpine core, and HTMX. Optional manifest entries still follow their IncludeInMinimal setting.</p></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -299,12 +353,12 @@ func dependenciesAssetContractPreview() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div id=\"dependencies-asset-contract\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Serve bundled assets</p><pre class=\"mt-3 overflow-x-auto rounded-radius bg-surface p-3 text-xs text-on-surface dark:bg-surface-dark dark:text-on-surface-dark\"><code>mux.Handle(\"GET /assets/\", assets.Handler())</code></pre></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<div id=\"dependencies-asset-contract\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">Serve bundled assets</p><pre class=\"mt-3 overflow-x-auto rounded-radius bg-surface p-3 text-xs text-on-surface dark:bg-surface-dark dark:text-on-surface-dark\"><code>mux.Handle(\"GET /assets/\", assets.Handler())</code></pre></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/internal/pages/demo/componentpages/head/dependencies_templ.go
+++ b/site/internal/pages/demo/componentpages/head/dependencies_templ.go
@@ -200,7 +200,7 @@ func metadataPreview() templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"head-metadata\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">One route config, complete social contract</p><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">Metadata defaults to website plus a summary card, or a large-image card when a preview image is present.</p></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"head-metadata\" class=\"w-full max-w-2xl mx-auto\"><div class=\"rounded-radius border border-outline bg-surface-alt p-4 text-sm dark:border-outline-dark dark:bg-surface-dark-alt\"><p class=\"font-medium text-on-surface-strong dark:text-on-surface-dark-strong\">One route config, complete social contract</p><p class=\"mt-2 text-on-surface-muted dark:text-on-surface-dark-muted\">Metadata defaults to website plus a large-image card and rejects incomplete or non-HTTPS configurations before writing tags.</p></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/site/tests/e2e/head_test.go
+++ b/site/tests/e2e/head_test.go
@@ -39,6 +39,8 @@ func TestDependenciesDemoPage(t *testing.T) {
 	assert.Equal(t, 1, linkCount)
 
 	require.NoError(t, page.Locator("#dependencies-full").GetByText("Fallback: /assets/js/runtime/*").WaitFor())
+	require.NoError(t, page.Locator("#head-metadata").GetByText("complete social contract").WaitFor())
+	require.NoError(t, page.GetByText("head.Metadata(head.MetadataConfig{").WaitFor())
 	require.NoError(t, page.Locator("#dependencies-minimal").GetByText("DependenciesMinimal").WaitFor())
 	require.NoError(t, page.Locator("#dependencies-asset-contract").GetByText("assets.Handler()").WaitFor())
 	require.NoError(t, page.Locator("#dependencies-options").GetByText("Strong defaults, explicit escape hatches").WaitFor())


### PR DESCRIPTION
## Summary

- add `head.Metadata` as a route-level Open Graph and X/Twitter Card primitive
- fail closed on incomplete metadata, non-HTTPS URLs, and invalid RFC 6838 image media types
- update consumer skill, generated API references, usage docs, component demo, and focused coverage

## Related issue

None.

## Type of change

- [ ] Bug fix
- [x] New component / variant
- [ ] Visual-parity fix
- [x] Docs
- [x] Tests / CI
- [ ] Refactor / chore

## Checklist

- [x] Ran `templ generate` after editing `.templ` files
- [ ] Rebuilt theme/component CSS with `just css` if CSS or Tailwind utilities changed — not applicable; no CSS or Tailwind changes
- [x] `golangci-lint run` is clean (cyclomatic-complexity ceiling 20)
- [ ] `go fix ./...` applied (pre-commit hook enabled via `git config core.hooksPath .githooks`)
- [ ] Unit + E2E tests pass (`go test ./... -count=1` and `go test -tags=e2e,full ./site/tests/e2e/... -count=1 -timeout 15m`) — root suite and focused head E2E pass; full E2E left to CI
- [x] New/changed component demo page follows the docs-page pattern and has an API reference
- [x] Regenerated the component reference (`go run ./cmd/skillgen`) if a component API changed
- [ ] Tested in light **and** dark mode across themes (especially Minimal — no border-radius) — not applicable; no visual component change
- [x] Did **not** hand-edit generated files (`*_templ.go`, `assets/styles.css`)

## Screenshots

Not applicable: this change emits document-head metadata and adds a documentation example without changing component visuals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added route-specific page metadata, including titles, descriptions, canonical URLs, Open Graph tags, and X/Twitter Cards.
  * Added social preview image configuration with supported formats, dimensions, and alternative text.
  * Added sensible defaults and HTTPS validation for metadata and social links.

* **Bug Fixes**
  * Invalid metadata configurations now return errors without rendering incomplete tags.

* **Documentation**
  * Added usage guidance and a live demo showcasing metadata configuration and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->