### PR TITLE
chore: publish authored coverage to Codecov

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,9 @@ jobs:
           configured=false
           if [[ -n "$CODECOV_TOKEN" ]]; then
             configured=true
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "::error::CODECOV_TOKEN is required for tagged releases"
+            exit 1
           else
             echo "::warning::CODECOV_TOKEN is not configured; authored coverage will not be published"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,35 @@ jobs:
           {
             echo "### Authoritative release coverage"
             echo
-            echo "Coverage: ${percent}%"
+            echo "Authored Go coverage: ${percent}%"
+            echo "Full generated-inclusive coverage: $(cat .coverage/full-percentage.txt)%"
             echo
             echo "Packages: $(wc -l < .coverage/component-packages.txt) publishable component packages"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Detect Codecov configuration
+        id: codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          configured=false
+          if [[ -n "$CODECOV_TOKEN" ]]; then
+            configured=true
+          else
+            echo "::warning::CODECOV_TOKEN is not configured; authored coverage will not be published"
+          fi
+          echo "configured=$configured" >> "$GITHUB_OUTPUT"
+
+      - name: Upload authored Go coverage to Codecov
+        if: steps.codecov.outputs.configured == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          disable_search: true
+          fail_ci_if_error: true
+          files: .coverage/coverage-authored.out
+          flags: authored-go
+          name: release-authored-go
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload authoritative coverage
         if: always()
@@ -106,10 +131,14 @@ jobs:
           path: |
             .coverage/component-packages.txt
             .coverage/percentage.txt
+            .coverage/full-percentage.txt
             .coverage/coverage-percent.txt
             .coverage/coverage.out
             .coverage/coverage-func.txt
             .coverage/coverage.html
+            .coverage/coverage-authored.out
+            .coverage/coverage-authored-func.txt
+            .coverage/coverage-authored.html
           retention-days: 30
           if-no-files-found: ignore
 
@@ -166,7 +195,7 @@ jobs:
           auth: ${{ secrets.GIST_TOKEN }}
           gistID: fb3843c3a13793eb6cc0af638bc00ad4
           filename: coverage.json
-          label: coverage
+          label: authored coverage
           message: ${{ needs.pre-release.outputs.coverage-percent }}%
           color: ${{ needs.pre-release.outputs.coverage-color }}
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/araihu/goshtoso/actions/workflows/ci.yml"><img src="https://github.com/araihu/goshtoso/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="https://github.com/araihu/goshtoso/actions/workflows/ci.yml"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/guilycst/fb3843c3a13793eb6cc0af638bc00ad4/raw/coverage.json" alt="Coverage" /></a>
+  <a href="https://app.codecov.io/gh/araihu/goshtoso"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/guilycst/fb3843c3a13793eb6cc0af638bc00ad4/raw/coverage.json" alt="Authored Go coverage" /></a>
   <a href="https://pkg.go.dev/github.com/araihu/goshtoso"><img src="https://pkg.go.dev/badge/github.com/araihu/goshtoso.svg" alt="Go Reference" /></a>
   <a href="https://goreportcard.com/report/github.com/araihu/goshtoso"><img src="https://goreportcard.com/badge/github.com/araihu/goshtoso" alt="Go Report Card" /></a>
   <a href="https://github.com/araihu/goshtoso/releases/latest"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/guilycst/fb3843c3a13793eb6cc0af638bc00ad4/raw/release.json" alt="Latest release" /></a>
@@ -328,7 +328,16 @@ cd site && go test ./...
 
 # Full Playwright E2E suite
 go test -tags=e2e,full ./site/tests/e2e/... -count=1 -timeout 15m
+
+# Release-equivalent unit + Playwright coverage
+just coverage
 ```
+
+Release coverage keeps two reports. When `CODECOV_TOKEN` is configured, the
+public [Codecov report](https://app.codecov.io/gh/araihu/goshtoso) measures
+authored Go source and excludes only generated `*_templ.go` files. Release
+artifacts always retain the full generated-inclusive profile and HTML report.
+Both reports come from the same root, site, and real-browser test run.
 
 Run lint checks per module:
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -55,7 +55,12 @@ many of these steps, but the checklist keeps the public release story coherent.
   `assets/goshtoso-theme.css`.
 - Confirm the release badge endpoint has the new tag.
 - Confirm the coverage badge reports the authoritative full-suite percentage
-  from this release; focused PR/main runs must never update it.
+  for authored Go source from this release; focused PR/main runs must never
+  update it.
+- Confirm Codecov received `.coverage/coverage-authored.out` and exposes the
+  current release report. The `CODECOV_TOKEN` repository secret must be present.
+- Confirm the release coverage artifact retains both authored-source and full
+  generated-inclusive profiles, function summaries, and HTML reports.
 - Open a follow-up PR that pins `site/go.mod` to the new tag and updates any
   version-aware documentation links. Never push this follow-up directly to the
   protected `main` branch.

--- a/scripts/component-coverage-contract_test.sh
+++ b/scripts/component-coverage-contract_test.sh
@@ -8,6 +8,10 @@ test -n "$actual"
 test "$actual" = "$expected"
 
 grep -q -- '-pkg="$component_coverpkg"' "$repo_root/scripts/run-component-coverage.sh"
+grep -q -- 'filter-authored-coverage' "$repo_root/scripts/run-component-coverage.sh"
+grep -q -- 'coverage-authored.out' "$repo_root/scripts/run-component-coverage.sh"
+grep -q -- 'full-percentage.txt' "$repo_root/scripts/run-component-coverage.sh"
+grep -q -- 'authored Go coverage is below 80%' "$repo_root/scripts/run-component-coverage.sh"
 grep -q -- '--tags e2e,full' "$repo_root/scripts/run-release-coverage.sh"
 grep -q -- 'scripts/run-release-coverage.sh' "$repo_root/justfile"
 

--- a/scripts/coverage_profile_test.go
+++ b/scripts/coverage_profile_test.go
@@ -1,0 +1,51 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestFilterAuthoredCoverageExcludesGeneratedTempl(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	filter := filepath.Join(repoRoot, "scripts", "filter-authored-coverage")
+
+	fixture := t.TempDir()
+	input := filepath.Join(fixture, "coverage.out")
+	output := filepath.Join(fixture, "coverage-authored.out")
+	writeFile(t, input, `mode: atomic
+github.com/araihu/goshtoso/components/button/button_templ.go:10.1,12.2 2 1
+github.com/araihu/goshtoso/components/button/types.go:20.1,24.2 3 1
+github.com/araihu/goshtoso/components/card/card_templ.go:30.1,36.2 5 0
+github.com/araihu/goshtoso/components/card/types.go:40.1,48.2 7 0
+`)
+
+	command := exec.Command(filter, input, output)
+	if combined, runErr := command.CombinedOutput(); runErr != nil {
+		t.Fatalf("filter authored coverage: %v\n%s", runErr, combined)
+	}
+
+	want := `mode: atomic
+github.com/araihu/goshtoso/components/button/types.go:20.1,24.2 3 1
+github.com/araihu/goshtoso/components/card/types.go:40.1,48.2 7 0
+`
+	assertFileContent(t, output, want)
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("%s content mismatch\nwant:\n%s\ngot:\n%s", path, want, got)
+	}
+}

--- a/scripts/filter-authored-coverage
+++ b/scripts/filter-authored-coverage
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: scripts/filter-authored-coverage <input> <output>" >&2
+  exit 2
+fi
+
+awk 'NR == 1 || $1 !~ /_templ\.go:/' "$1" > "$2"

--- a/scripts/run-component-coverage.sh
+++ b/scripts/run-component-coverage.sh
@@ -96,12 +96,24 @@ go tool covdata percent \
 go tool covdata textfmt \
   -i=.coverage/merged -pkg="$component_coverpkg" \
   -o=.coverage/coverage.out
+scripts/filter-authored-coverage \
+  .coverage/coverage.out .coverage/coverage-authored.out
 go tool cover -func=.coverage/coverage.out > .coverage/coverage-func.txt
+go tool cover -func=.coverage/coverage-authored.out > .coverage/coverage-authored-func.txt
 go tool cover -html=.coverage/coverage.out -o .coverage/coverage.html
+go tool cover -html=.coverage/coverage-authored.out -o .coverage/coverage-authored.html
 
-total_line="$(grep '^total:' .coverage/coverage-func.txt)"
-total_percent="$(printf '%s\n' "$total_line" | sed -E 's/.*[[:space:]]([0-9.]+)%.*/\1/')"
+full_total_line="$(grep '^total:' .coverage/coverage-func.txt)"
+full_total_percent="$(printf '%s\n' "$full_total_line" | sed -E 's/.*[[:space:]]([0-9.]+)%.*/\1/')"
+printf '%s\n' "$full_total_percent" > .coverage/full-percentage.txt
+
+authored_total_line="$(grep '^total:' .coverage/coverage-authored-func.txt)"
+total_percent="$(printf '%s\n' "$authored_total_line" | sed -E 's/.*[[:space:]]([0-9.]+)%.*/\1/')"
 printf '%s\n' "$total_percent" > .coverage/percentage.txt
+if ! awk "BEGIN { exit !($total_percent >= 80) }"; then
+  echo "authored Go coverage is below 80%: $total_percent%" >&2
+  exit 1
+fi
 
 color="red"
 awk "BEGIN { exit !($total_percent >= 80) }" && color="brightgreen" || true
@@ -113,6 +125,7 @@ if [[ "$write_badge" == true ]]; then
   scripts/coveragebadge "$total_percent"
 fi
 
-echo "$total_line"
+echo "full generated-inclusive coverage: $full_total_line"
+echo "authored Go coverage: $authored_total_line"
 echo "component package list: .coverage/component-packages.txt"
-echo "coverage percentage: $total_percent"
+echo "authored coverage percentage: $total_percent"

--- a/site/tests/e2e/table_htmx_test.go
+++ b/site/tests/e2e/table_htmx_test.go
@@ -402,19 +402,15 @@ func TestTableHTMX_BrowserSorting(t *testing.T) {
 		t.Logf("After sort:  %.50s", strings.TrimSpace(newFirst))
 
 		// Response-generated headers must retain the six-row endpoint state.
-		err = nameHeader.Click()
-		require.NoError(t, err)
-		_, err = page.WaitForFunction(
+		clickUntil(t, page, nameHeader,
 			`() => {
 				var rows = document.querySelectorAll('#sortable-table tbody tr');
 				var nameHeader = document.querySelector('#sortable-table-thead th[hx-get*="order_by=name"]');
 				return rows.length === 6 &&
 					rows[0].textContent.includes('Sophia Chen') &&
 					!nameHeader?.getAttribute('hx-get').includes('order_dir=');
-			}`, nil,
-			playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(3000)},
+			}`,
 		)
-		require.NoError(t, err, "second sort should preserve all six preview rows")
 	})
 }
 

--- a/site/tests/e2e/table_htmx_test.go
+++ b/site/tests/e2e/table_htmx_test.go
@@ -370,7 +370,9 @@ func TestTableHTMX_BrowserSorting(t *testing.T) {
 		require.NoError(t, err)
 
 		// Click the Name header to sort
-		nameHeader := page.Locator("#sortable-table thead th[hx-get*='order_by=name']")
+		nameHeader := page.Locator("#sortable-table-thead th").Filter(
+			playwright.LocatorFilterOptions{HasText: "Name"},
+		).First()
 		count, err := nameHeader.Count()
 		require.NoError(t, err)
 		if count == 0 {
@@ -405,10 +407,18 @@ func TestTableHTMX_BrowserSorting(t *testing.T) {
 		clickUntil(t, page, nameHeader,
 			`() => {
 				var rows = document.querySelectorAll('#sortable-table tbody tr');
-				var nameHeader = document.querySelector('#sortable-table-thead th[hx-get*="order_by=name"]');
+				var tableHead = document.querySelector('#sortable-table-thead');
+				var nameHeader = Array.from(tableHead?.querySelectorAll('th') || [])
+					.find((header) => header.textContent.includes('Name'));
+				var nextURL = nameHeader?.getAttribute('hx-get') || '';
 				return rows.length === 6 &&
 					rows[0].textContent.includes('Sophia Chen') &&
-					!nameHeader?.getAttribute('hx-get').includes('order_dir=');
+					tableHead?.dataset.tableSortBy === 'name' &&
+					tableHead?.dataset.tableSortDir === 'desc' &&
+					nameHeader !== undefined &&
+					nextURL.includes('per_page=6') &&
+					!nextURL.includes('order_by=') &&
+					!nextURL.includes('order_dir=');
 			}`,
 		)
 	})


### PR DESCRIPTION
## Summary

- publish authored Go coverage to Codecov while retaining the generated-inclusive release artifact
- exclude only generated `*_templ.go` files from the public authored metric and enforce an 80% floor
- document the public report and release checks
- make the table HTMX coverage test resilient to response-generated header rebinding

Current release-equivalent coverage:

- authored Go: 96.8%
- full generated-inclusive: 74.9%

## Related issue

None.

## Type of change

- [ ] Bug fix
- [ ] New component / variant
- [ ] Visual-parity fix
- [x] Docs
- [x] Tests / CI
- [x] Refactor / chore

## Checklist

- [ ] Ran `templ generate` after editing `.templ` files — not applicable
- [ ] Rebuilt theme/component CSS with `just css` if CSS or Tailwind utilities changed — not applicable
- [x] `golangci-lint run` is clean (cyclomatic-complexity ceiling 20)
- [ ] `go fix ./...` applied (pre-commit hook enabled via `git config core.hooksPath .githooks`) — no production Go source changed
- [x] Unit + E2E tests pass (`scripts/run-release-coverage.sh --local-dry-run`, E2E 449.653s)
- [ ] New/changed component demo page follows the docs-page pattern and has an API reference — not applicable
- [ ] Regenerated the component reference (`go run ./cmd/skillgen`) if a component API changed — not applicable
- [ ] Tested in light **and** dark mode across themes (especially Minimal — no border-radius) — no visual change
- [x] Did **not** hand-edit generated files (`*_templ.go`, `assets/styles.css`)

Additional gates: `actionlint`, shell syntax, coverage contract tests, `git diff --check`, root scripts lint, and tagged site E2E lint.

## Screenshots

Not applicable; no visual changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release artifacts now include separate authored-source and full coverage reports.
  * Coverage reporting distinguishes generated code from authored Go code.
  * Codecov uploads authored coverage when configured, with an updated coverage badge.

* **Documentation**
  * Added instructions for generating release-equivalent coverage reports.
  * Updated release checklist requirements for validating coverage reports and artifacts.

* **Tests**
  * Added validation for authored coverage filtering and improved browser sorting test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->