### PR TITLE
chore(site): pin Goshtoso v0.1.12

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.1.10
+	github.com/araihu/goshtoso v0.1.12
 	github.com/araihu/goshtoso-app-shells v0.1.3
 	github.com/araihu/goshtoso-charts v0.0.2-0.20260730033312-82e67bb7111f
 	github.com/coder/websocket v1.8.15

--- a/site/go.sum
+++ b/site/go.sum
@@ -8,6 +8,8 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/araihu/goshtoso v0.1.10 h1:SM1Hu1V3D9wjD0YEnruoUzsloKn1iYrNU9qFsGOpVJA=
 github.com/araihu/goshtoso v0.1.10/go.mod h1:azo/Qk2qxDi95Cixh1PCDB5SwYsldJmwgT8r2xqwA5I=
+github.com/araihu/goshtoso v0.1.12 h1:KhCT2n0z3X7x8I1airNUO7M7PH4t9ukg8fN93bxfgXo=
+github.com/araihu/goshtoso v0.1.12/go.mod h1:sZbyx6KnzEwJC4ss/gM9BE3h182ZyREbixxAvRlwRRw=
 github.com/araihu/goshtoso-app-shells v0.1.3 h1:YNWMuGst4MZT3TZ04Ohk4FHNfxW3zVV4H6db1DXKyek=
 github.com/araihu/goshtoso-app-shells v0.1.3/go.mod h1:P7CRRVDOMMbGs+clvddEmH+x2Jd35uk991WbU86nw84=
 github.com/araihu/goshtoso-charts v0.0.2-0.20260730033312-82e67bb7111f h1:XCzv73dCpGDdZlGgF3be5BuGy6tl4INT+iOJoS+TYww=


### PR DESCRIPTION
## Summary
- pin the standalone demo site to public Goshtoso `v0.1.12`
- refresh `site/go.sum` for the released module bytes

## Validation
- public tag resolves through Go module download
- `scripts/check-site-module pinned-dependency`
- `scripts/check-site-module current-source`
- standalone site non-E2E tests, vet, and golangci-lint

This follows the published Goshtoso `v0.1.12` release.
