### PR TITLE
docs: use Codecov coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/araihu/goshtoso/actions/workflows/ci.yml"><img src="https://github.com/araihu/goshtoso/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="https://app.codecov.io/gh/araihu/goshtoso"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/guilycst/fb3843c3a13793eb6cc0af638bc00ad4/raw/coverage.json" alt="Authored Go coverage" /></a>
+  <a href="https://app.codecov.io/gh/araihu/goshtoso"><img src="https://codecov.io/gh/araihu/goshtoso/branch/main/graph/badge.svg" alt="Codecov coverage" /></a>
   <a href="https://pkg.go.dev/github.com/araihu/goshtoso"><img src="https://pkg.go.dev/badge/github.com/araihu/goshtoso.svg" alt="Go Reference" /></a>
   <a href="https://goreportcard.com/report/github.com/araihu/goshtoso"><img src="https://goreportcard.com/badge/github.com/araihu/goshtoso" alt="Go Report Card" /></a>
   <a href="https://github.com/araihu/goshtoso/releases/latest"><img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/guilycst/fb3843c3a13793eb6cc0af638bc00ad4/raw/release.json" alt="Latest release" /></a>


### PR DESCRIPTION
## Summary

- replace the custom Shields/Gist coverage image with Codecov's official badge
- keep the badge linked to the public Codecov report

## Validation

- `git diff --check`
- Codecov badge endpoint returns HTTP 200 and reports 96% coverage

`lychee` is unavailable locally; the repository's Markdown links CI gate will validate the README link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Codecov coverage badge to use Codecov’s hosted badge endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->