### PR TITLE
release: publish Goshtoso v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Goshtoso are documented in this file.
 
+## [v0.1.13] - 2026-08-11
+
+### Modern-based Arai Hû theme
+
+- Adopted the verified Arai Hû Assets `v0.2.1` fallback release.
+- Aligned Arai Hû typography and corner geometry with the Modern theme by
+  using Lato and `--radius-sm`, while preserving the Arai Hû semantic palette.
+- Kept Goshtoso's curated 67-symbol typed Heroicons surface separate from the
+  broader Assets UI sprite.
+
+### Upgrade note
+
+- No Go API changes are required. Consumers serving the Arai Hû fallback
+  should update the stylesheet and Goshtoso dependency together.
+
 ## [v0.1.12] - 2026-08-09
 
 ### TOFU iconpack sources

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,6 +11,7 @@ is retained in this table.
 
 | Goshtoso | Tailwind CSS |
 |----------|--------------|
+| v0.1.13  | 4.3.3        |
 | v0.1.12  | 4.3.3        |
 | v0.1.11  | 4.3.3        |
 | v0.1.9   | 4.3.3        |

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -147,6 +147,10 @@ design-system catalog.
 
 The catalog intentionally contains keys and labels only. CSS tokens, fonts,
 colors, radii, and other styling details remain CSS and consumer concerns.
+The built-in Arai Hû theme uses Modern typography and corner geometry (`Lato`
+and `--radius-sm`) with the Arai Hû semantic palette. Its fallback copy is
+byte-identical to `araihu/assets` release `v0.2.1` at commit
+`fdfb1c2aad8fa61779e7b8c6f208e52a6cf825ce`.
 
 | Key | Canonical label |
 |-----|-----------------|

--- a/examples/getting-started/main_test.go
+++ b/examples/getting-started/main_test.go
@@ -34,9 +34,22 @@ func TestAraiHuThemeIsServed(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("theme status = %d, want 200", rec.Code)
 	}
-	for _, want := range []string{`[data-theme="araihu"]`, `--color-primary: #173b72`, `--color-primary-dark: #c7ff4a`} {
+	for _, want := range []string{
+		`[data-theme="araihu"]`,
+		`Modern geometry with the Arai Hû organization palette`,
+		`--font-body: "Lato", ui-sans-serif, system-ui, sans-serif;`,
+		`--font-title: "Lato", ui-sans-serif, system-ui, sans-serif;`,
+		`--color-primary: #173b72`,
+		`--color-primary-dark: #c7ff4a`,
+		`--radius-radius: var(--radius-sm);`,
+	} {
 		if !strings.Contains(rec.Body.String(), want) {
 			t.Fatalf("theme missing canonical token %q", want)
+		}
+	}
+	for _, obsolete := range []string{"Instrument Sans", "var(--radius-lg)"} {
+		if strings.Contains(rec.Body.String(), obsolete) {
+			t.Fatalf("theme retains pre-Modern token %q", obsolete)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- publish the Assets v0.2.1-backed Arai Hû theme as Goshtoso v0.1.13
- document the Modern lineage: Lato typography and small-radius geometry with the Arai Hû palette
- preserve the curated 67-symbol typed Heroicons boundary
- add a regression test for the served fallback bytes

## Local release proof

- `go test ./examples/getting-started -run ^TestAraiHuThemeIsServed$ -count=1`
- `scripts/run-release-coverage.sh --local-dry-run`
  - full E2E: PASS
  - authored Go coverage: 97.1%
- `scripts/check-site-module current-source`
- `scripts/check-site-module pinned-dependency`
- `git diff --check`

Release source commit: `10c7c9d0cf1b739e7f64ab3ba9a55aa49d0c7283`
Assets release: `araihu/assets@v0.2.1` (`fdfb1c2aad8fa61779e7b8c6f208e52a6cf825ce`)

After merge, the tag will be created from the exact merged `main` commit; the site dependency pin remains a separate follow-up.