### PR TITLE
chore(release): Goshtoso v0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Goshtoso are documented in this file.
 
+## [v0.1.12] - 2026-08-09
+
+### TOFU iconpack sources
+
+- Added the Muamba-backed `.iconpack.yaml` and `.iconpack.lock.yaml` flow for
+  consumer-owned icon packs, without reading or changing an existing Muamba
+  manifest in the consumer repository.
+- Added Git tree, archive, single-file, and multi-source inputs with explicit
+  first trust, later byte verification, deterministic names, typed Go bindings,
+  sprites, provenance, licenses, and atomic output publication.
+- Updated the Goshtoso site guide and Bootstrap Icons browser proof to exercise
+  the generic source contract through the core `components/icon` API.
+
+### Upgrade note
+
+- Existing embedded icons and the previous source-manifest flags remain
+  compatible. Consumers using the new config flow do not install Muamba; the
+  generator uses Muamba `v0.0.5` as an in-memory Go library and never creates
+  `.iconpack.engine.yaml`.
+
 ## [v0.1.11] - 2026-08-09
 
 ### Arbitrary consumer icon packs

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,6 +11,7 @@ is retained in this table.
 
 | Goshtoso | Tailwind CSS |
 |----------|--------------|
+| v0.1.12  | 4.3.3        |
 | v0.1.11  | 4.3.3        |
 | v0.1.9   | 4.3.3        |
 | v0.1.8   | 4.3.3        |


### PR DESCRIPTION
## Summary
- prepare the Goshtoso v0.1.12 patch release
- document the Muamba-backed TOFU iconpack source flow
- record the Tailwind compatibility row

## Validation
- Muamba strict verification and generated-byte drift check
- templ/theme/JS/skill/CSS generation drift check
- root and site tests, vet, and golangci-lint
- current-source and pinned-dependency site contracts
- focused iconpack browser proof
- full release coverage: 97.1% authored Go, 74.9% generated-inclusive

Release tag will be created only after this release commit reaches `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.1.12, covering iconpack configuration, verified source types, deterministic outputs, provenance, licensing, and site-guide updates.
  * Documented Bootstrap Icons browser coverage and upgrade compatibility details.
  * Updated the version compatibility table for Goshtoso 0.1.12 with Tailwind CSS 4.3.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->