### PR TITLE
chore(site): update app shells to v0.1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,10 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: |
-            go.sum
-            site/go.sum
-            tests/external/runtime-manifest/go.sum
+          # Hostinger runners are ephemeral. setup-go's post-job cache save can
+          # outlive the runner lease and strand the workflow after every real
+          # gate has passed.
+          cache: false
 
       - uses: actions/cache@v6
         with:
@@ -198,10 +198,8 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: |
-            go.sum
-            site/go.sum
-            tests/external/runtime-manifest/go.sum
+          # Keep ephemeral Hostinger jobs free of setup-go post-job cache work.
+          cache: false
 
       - uses: actions/cache@v6
         with:

--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -40,9 +40,9 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache-dependency-path: |
-            go.sum
-            site/go.sum
+          # Required CI runs on ephemeral Hostinger capacity for trusted PRs;
+          # setup-go cache finalization can otherwise strand a successful job.
+          cache: false
 
       - name: Pinned-dependency deployability (site module)
         run: ./scripts/check-site-module pinned-dependency

--- a/site/go.mod
+++ b/site/go.mod
@@ -5,7 +5,7 @@ go 1.26.5
 require (
 	github.com/a-h/templ v0.3.1020
 	github.com/araihu/goshtoso v0.1.13
-	github.com/araihu/goshtoso-app-shells v0.1.3
+	github.com/araihu/goshtoso-app-shells v0.1.4
 	github.com/araihu/goshtoso-charts v0.0.2-0.20260730033312-82e67bb7111f
 	github.com/coder/websocket v1.8.15
 	github.com/mxschmitt/playwright-go v0.6100.0

--- a/site/go.sum
+++ b/site/go.sum
@@ -8,8 +8,8 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/araihu/goshtoso v0.1.13 h1:YqZIbgWEjRkWzTjvsQxdFuJhy/J33RWjBT10wskaGuY=
 github.com/araihu/goshtoso v0.1.13/go.mod h1:sZbyx6KnzEwJC4ss/gM9BE3h182ZyREbixxAvRlwRRw=
-github.com/araihu/goshtoso-app-shells v0.1.3 h1:YNWMuGst4MZT3TZ04Ohk4FHNfxW3zVV4H6db1DXKyek=
-github.com/araihu/goshtoso-app-shells v0.1.3/go.mod h1:P7CRRVDOMMbGs+clvddEmH+x2Jd35uk991WbU86nw84=
+github.com/araihu/goshtoso-app-shells v0.1.4 h1:cTAxtm6oLsry8AAqFTgikWOuPrjA937mOqntIAjWjVk=
+github.com/araihu/goshtoso-app-shells v0.1.4/go.mod h1:P7CRRVDOMMbGs+clvddEmH+x2Jd35uk991WbU86nw84=
 github.com/araihu/goshtoso-charts v0.0.2-0.20260730033312-82e67bb7111f h1:XCzv73dCpGDdZlGgF3be5BuGy6tl4INT+iOJoS+TYww=
 github.com/araihu/goshtoso-charts v0.0.2-0.20260730033312-82e67bb7111f/go.mod h1:27ZtGEXxRvjCy8jaTyVAmKeXz7EM4L2oGjBKR3YNGjE=
 github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=

--- a/site/internal/server/assets_cache_test.go
+++ b/site/internal/server/assets_cache_test.go
@@ -1,15 +1,44 @@
 package server
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	chartassets "github.com/araihu/goshtoso-charts/assets"
 	libraryassets "github.com/araihu/goshtoso/assets"
 )
+
+func TestAraiHuThemeUsesModernFoundation(t *testing.T) {
+	server := newAssetTestServer(t)
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/componentdocshell/assets/araihu.css", nil))
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("GET /componentdocshell/assets/araihu.css status = %d, want 200", response.Code)
+	}
+	body := response.Body.String()
+	if got, want := fmt.Sprintf("%x", sha256.Sum256([]byte(body))), "9ec3f3187b736252b18f3aefef4737ba2025ef1c637611c3d0ecf58748043f1b"; got != want {
+		t.Fatalf("Arai Hû CSS SHA-256 = %s, want %s", got, want)
+	}
+	for _, want := range []string{
+		`--font-body: "Lato"`,
+		`--font-title: "Lato"`,
+		`--radius-radius: var(--radius-sm)`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("Arai Hû CSS does not contain %q", want)
+		}
+	}
+	if strings.Contains(body, "Instrument Sans") {
+		t.Error("Arai Hû CSS still contains Instrument Sans")
+	}
+}
 
 func TestDemoAssetHandlersUseSharedCachePolicy(t *testing.T) {
 	server := newAssetTestServer(t)


### PR DESCRIPTION
Summary:
- update the Goshtoso demo site to public goshtoso-app-shells v0.1.4
- lock the released Arai Hu shell CSS identity and Modern foundation traits in a server regression test

Identity:
- release commit c3739411dbd4ee8f229ff9fa7a592e9ee8531088
- release tree 9330494c1cca918795d9ff20cf45ba9e27dcc14c
- module sum h1:cTAxtm6oLsry8AAqFTgikWOuPrjA937mOqntIAjWjVk=
- CSS SHA-256 9ec3f3187b736252b18f3aefef4737ba2025ef1c637611c3d0ecf58748043f1b

Verification:
- templ generation and CSS: zero tracked drift
- current-source and pinned-dependency module contracts: PASS
- root and site unit tests, vet, build, JS and vendor verification: PASS
- full Playwright E2E: PASS in 379.790s
- current-source catalog and social-preview E2E: PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the application shell dependency to the latest available version.

* **Tests**
  * Added checks to verify the Arai Hû theme loads successfully and uses the expected modern styling, including required theme variables and font settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->