### PR TITLE
chore(site): pin Goshtoso v0.1.14

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.1.13
+	github.com/araihu/goshtoso v0.1.14
 	github.com/araihu/goshtoso-app-shells v0.1.4
 	github.com/araihu/goshtoso-charts v0.0.2-0.20260730033312-82e67bb7111f
 	github.com/coder/websocket v1.8.15

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/chroma/v2 v2.27.0 h1:FodwmyOBgJULFYmDqibcp9pvfDLWdtPRh9v/r
 github.com/alecthomas/chroma/v2 v2.27.0/go.mod h1:NjJ3ciIgrqBNeIkWZ4e46nseoLDslxU1LmfCoL+wcY8=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.1.13 h1:YqZIbgWEjRkWzTjvsQxdFuJhy/J33RWjBT10wskaGuY=
-github.com/araihu/goshtoso v0.1.13/go.mod h1:sZbyx6KnzEwJC4ss/gM9BE3h182ZyREbixxAvRlwRRw=
+github.com/araihu/goshtoso v0.1.14 h1:u2xAwbnBqr4SVl1maz7jD372omPBd+3ux8/S0SbUmOk=
+github.com/araihu/goshtoso v0.1.14/go.mod h1:II6TL6BzW9OS2ux/7CkhcYEJcLdH97Kwkwe2qUOugNo=
 github.com/araihu/goshtoso-app-shells v0.1.4 h1:cTAxtm6oLsry8AAqFTgikWOuPrjA937mOqntIAjWjVk=
 github.com/araihu/goshtoso-app-shells v0.1.4/go.mod h1:P7CRRVDOMMbGs+clvddEmH+x2Jd35uk991WbU86nw84=
 github.com/araihu/goshtoso-charts v0.0.2-0.20260730033312-82e67bb7111f h1:XCzv73dCpGDdZlGgF3be5BuGy6tl4INT+iOJoS+TYww=


### PR DESCRIPTION
## Summary

- pin the standalone site module to public Goshtoso v0.1.14
- refresh module sums from the public Go module proxy

## Verification

- `GOWORK=off go mod verify`
- `just site-current-source-integration` (82 packages; server built)
- `just site-pinned-dependency-deployability` (v0.1.14, 81 packages; server built)
- no `replace` directive