### PR TITLE
ci: migrate pipelines to Dagger

### DIFF
--- a/.dagger/package-lock.json
+++ b/.dagger/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "goshtoso-dagger",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "goshtoso-dagger",
+      "dependencies": {
+        "@dagger.io/dagger": "./sdk",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@dagger.io/dagger": {
+      "resolved": "sdk",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "sdk": {
+      "name": "@dagger.io/dagger"
+    }
+  }
+}

--- a/.dagger/package.json
+++ b/.dagger/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "goshtoso-dagger",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@dagger.io/dagger": "./sdk",
+    "typescript": "^6.0.3"
+  }
+}

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -23,8 +23,8 @@ const GOLANGCI_LINT_VERSION = "v2.12.2"
 const GOLANGCI_LINT_AMD64_SHA256 = "8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 const GOLANGCI_LINT_ARM64_SHA256 = "44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
 const LYCHEE_VERSION = "v0.24.2"
-const LYCHEE_X86_64_SHA256 = "1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
-const LYCHEE_AARCH64_SHA256 = "91a7bd65685da41b90ccb9bc867a3d649a7818042dae04ff405e55a25bddee4c"
+const LYCHEE_X86_64_SHA256 = "73657a111819a30c47c08352896796f23d64e4eb2b3ed39b6d32149241566fc5"
+const LYCHEE_AARCH64_SHA256 = "5d0b0e3aeab240f41920c633a6eaf97599be6eedda034b36e858ede7dba5e535"
 
 const SOURCE_EXCLUDES = [
   ".dagger/node_modules",
@@ -133,7 +133,7 @@ scripts/run-component-coverage.sh --phase e2e-merge --impact /out/e2e-impact.jso
     cachePartition: string,
   ): Promise<string> {
     return this.base(source, cachePartition)
-      .withExec(["bash", "-euo", "pipefail", "-c", `case "$(uname -m)" in x86_64) arch=x86_64; sha=${LYCHEE_X86_64_SHA256};; aarch64|arm64) arch=aarch64; sha=${LYCHEE_AARCH64_SHA256};; *) echo unsupported architecture >&2; exit 1;; esac; file=lychee-$arch-unknown-linux-gnu.tar.gz; dir=lychee-$arch-unknown-linux-gnu; curl -fsSL -o /tmp/lychee.tgz https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/$file; echo "$sha  /tmp/lychee.tgz" | sha256sum -c -; tar -xzf /tmp/lychee.tgz -C /usr/local/bin --strip-components=1 "$dir/lychee"`])
+      .withExec(["bash", "-euo", "pipefail", "-c", `case "$(uname -m)" in x86_64) arch=x86_64; sha=${LYCHEE_X86_64_SHA256};; aarch64|arm64) arch=aarch64; sha=${LYCHEE_AARCH64_SHA256};; *) echo unsupported architecture >&2; exit 1;; esac; file=lychee-$arch-unknown-linux-musl.tar.gz; dir=lychee-$arch-unknown-linux-musl; curl -fsSL -o /tmp/lychee.tgz https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/$file; echo "$sha  /tmp/lychee.tgz" | sha256sum -c -; tar -xzf /tmp/lychee.tgz -C /usr/local/bin --strip-components=1 "$dir/lychee"`])
       .withExec(["lychee", "--config", ".lychee.toml", "./**/*.md"])
       .stdout()
   }

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -1,0 +1,355 @@
+import {
+  argument,
+  dag,
+  Container,
+  Directory,
+  File,
+  func,
+  object,
+  ReturnType,
+  Secret,
+} from "@dagger.io/dagger"
+
+const GO_IMAGE =
+  "golang:1.26.5-bookworm@sha256:53eeac89074db483fdf0ab3be1df32bf6e47562263d2d0d6baa7f26acb4957dd"
+const JQ_IMAGE =
+  "ghcr.io/jqlang/jq:1.8.2@sha256:b9c68867e5766576263a222e91db3de422d802069c7af70440e667a95344e486"
+const NODE_IMAGE =
+  "node:24.19.0-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03"
+const TEMPL_VERSION = "v0.3.1020"
+const PLAYWRIGHT_VERSION = "v0.6100.0"
+const GOLANGCI_LINT_VERSION = "v2.12.2"
+const LYCHEE_VERSION = "v0.24.2"
+const LYCHEE_X86_64_SHA256 = "1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
+const LYCHEE_AARCH64_SHA256 = "91a7bd65685da41b90ccb9bc867a3d649a7818042dae04ff405e55a25bddee4c"
+
+const SOURCE_EXCLUDES = [
+  ".dagger/node_modules",
+  ".dagger/node_modules/**",
+  ".dagger/sdk",
+  ".dagger/sdk/**",
+  ".git",
+  ".git/**",
+  ".cache",
+  ".cache/**",
+  ".coverage",
+  ".coverage/**",
+  "bin",
+  "bin/**",
+  "site/tests/e2e/test-results",
+  "site/tests/e2e/test-results/**",
+]
+
+@object()
+export class Goshtoso {
+  /** Root+site lint, generated drift, dependency integrity, and current-source build. */
+  @func()
+  async lintBuild(
+    @argument({ defaultPath: ".", ignore: SOURCE_EXCLUDES }) source: Directory,
+    cachePartition: string,
+  ): Promise<string> {
+    return this.goProject(source, cachePartition)
+      .withExec(["go", "tool", "muamba", "sync", "--strict", "--target", "linux/amd64", "--cache-dir", ".cache/muamba"])
+      .withExec(["go", "tool", "muamba", "verify", "--strict", "--target", "linux/amd64", "--cache-dir", ".cache/muamba"])
+      .withExec(["go", "tool", "muamba", "generate-go", "--strict", "--check", "--target", "linux/amd64", "--dir", "assets", "--output", "muamba_gen.go"])
+      .withExec(["go", "run", "./cmd/runtimegen", "-check"])
+      .withExec(["templ", "generate"])
+      .withExec(["bash", "-euo", "pipefail", "-c", "git diff --exit-code -- '*_templ.go'"])
+      .withExec(["go", "run", "./cmd/themegen"])
+      .withExec([".tools/tailwindcss", "-i", "css/main.css", "-o", "assets/styles.css"])
+      .withExec(["bash", "-euo", "pipefail", "-c", "git diff --exit-code -- assets/styles.css assets/goshtoso-theme.css"])
+      .withExec(["go", "run", "./cmd/skillgen"])
+      .withExec(["git", "diff", "--exit-code", "--", ".agents/skills/using-goshtoso/references/components-reference.md", ".claude/skills/using-goshtoso/components-reference.md"])
+      .withExec(["go", "run", "./cmd/iconcatalog", "-catalog", "internal/iconcatalog/testdata/heroicons-catalog.json", "-namespace", "ui", "-product", "heroicons", "-sprite-url", "/assets/icons/heroicons.svg", "-package", "heroicons", "-const-prefix", "Icon", "-out", "components/icon/heroicons/names_gen.go", "-check"])
+      .withExec(["go", "run", "./cmd/jslint"])
+      .withExec(["go", "run", "./cmd/jsbuild", "-check"])
+      .withExec(["go", "mod", "tidy"])
+      .withExec(["git", "diff", "--exit-code", "--", "go.mod", "go.sum"])
+      .withExec(["bash", "-euo", "pipefail", "-c", "test -z \"$(gofmt -l .)\""])
+      .withExec(["go", "vet", "./..."])
+      .withExec(["golangci-lint", "run", "--timeout", "5m"])
+      .withExec(["bash", "-euo", "pipefail", "-c", "test -f go.work || go work init . ./site"])
+      .withExec(["bash", "-euo", "pipefail", "-c", "cd site && go vet ./... && golangci-lint run --timeout 5m"])
+      .withExec(["bash", "-euo", "pipefail", "-c", "v=$(cd site && GOWORK=off go list -m -f '{{.Version}}' github.com/araihu/goshtoso); go build -ldflags \"-X github.com/araihu/goshtoso/site/internal/buildinfo.goDocsVersion=$v\" -o /tmp/server ./site/cmd/server"])
+      .stdout()
+  }
+
+  /** Unit, external-consumer, focused E2E, and merged partial coverage gates. */
+  @func({ cache: "never" })
+  tests(
+    @argument({ defaultPath: ".", ignore: SOURCE_EXCLUDES }) source: Directory,
+    changes: File,
+    cachePartition: string,
+    runNonce: string,
+  ): Directory {
+    const script = `set -Eeuo pipefail
+mkdir -p /out
+finish() {
+  rc=$?
+  trap - EXIT
+  set +e
+  test -f /out/e2e-impact.json || printf '{"mode":"full","tags":["full"],"changed_paths":[],"reasons":["impact selection did not complete"]}\n' > /out/e2e-impact.json
+  test ! -d .coverage || cp -a .coverage /out/coverage
+  test ! -d site/tests/e2e/test-results || cp -a site/tests/e2e/test-results /out/e2e-results
+  printf '%s\n' "$rc" > /out/status
+  exit 0
+}
+trap finish EXIT
+exec > >(tee /out/tests.log) 2>&1
+test -f go.work || go work init . ./site
+scripts/run-component-coverage.sh --phase units
+(cd tests/external/runtime-manifest && GOWORK=off go test ./... -count=1)
+go run ./cmd/e2eimpact --changes-file /tmp/e2e-changes > /out/e2e-impact.json
+templ generate
+.tools/tailwindcss -i css/main.css -o assets/styles.css
+scripts/run-focused-e2e.sh --current-source-theme-catalog
+scripts/run-component-coverage.sh --phase e2e-merge --impact /out/e2e-impact.json`
+    return this.browserProject(source, cachePartition)
+      .withFile("/tmp/e2e-changes", changes)
+      .withEnvVariable("GOSHTOSO_RUN_NONCE", runNonce)
+      .withExec(["bash", "-c", script], { expect: ReturnType.Any })
+      .directory("/out")
+  }
+
+  /** Standalone site/go.mod consumer contract (GOWORK=off). */
+  @func()
+  async required(
+    @argument({ defaultPath: ".", ignore: SOURCE_EXCLUDES }) source: Directory,
+    cachePartition: string,
+  ): Promise<string> {
+    return this.goProject(source, cachePartition)
+      .withExec(["scripts/check-site-module", "pinned-dependency"])
+      .stdout()
+  }
+
+  /** Markdown link gate using a checksum-verified lychee release. */
+  @func()
+  async docs(
+    @argument({ defaultPath: ".", ignore: SOURCE_EXCLUDES }) source: Directory,
+    cachePartition: string,
+  ): Promise<string> {
+    return this.base(source, cachePartition)
+      .withExec(["bash", "-euo", "pipefail", "-c", `case "$(uname -m)" in x86_64) arch=x86_64; sha=${LYCHEE_X86_64_SHA256};; aarch64|arm64) arch=aarch64; sha=${LYCHEE_AARCH64_SHA256};; *) echo unsupported architecture >&2; exit 1;; esac; file=lychee-$arch-unknown-linux-gnu.tar.gz; curl -fsSL -o /tmp/lychee.tgz https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/$file; echo "$sha  /tmp/lychee.tgz" | sha256sum -c -; tar -xzf /tmp/lychee.tgz -C /usr/local/bin lychee`])
+      .withExec(["lychee", "--config", ".lychee.toml", "./**/*.md"])
+      .stdout()
+  }
+
+  /** Full release-equivalent regeneration, both site contracts, E2E, and coverage. */
+  @func({ cache: "never" })
+  releaseVerify(
+    @argument({ defaultPath: ".", ignore: SOURCE_EXCLUDES }) source: Directory,
+    cachePartition: string,
+    runNonce: string,
+  ): Directory {
+    const script = `set -Eeuo pipefail
+mkdir -p /out
+finish() { rc=$?; trap - EXIT; set +e; test ! -d .coverage || cp -a .coverage/. /out/; test ! -d site/tests/e2e/test-results || cp -a site/tests/e2e/test-results /out/e2e-results; printf '%s\n' "$rc" > /out/status; exit 0; }
+trap finish EXIT
+exec > >(tee /out/release.log) 2>&1
+for t in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64; do go tool muamba sync --strict --target "$t" --cache-dir .cache/muamba tailwindcss/cli; done
+go tool muamba sync --strict --target linux/amd64 --cache-dir .cache/muamba
+go tool muamba verify --strict --all-platforms --cache-dir .cache/muamba
+go tool muamba generate-go --strict --check --target linux/amd64 --dir assets --output muamba_gen.go
+go run ./cmd/runtimegen -check
+test -f go.work || go work init . ./site
+templ generate; go run ./cmd/themegen; go run ./cmd/jsbuild; go run ./cmd/skillgen
+.tools/tailwindcss -i css/main.css -o assets/styles.css
+git ls-files --error-unmatch assets/styles.css assets/goshtoso-theme.css >/dev/null
+git diff --exit-code -- '*_templ.go' assets/styles.css assets/goshtoso-theme.css 'assets/js/*.js' .agents/skills/using-goshtoso/references/components-reference.md .claude/skills/using-goshtoso/components-reference.md
+scripts/check-site-module current-source
+scripts/check-site-module pinned-dependency
+scripts/run-release-coverage.sh --local-dry-run`
+    return this.browserProject(source, cachePartition)
+      .withEnvVariable("GOSHTOSO_RUN_NONCE", runNonce)
+      .withExec(["bash", "-c", script], { expect: ReturnType.Any })
+      .directory("/out")
+  }
+
+  /** Publish the verified tag assets and both authoritative badge documents. */
+  @func({ cache: "never" })
+  async publishRelease(
+    @argument({ defaultPath: ".", ignore: SOURCE_EXCLUDES }) source: Directory,
+    coverage: Directory,
+    metadata: File,
+    githubToken: Secret,
+    gistToken: Secret,
+    runNonce: string,
+  ): Promise<string> {
+    const release = await this.json(metadata, ["tag"])
+    const tag = this.string(release, "tag")
+    if (!/^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(tag)) throw new Error(`invalid release tag: ${tag}`)
+    const script = `set -euo pipefail
+ver=$(sed -n '/^  tailwindcss:$/,/^  [^ ]/ s/^    version: "\\([^"]*\\)"/\\1/p' muamba.yaml)
+test -n "$ver"
+awk -v heading="## [$TAG]" 'index($0, heading) == 1 { found=1; next } found && /^## \\[/ { exit } found { print } END { if (!found) exit 1 }' CHANGELOG.md > /tmp/release-notes.md
+printf '\\n## Build artifacts\\n\\nBuilt with Tailwind CSS %s.\\nAssets attached: styles.css and goshtoso-theme.css.\\n' "$ver" >> /tmp/release-notes.md
+if gh release view "$TAG" --repo araihu/goshtoso >/dev/null 2>&1; then
+  gh release edit "$TAG" --repo araihu/goshtoso --notes-file /tmp/release-notes.md
+  gh release upload "$TAG" --repo araihu/goshtoso --clobber assets/styles.css assets/goshtoso-theme.css
+else
+  gh release create "$TAG" --repo araihu/goshtoso --verify-tag --notes-file /tmp/release-notes.md assets/styles.css assets/goshtoso-theme.css
+fi
+percent=$(cat /coverage/percentage.txt)
+color=$(cat /coverage/color.txt)
+jq -n --arg coverage "{\\"schemaVersion\\":1,\\"label\\":\\"authored coverage\\",\\"message\\":\\"$percent%\\",\\"color\\":\\"$color\\"}" --arg release "{\\"schemaVersion\\":1,\\"label\\":\\"release\\",\\"message\\":\\"$TAG\\",\\"color\\":\\"blue\\"}" '{files:{"coverage.json":{content:$coverage},"release.json":{content:$release}}}' > /tmp/gist.json
+curl -fsS -X PATCH -H 'Accept: application/vnd.github+json' -H "Authorization: Bearer $GIST_TOKEN" -H 'X-GitHub-Api-Version: 2022-11-28' --data-binary @/tmp/gist.json https://api.github.com/gists/fb3843c3a13793eb6cc0af638bc00ad4 >/dev/null
+echo "published $TAG and badge documents"`
+    return this.base(source, "trusted-release")
+      .withDirectory("/coverage", coverage)
+      .withSecretVariable("GH_TOKEN", githubToken)
+      .withSecretVariable("GIST_TOKEN", gistToken)
+      .withEnvVariable("TAG", tag)
+      .withEnvVariable("GOSHTOSO_RUN_NONCE", runNonce)
+      .withExec(["bash", "-euo", "pipefail", "-c", script])
+      .stdout()
+  }
+
+  /** Dispatch the verified main SHA to the central Fly deployment repository. */
+  @func({ cache: "never" })
+  async dispatchFly(metadata: File, token: Secret, runNonce: string): Promise<string> {
+    const handoff = await this.json(metadata, ["source_repository", "source_run_id", "source_sha"])
+    const sourceSha = this.string(handoff, "source_sha")
+    const sourceRunId = this.string(handoff, "source_run_id")
+    if (!/^[0-9a-f]{40}$/.test(sourceSha)) throw new Error("invalid Fly source SHA")
+    if (!/^[1-9][0-9]*$/.test(sourceRunId)) throw new Error("invalid Fly source run ID")
+    if (this.string(handoff, "source_repository") !== "araihu/goshtoso") throw new Error("invalid Fly source repository")
+    const payload = JSON.stringify({ event_type: "goshtoso-main", client_payload: { goshtoso_ref: sourceSha, goshtoso_sha: sourceSha, goshtoso_run_id: sourceRunId, source_repository: "araihu/goshtoso" } })
+    return dag.container().from(GO_IMAGE)
+      .withExec(["apt-get", "update"])
+      .withExec(["apt-get", "install", "-y", "--no-install-recommends", "ca-certificates", "curl"])
+      .withExec(["rm", "-rf", "/var/lib/apt/lists/*"])
+      .withSecretVariable("GH_TOKEN", token)
+      .withNewFile("/tmp/payload.json", payload)
+      .withEnvVariable("GOSHTOSO_RUN_NONCE", runNonce)
+      .withExec(["bash", "-euo", "pipefail", "-c", "curl -fsS -X POST -H 'Accept: application/vnd.github+json' -H \"Authorization: Bearer $GH_TOKEN\" -H 'X-GitHub-Api-Version: 2022-11-28' --data-binary @/tmp/payload.json https://api.github.com/repos/araihu/fly-deploy/dispatches"])
+      .withExec(["echo", "Fly dispatch accepted"])
+      .stdout()
+  }
+
+  /** Validate immutable Assets handoff, update allowlisted files, and return the patch tree. */
+  @func({ cache: "never" })
+  async updateAraihuAssets(
+    @argument({ defaultPath: ".", ignore: SOURCE_EXCLUDES }) source: Directory,
+    metadata: File,
+    githubToken: Secret,
+    cachePartition: string,
+    runNonce: string,
+  ): Promise<Directory> {
+    const handoff = await this.json(metadata, ["assets_repository", "assets_revision", "release", "release_json_sha256", "release_sha256", "release_url"])
+    const assetsRepository = this.string(handoff, "assets_repository")
+    const assetsRevision = this.string(handoff, "assets_revision")
+    const release = this.string(handoff, "release")
+    const releaseUrl = this.string(handoff, "release_url")
+    const releaseSha256 = this.string(handoff, "release_sha256")
+    const releaseJsonSha256 = this.string(handoff, "release_json_sha256")
+    if (assetsRepository !== "araihu/assets" || !/^[0-9a-f]{40}$/.test(assetsRevision) || !/^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(release) || !/^[0-9a-f]{64}$/.test(releaseSha256) || !/^[0-9a-f]{64}$/.test(releaseJsonSha256) || releaseUrl !== `https://github.com/araihu/assets/releases/download/${release}/araihu-assets-${release}.tar.gz`) throw new Error("invalid immutable Assets handoff")
+    const args = ["-release-dir", "/tmp/release", "-assets-repository", assetsRepository, "-assets-revision", assetsRevision, "-release", release, "-release-url", releaseUrl, "-release-sha256", releaseSha256, "-release-json-sha256", releaseJsonSha256]
+    return this.goProject(source, cachePartition)
+      .withSecretVariable("GH_TOKEN", githubToken)
+      .withEnvVariable("ASSETS_REPOSITORY", assetsRepository).withEnvVariable("ASSETS_REVISION", assetsRevision)
+      .withEnvVariable("RELEASE", release).withEnvVariable("RELEASE_URL", releaseUrl)
+      .withEnvVariable("RELEASE_SHA256", releaseSha256).withEnvVariable("RELEASE_JSON_SHA256", releaseJsonSha256)
+      .withExec(["bash", "-euo", "pipefail", "-c", "test \"$ASSETS_REPOSITORY\" = araihu/assets; [[ $ASSETS_REVISION =~ ^[0-9a-f]{40}$ ]]; [[ $RELEASE =~ ^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$ ]]; [[ $RELEASE_SHA256 =~ ^[0-9a-f]{64}$ ]]; [[ $RELEASE_JSON_SHA256 =~ ^[0-9a-f]{64}$ ]]; test \"$RELEASE_URL\" = \"https://github.com/araihu/assets/releases/download/$RELEASE/araihu-assets-$RELEASE.tar.gz\""])
+      .withEnvVariable("GOSHTOSO_RUN_NONCE", runNonce)
+      .withExec(["bash", "-euo", "pipefail", "-c", "o=$(curl -fsS -H \"Authorization: Bearer $GH_TOKEN\" -H 'Accept: application/vnd.github+json' https://api.github.com/repos/araihu/assets/git/ref/tags/$RELEASE); type=$(printf '%s' \"$o\" | sed -n 's/.*\"type\": *\"\\([^\"]*\\)\".*/\\1/p'); sha=$(printf '%s' \"$o\" | sed -n 's/.*\"sha\": *\"\\([0-9a-f]*\\)\".*/\\1/p'); if test \"$type\" = tag; then o=$(curl -fsS -H \"Authorization: Bearer $GH_TOKEN\" -H 'Accept: application/vnd.github+json' https://api.github.com/repos/araihu/assets/git/tags/$sha); type=$(printf '%s' \"$o\" | sed -n 's/.*\"type\": *\"\\([^\"]*\\)\".*/\\1/p'); sha=$(printf '%s' \"$o\" | sed -n 's/.*\"sha\": *\"\\([0-9a-f]*\\)\".*/\\1/p'); fi; test \"$type\" = commit; test \"$sha\" = \"$ASSETS_REVISION\""])
+      .withExec(["bash", "-euo", "pipefail", "-c", "curl -fsSL --retry 3 -o /tmp/release.tgz \"$RELEASE_URL\"; printf '%s  %s\n' \"$RELEASE_SHA256\" /tmp/release.tgz | sha256sum -c --strict; while IFS= read -r m; do case \"$m\" in /*|../*|*/../*|*/..) exit 1;; esac; done < <(tar -tzf /tmp/release.tgz); ! tar -tvzf /tmp/release.tgz | grep -Eq '^[lh]'; mkdir /tmp/release; tar -xzf /tmp/release.tgz -C /tmp/release --no-same-owner --no-same-permissions"])
+      .withExec(["go", "run", "./cmd/araihu-assets-update", ...args])
+      .withExec(["git", "diff", "--binary"], { redirectStdout: "/tmp/first.diff" })
+      .withExec(["go", "run", "./cmd/araihu-assets-update", ...args])
+      .withExec(["git", "diff", "--binary"], { redirectStdout: "/tmp/second.diff" })
+      .withExec(["cmp", "/tmp/first.diff", "/tmp/second.diff"])
+      .withExec(["go", "test", "./internal/araihuassets", "./cmd/araihu-assets-update", "-count=1"])
+      .directory("/work")
+  }
+
+  /** Minimal runner-to-Dagger execution proof. */
+  @func({ cache: "never" })
+  async smoke(@argument({ defaultPath: ".", ignore: SOURCE_EXCLUDES }) source: Directory, identity: File, runNonce: string): Promise<string> {
+    const metadata = await this.json(identity, ["revision"])
+    const revision = this.string(metadata, "revision")
+    if (!/^[0-9a-f]{40}$/.test(revision)) throw new Error("invalid provider Git revision")
+    return dag.container().from(GO_IMAGE).withDirectory("/work", source).withWorkdir("/work")
+      .withEnvVariable("GOSHTOSO_REVISION", revision)
+      .withEnvVariable("GOSHTOSO_RUN_NONCE", runNonce)
+      .withExec(["bash", "-euo", "pipefail", "-c", "printf '%s\\n' \"$GOSHTOSO_REVISION\"; go version; test -f dagger.json"])
+      .stdout()
+  }
+
+  private base(source: Directory, partition: string): Container {
+    const key = this.partition(partition)
+    const cacheNamespace = this.cacheNamespace(key)
+    const container = dag.container().from(GO_IMAGE)
+      .withExec(["apt-get", "update"])
+      .withExec(["apt-get", "install", "-y", "--no-install-recommends", "ca-certificates", "curl", "git", "gh"])
+      .withExec(["rm", "-rf", "/var/lib/apt/lists/*"])
+      .withFile("/usr/local/bin/jq", dag.container().from(JQ_IMAGE).file("/jq"), { permissions: 0o755 })
+      .withDirectory("/work", source).withWorkdir("/work")
+      .withExec(["bash", "-euo", "pipefail", "-c", "git init -q; git config user.name Dagger; git config user.email dagger@invalid; git add -A; git commit -qm source-baseline"])
+    return container
+      .withMountedCache("/root/.cache/go-build", dag.cacheVolume(`goshtoso-${cacheNamespace}-go-build-v1`))
+      .withMountedCache("/go/pkg/mod", dag.cacheVolume(`goshtoso-${cacheNamespace}-go-mod-v1`))
+      .withMountedCache("/work/.cache/muamba", dag.cacheVolume(`goshtoso-${cacheNamespace}-muamba-v1`))
+  }
+
+  private goProject(source: Directory, partition: string): Container {
+    const key = this.partition(partition)
+    const cacheNamespace = this.cacheNamespace(key)
+    const node = dag.container().from(NODE_IMAGE)
+    let project = this.base(source, key)
+      .withFile("/usr/local/bin/node", node.file("/usr/local/bin/node"), { permissions: 0o755 })
+      .withDirectory("/usr/local/lib/node_modules", node.directory("/usr/local/lib/node_modules"))
+      .withExec(["ln", "-sf", "../lib/node_modules/npm/bin/npm-cli.js", "/usr/local/bin/npm"])
+      .withExec(["ln", "-sf", "../lib/node_modules/npm/bin/npx-cli.js", "/usr/local/bin/npx"])
+      .withExec(["node", "--version"])
+      .withEnvVariable("GOBIN", "/tools/bin").withEnvVariable("PATH", "/tools/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+      .withExec(["mkdir", "-p", "/tools/bin"])
+    if (cacheNamespace !== undefined) {
+      project = project.withMountedCache("/tools", dag.cacheVolume(`goshtoso-${cacheNamespace}-go-tools-${TEMPL_VERSION}-${GOLANGCI_LINT_VERSION}-${PLAYWRIGHT_VERSION}`))
+    }
+    return project
+      .withExec(["bash", "-euo", "pipefail", "-c", `test -x /tools/bin/templ || go install github.com/a-h/templ/cmd/templ@${TEMPL_VERSION}; test -x /tools/bin/golangci-lint || { curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b /tools/bin ${GOLANGCI_LINT_VERSION}; }`])
+  }
+
+  private browserProject(source: Directory, partition: string): Container {
+    const key = this.partition(partition)
+    const cacheNamespace = this.cacheNamespace(key)
+    let project = this.goProject(source, key)
+      .withEnvVariable("PLAYWRIGHT_BROWSERS_PATH", "/playwright")
+      .withExec(["mkdir", "-p", "/playwright"])
+    if (cacheNamespace !== undefined) {
+      project = project.withMountedCache("/playwright", dag.cacheVolume(`goshtoso-${cacheNamespace}-playwright-${PLAYWRIGHT_VERSION}`))
+    }
+    return project
+      .withExec(["bash", "-euo", "pipefail", "-c", `test -x /tools/bin/playwright || go install github.com/mxschmitt/playwright-go/cmd/playwright@${PLAYWRIGHT_VERSION}; test -f /playwright/.chromium-ready || { playwright install --with-deps chromium; touch /playwright/.chromium-ready; }`])
+  }
+
+  private partition(value: string): string {
+    if (!/^(trusted-(main|release|assets)|local(-[a-z0-9-]+)?|(untrusted|fork|internal)(-[a-z0-9-]+)?)$/.test(value)) throw new Error(`unsafe cache partition: ${value}`)
+    return value
+  }
+
+  private isUntrustedPartition(value: string): boolean {
+    return /^(untrusted|fork|internal)(-|$)/.test(value)
+  }
+
+  private cacheNamespace(value: string): string {
+    // PR jobs now run on a proven host-owned isolated Engine. Never derive
+    // that boundary from workflow input: every PR partition collapses to pr.
+    if (this.isUntrustedPartition(value)) return "pr"
+    return value
+  }
+
+  private async json(file: File, keys: string[]): Promise<Record<string, unknown>> {
+    let value: unknown
+    try { value = JSON.parse(await file.contents()) } catch { throw new Error("metadata is not valid JSON") }
+    if (value === null || Array.isArray(value) || typeof value !== "object") throw new Error("metadata must be an object")
+    const actual = Object.keys(value as Record<string, unknown>).sort()
+    if (JSON.stringify(actual) !== JSON.stringify([...keys].sort())) throw new Error("metadata fields do not match the strict schema")
+    return value as Record<string, unknown>
+  }
+
+  private string(value: Record<string, unknown>, key: string): string {
+    if (typeof value[key] !== "string") throw new Error(`metadata field ${key} must be a string`)
+    return value[key]
+  }
+}

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -1,5 +1,6 @@
 import {
   argument,
+  CacheSharingMode,
   dag,
   Container,
   Directory,
@@ -19,6 +20,8 @@ const NODE_IMAGE =
 const TEMPL_VERSION = "v0.3.1020"
 const PLAYWRIGHT_VERSION = "v0.6100.0"
 const GOLANGCI_LINT_VERSION = "v2.12.2"
+const GOLANGCI_LINT_AMD64_SHA256 = "8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
+const GOLANGCI_LINT_ARM64_SHA256 = "44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
 const LYCHEE_VERSION = "v0.24.2"
 const LYCHEE_X86_64_SHA256 = "1f4e0ef7f6554a6ed33dd7ac144fb2e1bbed98598e7af973042fc5cd43951c9a"
 const LYCHEE_AARCH64_SHA256 = "91a7bd65685da41b90ccb9bc867a3d649a7818042dae04ff405e55a25bddee4c"
@@ -100,6 +103,7 @@ test -f go.work || go work init . ./site
 scripts/run-component-coverage.sh --phase units
 (cd tests/external/runtime-manifest && GOWORK=off go test ./... -count=1)
 go run ./cmd/e2eimpact --changes-file /tmp/e2e-changes > /out/e2e-impact.json
+go tool muamba sync --strict --target linux/amd64 --cache-dir .cache/muamba tailwindcss/cli
 templ generate
 .tools/tailwindcss -i css/main.css -o assets/styles.css
 scripts/run-focused-e2e.sh --current-source-theme-catalog
@@ -129,7 +133,7 @@ scripts/run-component-coverage.sh --phase e2e-merge --impact /out/e2e-impact.jso
     cachePartition: string,
   ): Promise<string> {
     return this.base(source, cachePartition)
-      .withExec(["bash", "-euo", "pipefail", "-c", `case "$(uname -m)" in x86_64) arch=x86_64; sha=${LYCHEE_X86_64_SHA256};; aarch64|arm64) arch=aarch64; sha=${LYCHEE_AARCH64_SHA256};; *) echo unsupported architecture >&2; exit 1;; esac; file=lychee-$arch-unknown-linux-gnu.tar.gz; curl -fsSL -o /tmp/lychee.tgz https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/$file; echo "$sha  /tmp/lychee.tgz" | sha256sum -c -; tar -xzf /tmp/lychee.tgz -C /usr/local/bin lychee`])
+      .withExec(["bash", "-euo", "pipefail", "-c", `case "$(uname -m)" in x86_64) arch=x86_64; sha=${LYCHEE_X86_64_SHA256};; aarch64|arm64) arch=aarch64; sha=${LYCHEE_AARCH64_SHA256};; *) echo unsupported architecture >&2; exit 1;; esac; file=lychee-$arch-unknown-linux-gnu.tar.gz; dir=lychee-$arch-unknown-linux-gnu; curl -fsSL -o /tmp/lychee.tgz https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/$file; echo "$sha  /tmp/lychee.tgz" | sha256sum -c -; tar -xzf /tmp/lychee.tgz -C /usr/local/bin --strip-components=1 "$dir/lychee"`])
       .withExec(["lychee", "--config", ".lychee.toml", "./**/*.md"])
       .stdout()
   }
@@ -304,10 +308,10 @@ echo "published $TAG and badge documents"`
       .withEnvVariable("GOBIN", "/tools/bin").withEnvVariable("PATH", "/tools/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
       .withExec(["mkdir", "-p", "/tools/bin"])
     if (cacheNamespace !== undefined) {
-      project = project.withMountedCache("/tools", dag.cacheVolume(`goshtoso-${cacheNamespace}-go-tools-${TEMPL_VERSION}-${GOLANGCI_LINT_VERSION}-${PLAYWRIGHT_VERSION}`))
+      project = project.withMountedCache("/tools", dag.cacheVolume(`goshtoso-${cacheNamespace}-go-tools-${TEMPL_VERSION}-${GOLANGCI_LINT_VERSION}-${PLAYWRIGHT_VERSION}`), { sharing: CacheSharingMode.Locked })
     }
     return project
-      .withExec(["bash", "-euo", "pipefail", "-c", `test -x /tools/bin/templ || go install github.com/a-h/templ/cmd/templ@${TEMPL_VERSION}; test -x /tools/bin/golangci-lint || { curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/v2.12.2/install.sh | sh -s -- -b /tools/bin ${GOLANGCI_LINT_VERSION}; }`])
+      .withExec(["bash", "-euo", "pipefail", "-c", `test -x /tools/bin/templ || go install github.com/a-h/templ/cmd/templ@${TEMPL_VERSION}; test -x /tools/bin/golangci-lint || { case "$(uname -m)" in x86_64) arch=amd64; sha=${GOLANGCI_LINT_AMD64_SHA256};; aarch64|arm64) arch=arm64; sha=${GOLANGCI_LINT_ARM64_SHA256};; *) echo unsupported architecture >&2; exit 1;; esac; file=golangci-lint-2.12.2-linux-$arch.tar.gz; dir=\${file%.tar.gz}; curl -fsSL --retry 3 -o /tmp/golangci-lint.tgz https://github.com/golangci/golangci-lint/releases/download/${GOLANGCI_LINT_VERSION}/$file; echo "$sha  /tmp/golangci-lint.tgz" | sha256sum -c -; tar -xzf /tmp/golangci-lint.tgz -C /tools/bin --strip-components=1 "$dir/golangci-lint"; }`])
   }
 
   private browserProject(source: Directory, partition: string): Container {
@@ -317,7 +321,7 @@ echo "published $TAG and badge documents"`
       .withEnvVariable("PLAYWRIGHT_BROWSERS_PATH", "/playwright")
       .withExec(["mkdir", "-p", "/playwright"])
     if (cacheNamespace !== undefined) {
-      project = project.withMountedCache("/playwright", dag.cacheVolume(`goshtoso-${cacheNamespace}-playwright-${PLAYWRIGHT_VERSION}`))
+      project = project.withMountedCache("/playwright", dag.cacheVolume(`goshtoso-${cacheNamespace}-playwright-${PLAYWRIGHT_VERSION}`), { sharing: CacheSharingMode.Locked })
     }
     return project
       .withExec(["bash", "-euo", "pipefail", "-c", `test -x /tools/bin/playwright || go install github.com/mxschmitt/playwright-go/cmd/playwright@${PLAYWRIGHT_VERSION}; test -f /playwright/.chromium-ready || { playwright install --with-deps chromium; touch /playwright/.chromium-ready; }`])

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -19,6 +19,7 @@ const NODE_IMAGE =
   "node:24.19.0-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03"
 const TEMPL_VERSION = "v0.3.1020"
 const PLAYWRIGHT_VERSION = "v0.6100.0"
+const PLAYWRIGHT_DRIVER_VERSION = "1.61.1"
 const GOLANGCI_LINT_VERSION = "v2.12.2"
 const GOLANGCI_LINT_AMD64_SHA256 = "8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
 const GOLANGCI_LINT_ARM64_SHA256 = "44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
@@ -319,12 +320,13 @@ echo "published $TAG and badge documents"`
     const cacheNamespace = this.cacheNamespace(key)
     let project = this.goProject(source, key)
       .withEnvVariable("PLAYWRIGHT_BROWSERS_PATH", "/playwright")
+      .withEnvVariable("PLAYWRIGHT_DRIVER_PATH", "/playwright/driver")
       .withExec(["mkdir", "-p", "/playwright"])
     if (cacheNamespace !== undefined) {
       project = project.withMountedCache("/playwright", dag.cacheVolume(`goshtoso-${cacheNamespace}-playwright-${PLAYWRIGHT_VERSION}`), { sharing: CacheSharingMode.Locked })
     }
     return project
-      .withExec(["bash", "-euo", "pipefail", "-c", `test -x /tools/bin/playwright || go install github.com/mxschmitt/playwright-go/cmd/playwright@${PLAYWRIGHT_VERSION}; test -f /playwright/.chromium-ready || { playwright install --with-deps chromium; touch /playwright/.chromium-ready; }`])
+      .withExec(["bash", "-euo", "pipefail", "-c", `test -x /tools/bin/playwright || go install github.com/mxschmitt/playwright-go/cmd/playwright@${PLAYWRIGHT_VERSION}; ready=/playwright/.chromium-${PLAYWRIGHT_DRIVER_VERSION}-ready; if ! test -f "$ready" || ! test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js" || ! test -x "$PLAYWRIGHT_DRIVER_PATH/node"; then rm -rf -- "$PLAYWRIGHT_DRIVER_PATH"; rm -f -- "$ready"; playwright install --with-deps chromium; test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js"; test -x "$PLAYWRIGHT_DRIVER_PATH/node"; marker_tmp="$ready.tmp.$$"; : > "$marker_tmp"; mv -f -- "$marker_tmp" "$ready"; fi`])
   }
 
   private partition(value: string): string {

--- a/.dagger/tsconfig.json
+++ b/.dagger/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/.github/workflows/araihu-assets.yml
+++ b/.github/workflows/araihu-assets.yml
@@ -5,31 +5,12 @@ on:
     types: [araihu-assets-released]
   workflow_dispatch:
     inputs:
-      assets_repository:
-        description: Release repository
-        required: true
-        default: araihu/assets
-        type: string
-      assets_revision:
-        description: Full release commit SHA
-        required: true
-        type: string
-      release:
-        description: Stable release tag (vX.Y.Z)
-        required: true
-        type: string
-      release_url:
-        description: Immutable tar.gz release URL
-        required: true
-        type: string
-      release_sha256:
-        description: Release archive SHA-256
-        required: true
-        type: string
-      release_json_sha256:
-        description: release.json SHA-256
-        required: true
-        type: string
+      assets_repository: {description: Release repository, required: true, default: araihu/assets, type: string}
+      assets_revision: {description: Full release commit SHA, required: true, type: string}
+      release: {description: Stable release tag (vX.Y.Z), required: true, type: string}
+      release_url: {description: Immutable tar.gz release URL, required: true, type: string}
+      release_sha256: {description: Release archive SHA-256, required: true, type: string}
+      release_json_sha256: {description: release.json SHA-256, required: true, type: string}
 
 permissions:
   contents: read
@@ -49,35 +30,22 @@ jobs:
       RELEASE_SHA256: ${{ github.event.client_payload.release_sha256 || inputs.release_sha256 }}
       RELEASE_JSON_SHA256: ${{ github.event.client_payload.release_json_sha256 || inputs.release_json_sha256 }}
     steps:
-      - name: Validate immutable release identity
+      - name: Check out Goshtoso read-only
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Validate and materialize immutable handoff
         shell: bash
         run: |
           set -euo pipefail
-          test "$ASSETS_REPOSITORY" = "araihu/assets"
+          test "$ASSETS_REPOSITORY" = araihu/assets
           [[ "$ASSETS_REVISION" =~ ^[0-9a-f]{40}$ ]]
           [[ "$RELEASE" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
           [[ "$RELEASE_SHA256" =~ ^[0-9a-f]{64}$ ]]
           [[ "$RELEASE_JSON_SHA256" =~ ^[0-9a-f]{64}$ ]]
-          expected_url="https://github.com/araihu/assets/releases/download/${RELEASE}/araihu-assets-${RELEASE}.tar.gz"
-          test "$RELEASE_URL" = "$expected_url"
-
-      - name: Verify tag resolves to dispatched revision
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          object=$(gh api "repos/araihu/assets/git/ref/tags/${RELEASE}" \
-            --jq '.object.type + " " + .object.sha')
-          read -r object_type object_sha <<< "$object"
-          if test "$object_type" = tag; then
-            object=$(gh api "repos/araihu/assets/git/tags/${object_sha}" \
-              --jq '.object.type + " " + .object.sha')
-            read -r object_type object_sha <<< "$object"
-          fi
-          test "$object_type" = commit
-          test "$object_sha" = "$ASSETS_REVISION"
-
+          test "$RELEASE_URL" = "https://github.com/araihu/assets/releases/download/$RELEASE/araihu-assets-$RELEASE.tar.gz"
+          jq -cn --arg assets_repository "$ASSETS_REPOSITORY" --arg assets_revision "$ASSETS_REVISION" --arg release "$RELEASE" --arg release_url "$RELEASE_URL" --arg release_sha256 "$RELEASE_SHA256" --arg release_json_sha256 "$RELEASE_JSON_SHA256" \
+            '{assets_repository:$assets_repository,assets_revision:$assets_revision,release:$release,release_url:$release_url,release_sha256:$release_sha256,release_json_sha256:$release_json_sha256}' > .assets-handoff.json
       - name: Create selected-repository App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -89,68 +57,21 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
           permission-issues: read
-
-      - name: Check out Goshtoso
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Validate and update fallback assets through Dagger
+        uses: dagger/dagger-for-github@456fc3af63a2ba6f9789af9c55045b459115541b # v8.2.1
         with:
-          token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: '1.26.5'
-          cache: true
-
-      - name: Download and verify release once
-        id: archive
+          version: '0.21.8'
+          verb: call
+          args: update-araihu-assets --source=. --metadata=.assets-handoff.json --github-token=env:ASSETS_GITHUB_TOKEN --cache-partition=trusted-assets --run-nonce=${{ github.run_id }}-${{ github.run_attempt }} export --path=.dagger-assets
+        env:
+          ASSETS_GITHUB_TOKEN: ${{ github.token }}
+      - name: Materialize allowlisted update
         shell: bash
         run: |
           set -euo pipefail
-          archive="$RUNNER_TEMP/araihu-assets-${RELEASE}.tar.gz"
-          extracted="$RUNNER_TEMP/araihu-assets-${RELEASE}"
-          curl --fail --location --silent --show-error --retry 3 \
-            --output "$archive" "$RELEASE_URL"
-          printf '%s  %s\n' "$RELEASE_SHA256" "$archive" \
-            | sha256sum --check --strict
-          while IFS= read -r member; do
-            case "$member" in
-              /*|../*|*/../*|*/..) echo "unsafe archive member: $member" >&2; exit 1 ;;
-            esac
-          done < <(tar --list --gzip --file "$archive")
-          if tar --list --verbose --gzip --file "$archive" | grep --extended-regexp --quiet '^[lh]'; then
-            echo "release archive contains a link" >&2
-            exit 1
-          fi
-          mkdir "$extracted"
-          tar --extract --gzip --file "$archive" --directory "$extracted" \
-            --no-same-owner --no-same-permissions
-          echo "release-dir=$extracted" >> "$GITHUB_OUTPUT"
-
-      - name: Update allowlisted fallback assets
-        shell: bash
-        run: |
-          set -euo pipefail
-          args=(
-            -release-dir "${{ steps.archive.outputs.release-dir }}"
-            -assets-repository "$ASSETS_REPOSITORY"
-            -assets-revision "$ASSETS_REVISION"
-            -release "$RELEASE"
-            -release-url "$RELEASE_URL"
-            -release-sha256 "$RELEASE_SHA256"
-            -release-json-sha256 "$RELEASE_JSON_SHA256"
-          )
-          go run ./cmd/araihu-assets-update "${args[@]}"
-          first_diff="$RUNNER_TEMP/first.diff"
-          second_diff="$RUNNER_TEMP/second.diff"
-          git diff --binary > "$first_diff"
-          go run ./cmd/araihu-assets-update "${args[@]}"
-          git diff --binary > "$second_diff"
-          cmp "$first_diff" "$second_diff"
-
-      - name: Run focused updater tests
-        run: go test ./internal/araihuassets ./cmd/araihu-assets-update -count=1
-
+          for path in araihu-assets.json examples/getting-started/araihu.css assets/favicon.svg assets/images/goshtoso-logo.svg assets/images/goshtoso-mark.svg; do
+            install -D ".dagger-assets/$path" "$path"
+          done
       - name: Select existing labels only
         id: labels
         shell: bash
@@ -158,20 +79,12 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          available=$(gh label list --repo "$GITHUB_REPOSITORY" --limit 1000 \
-            --json name --jq '.[].name')
+          available=$(gh label list --repo "$GITHUB_REPOSITORY" --limit 1000 --json name --jq '.[].name')
           selected=""
           for label in dependencies assets; do
-            if grep --fixed-strings --line-regexp --quiet "$label" <<< "$available"; then
-              selected+="${selected:+$'\n'}$label"
-            fi
+            if grep -Fxq "$label" <<< "$available"; then selected+="${selected:+$'\n'}$label"; fi
           done
-          {
-            echo 'labels<<EOF'
-            printf '%s\n' "$selected"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-
+          { echo 'labels<<EOF'; printf '%s\n' "$selected"; echo EOF; } >> "$GITHUB_OUTPUT"
       - name: Create or update fallback asset PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:

--- a/.github/workflows/araihu-assets.yml
+++ b/.github/workflows/araihu-assets.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           set -euo pipefail
           for path in araihu-assets.json examples/getting-started/araihu.css assets/favicon.svg assets/images/goshtoso-logo.svg assets/images/goshtoso-mark.svg; do
-            install -D ".dagger-assets/$path" "$path"
+            install -D -m 0644 ".dagger-assets/$path" "$path"
           done
       - name: Select existing labels only
         id: labels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,25 +3,24 @@ name: Code CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
+    paths-ignore: ['**/*.md']
   push:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
+    paths-ignore: ['**/*.md']
 
-# PRs cancel superseded runs per head ref; main pushes each get a unique group
-# (run_id) so rapid merges don't cancel the coverage/deploy jobs mid-flight.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 env:
-  GO_VERSION: '1.26.5'
-  NODE_VERSION: '24.19.0'
-  TEMPL_VERSION: 'v0.3.1020'
-  PLAYWRIGHT_VERSION: 'v0.6100.0'
-  GOLANGCI_LINT_VERSION: 'v2.12.2'
+  CACHE_PARTITION: >-
+    ${{
+      github.event_name == 'push' && 'trusted-main' ||
+      'untrusted-github'
+    }}
 
 jobs:
   lint-build:
@@ -30,214 +29,51 @@ jobs:
       ${{
         github.event_name == 'pull_request' &&
         contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action) &&
-        github.event.pull_request.draft == false &&
-        github.event.pull_request.user.login == github.actor &&
-        github.event.pull_request.base.repo.full_name == github.repository &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(fromJSON(vars.HOSTINGER_PR_ACTORS_JSON || '[]'), github.actor) &&
-        fromJSON('["self-hosted","Linux","X64","hostinger-vps"]') ||
-        'ubuntu-24.04'
+        github.event.pull_request.draft == false && github.event.pull_request.user.login == github.actor &&
+        github.event.pull_request.base.repo.full_name == github.repository && github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.repo.fork == false && contains(fromJSON(vars.HOSTINGER_PR_ACTORS_JSON || '[]'), github.actor) &&
+        fromJSON('["self-hosted","Linux","X64","hostinger-vps-pr"]') || 'ubuntu-24.04'
       }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Configure job-local tools
+      - name: Dagger lint, drift, and build gates (embedded CLI)
+        if: runner.environment == 'self-hosted'
+        shell: bash
         run: |
           set -euo pipefail
-          tool_bin="$RUNNER_TEMP/go-bin"
-          mkdir -p "$tool_bin"
-          echo "GOBIN=$tool_bin" >> "$GITHUB_ENV"
-          echo "$tool_bin" >> "$GITHUB_PATH"
-
-      - uses: actions/setup-go@v7
+          test "$(dagger version | awk '{print $2}')" = v0.21.8
+          dagger call lint-build --source=. --cache-partition="$CACHE_PARTITION"
+      - name: Dagger lint, drift, and build gates
+        if: runner.environment != 'self-hosted'
+        uses: dagger/dagger-for-github@456fc3af63a2ba6f9789af9c55045b459115541b # v8.2.1
         with:
-          go-version: ${{ env.GO_VERSION }}
-          # Hostinger runners are ephemeral. setup-go's post-job cache save can
-          # outlive the runner lease and strand the workflow after every real
-          # gate has passed.
-          cache: false
+          version: '0.21.8'
+          verb: call
+          args: lint-build --source=. --cache-partition=${{ env.CACHE_PARTITION }}
 
-      - uses: actions/cache@v6
-        with:
-          path: .cache/muamba
-          key: muamba-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('muamba.yaml') }}
-
-      - name: Verify Muamba acquisition and generated runtime
-        run: |
-          go tool muamba sync --strict --target linux/amd64 --cache-dir .cache/muamba
-          go tool muamba verify --strict --target linux/amd64 --cache-dir .cache/muamba
-          go tool muamba generate-go --strict --check --target linux/amd64 --dir assets --output muamba_gen.go
-          go run ./cmd/runtimegen -check
-
-      - name: Install templ
-        run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}
-
-      - name: templ generate drift check
-        run: |
-          templ generate
-          git diff --exit-code -- '*_templ.go' \
-            || { echo "::error::templ generate drift — run 'templ generate' and commit"; exit 1; }
-
-      - name: Tailwind CSS + theme drift check
-        run: |
-          go run ./cmd/themegen
-          .tools/tailwindcss -i css/main.css -o assets/styles.css
-          git diff --exit-code -- assets/styles.css assets/goshtoso-theme.css \
-            || { echo "::error::css/theme drift — run 'just css' and commit assets/styles.css + assets/goshtoso-theme.css"; exit 1; }
-
-      - name: using-goshtoso skill reference drift check
-        run: |
-          go run ./cmd/skillgen
-          git diff --exit-code -- \
-            .agents/skills/using-goshtoso/references/components-reference.md \
-            .claude/skills/using-goshtoso/components-reference.md \
-            || { echo "::error::using-goshtoso skill reference is stale — run 'go run ./cmd/skillgen' and commit"; exit 1; }
-
-      - name: Heroicons bindings drift check
-        run: |
-          go run ./cmd/iconcatalog \
-            -catalog internal/iconcatalog/testdata/heroicons-catalog.json \
-            -namespace ui -product heroicons \
-            -sprite-url /assets/icons/heroicons.svg \
-            -package heroicons -const-prefix Icon \
-            -out components/icon/heroicons/names_gen.go -check \
-            || { echo "::error::Heroicons bindings are stale — run iconcatalog and commit names_gen.go"; exit 1; }
-
-      - name: First-party JavaScript lint + drift check
-        run: |
-          go run ./cmd/jslint
-          go run ./cmd/jsbuild -check \
-            || { echo "::error::first-party JavaScript is stale — run 'go run ./cmd/jsbuild' and commit"; exit 1; }
-
-      - name: go mod tidy drift check
-        run: |
-          go mod tidy
-          git diff --exit-code -- go.mod go.sum \
-            || { echo "::error::go.mod/go.sum drift — run 'go mod tidy' and commit"; exit 1; }
-
-      - name: gofmt
-        run: |
-          out=$(gofmt -l .)
-          if [ -n "$out" ]; then
-            echo "::error::gofmt drift in:"
-            echo "$out"
-            exit 1
-          fi
-
-      - name: go vet
-        run: go vet ./...
-
-      - name: golangci-lint (library, root module)
-        run: |
-          set -euo pipefail
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
-            | sh -s -- -b "$GOBIN" "${GOLANGCI_LINT_VERSION}"
-          "$GOBIN/golangci-lint" run --timeout 5m
-
-      # Current-source integration: the site builds against the root library at
-      # this commit through a throwaway workspace. The pinned-dependency
-      # deployability contract runs separately in Required CI with GOWORK=off.
-      - name: Current-source integration workspace (root library + site)
-        run: go work init . ./site
-
-      - name: go vet (site module)
-        run: cd site && go vet ./...
-
-      - name: golangci-lint (site module)
-        run: cd site && "$GOBIN/golangci-lint" run --timeout 5m
-
-      - name: Build server (current-source integration)
-        run: |
-          GOSHTOSO_DOCS_VERSION="$(cd site && GOWORK=off go list -m -f '{{.Version}}' github.com/araihu/goshtoso)"
-          go build \
-            -ldflags "-X github.com/araihu/goshtoso/site/internal/buildinfo.goDocsVersion=${GOSHTOSO_DOCS_VERSION}" \
-            -o bin/server ./site/cmd/server
-
-  # Single test runner: executes the same root-unit + site-unit + E2E sets the
-  # old unit-test and e2e jobs ran, but coverage-instrumented — so tests run
-  # once, not twice. Unit tests remain unconditional; Playwright uses the
-  # conservative impact selector. Partial coverage never updates the badge.
   test:
     name: Tests + coverage
     runs-on: >-
       ${{
         github.event_name == 'pull_request' &&
         contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action) &&
-        github.event.pull_request.draft == false &&
-        github.event.pull_request.user.login == github.actor &&
-        github.event.pull_request.base.repo.full_name == github.repository &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(fromJSON(vars.HOSTINGER_PR_ACTORS_JSON || '[]'), github.actor) &&
-        fromJSON('["self-hosted","Linux","X64","hostinger-vps"]') ||
-        'ubuntu-24.04'
+        github.event.pull_request.draft == false && github.event.pull_request.user.login == github.actor &&
+        github.event.pull_request.base.repo.full_name == github.repository && github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.repo.fork == false && contains(fromJSON(vars.HOSTINGER_PR_ACTORS_JSON || '[]'), github.actor) &&
+        fromJSON('["self-hosted","Linux","X64","hostinger-vps-pr"]') || 'ubuntu-24.04'
       }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Configure job-local tools
-        run: |
-          set -euo pipefail
-          tool_bin="$RUNNER_TEMP/go-bin"
-          browser_path="$HOME/.cache/ms-playwright"
-          mkdir -p "$tool_bin" "$browser_path"
-          {
-            echo "GOBIN=$tool_bin"
-            echo "PLAYWRIGHT_BROWSERS_PATH=$browser_path"
-          } >> "$GITHUB_ENV"
-          echo "$tool_bin" >> "$GITHUB_PATH"
-
-      - uses: actions/setup-go@v7
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          # Keep ephemeral Hostinger jobs free of setup-go post-job cache work.
-          cache: false
-
-      - uses: actions/setup-node@v7
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - uses: actions/cache@v6
-        with:
-          path: .cache/muamba
-          key: muamba-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('muamba.yaml') }}
-
-      - name: Verify Muamba acquisition and generated runtime
-        run: |
-          go tool muamba sync --strict --target linux/amd64 --cache-dir .cache/muamba
-          go tool muamba verify --strict --target linux/amd64 --cache-dir .cache/muamba
-          go tool muamba generate-go --strict --check --target linux/amd64 --dir assets --output muamba_gen.go
-          go run ./cmd/runtimegen -check
-
-      - name: Install templ
-        run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}
-
-      - name: Install Playwright + Chromium
-        run: |
-          set -euo pipefail
-          go install github.com/mxschmitt/playwright-go/cmd/playwright@${{ env.PLAYWRIGHT_VERSION }}
-          "$GOBIN/playwright" install --with-deps chromium
-
-      - name: Current-source integration workspace
-        run: go work init . ./site
-
-      - name: Unconditional root and site unit coverage
-        run: scripts/run-component-coverage.sh --phase units
-
-      - name: External runtime-manifest consumer contract
-        run: cd tests/external/runtime-manifest && GOWORK=off go test ./... -count=1
-
-      - name: Select focused E2E identities
-        id: e2e-impact
+      - name: Materialize conservative E2E change stream
+        shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -246,65 +82,54 @@ jobs:
           PUSH_HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            if ! start="$(git merge-base "$PR_BASE_SHA" "$PR_HEAD_SHA")"; then
-              start="$PR_BASE_SHA"
+          if [[ "$EVENT_NAME" == pull_request ]]; then
+            if ! base=$(git merge-base "$PR_BASE_SHA" "$PR_HEAD_SHA"); then
+              printf 'M\0.dagger-unsafe-range\0' > .e2e-changes
+              exit 0
             fi
-            head="$PR_HEAD_SHA"
+            head=$PR_HEAD_SHA
           else
-            start="$PUSH_BEFORE_SHA"
-            head="$PUSH_HEAD_SHA"
+            base=$PUSH_BEFORE_SHA
+            head=$PUSH_HEAD_SHA
           fi
-          go run ./cmd/e2eimpact --base "$start" --head "$head" > .e2e-impact.json
-          cat .e2e-impact.json
-          {
-            echo "### Playwright impact"
-            echo
-            echo '```json'
-            cat .e2e-impact.json
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload E2E impact decision
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-impact
-          path: .e2e-impact.json
-          retention-days: 7
-
-      - name: Generate templ + CSS
-        run: |
-          templ generate
-          .tools/tailwindcss -i css/main.css -o assets/styles.css
-
-      - name: Current-source theme catalog E2E listing and run
-        run: scripts/run-focused-e2e.sh --current-source-theme-catalog
-
-      # The merged coverage profile uses Go's native 1.20+ coverage data format
-      # so package tests and the coverage-instrumented demo server can drive
-      # the publishable library without counting demo-site package coverage.
-      - name: Focused E2E + merged component coverage
-        id: coverage
+          if [[ ! "$base" =~ ^[0-9a-f]{40}$ || "$base" == 0000000000000000000000000000000000000000 ]] ||
+             ! git merge-base --is-ancestor "$base" "$head"; then
+            printf 'M\0.dagger-unsafe-range\0' > .e2e-changes
+          else
+            git diff --name-status -z -M "$base" "$head" > .e2e-changes
+          fi
+      - name: Dagger unit, E2E, and coverage gates (embedded CLI)
+        if: runner.environment == 'self-hosted'
+        shell: bash
         run: |
           set -euo pipefail
-          scripts/run-component-coverage.sh --phase e2e-merge --impact .e2e-impact.json
-          total_line="$(grep '^total:' .coverage/coverage-func.txt)"
-          echo "$total_line"
-          {
-            echo "### Partial component Go coverage"
-            echo
-            echo "Focused Playwright results never update the authoritative coverage badge."
-            echo
-            echo '```text'
-            echo "$total_line"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload E2E artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v7
+          test "$(dagger version | awk '{print $2}')" = v0.21.8
+          dagger call tests --source=. --changes=.e2e-changes --cache-partition="$CACHE_PARTITION" --run-nonce="${{ github.run_id }}-${{ github.run_attempt }}" export --path=.dagger-output
+      - name: Dagger unit, E2E, and coverage gates
+        if: runner.environment != 'self-hosted'
+        uses: dagger/dagger-for-github@456fc3af63a2ba6f9789af9c55045b459115541b # v8.2.1
+        with:
+          version: '0.21.8'
+          verb: call
+          args: tests --source=. --changes=.e2e-changes --cache-partition=${{ env.CACHE_PARTITION }} --run-nonce=${{ github.run_id }}-${{ github.run_attempt }} export --path=.dagger-output
+      - name: Upload E2E impact decision
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: e2e-impact
+          path: .dagger-output/e2e-impact.json
+          retention-days: 7
+      - name: Upload E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: e2e-results
-          path: site/tests/e2e/test-results/
+          path: |
+            .dagger-output/tests.log
+            .dagger-output/coverage/
+            .dagger-output/e2e-results/
           retention-days: 7
           if-no-files-found: ignore
+      - name: Propagate test status
+        if: always()
+        run: test "$(cat .dagger-output/status)" = 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,26 +12,30 @@ permissions:
 jobs:
   deploy:
     name: Trigger Fly deploy
-    if: >-
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
     concurrency: deploy-group
     steps:
-      - name: Dispatch central deployment
-        uses: actions/github-script@v9
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          github-token: ${{ secrets.FLY_DEPLOY_DISPATCH_TOKEN }}
-          script: |
-            const sourceSha = context.payload.workflow_run.head_sha
-            await github.rest.repos.createDispatchEvent({
-              owner: 'araihu',
-              repo: 'fly-deploy',
-              event_type: 'goshtoso-main',
-              client_payload: {
-                goshtoso_ref: sourceSha,
-                goshtoso_sha: sourceSha,
-                goshtoso_run_id: String(context.payload.workflow_run.id),
-                source_repository: `${context.repo.owner}/${context.repo.repo}`,
-              },
-            })
+          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
+      - name: Materialize verified deployment handoff
+        shell: bash
+        env:
+          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
+          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          jq -cn --arg source_repository araihu/goshtoso --arg source_sha "$SOURCE_SHA" --arg source_run_id "$SOURCE_RUN_ID" \
+            '{source_repository:$source_repository,source_run_id:$source_run_id,source_sha:$source_sha}' > .fly-handoff.json
+      - name: Dispatch central deployment through Dagger
+        uses: dagger/dagger-for-github@456fc3af63a2ba6f9789af9c55045b459115541b # v8.2.1
+        with:
+          version: '0.21.8'
+          verb: call
+          args: dispatch-fly --metadata=.fly-handoff.json --token=env:FLY_DEPLOY_DISPATCH_TOKEN --run-nonce=${{ github.run_id }}-${{ github.run_attempt }}
+        env:
+          FLY_DEPLOY_DISPATCH_TOKEN: ${{ secrets.FLY_DEPLOY_DISPATCH_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,16 +3,10 @@ name: Docs
 on:
   pull_request:
     branches: [main]
-    paths:
-      - '**/*.md'
-      - '.github/workflows/docs.yml'
-      - '.lychee.toml'
+    paths: ['**/*.md', '.github/workflows/docs.yml', '.lychee.toml', '.dagger/**', 'dagger.json']
   push:
     branches: [main]
-    paths:
-      - '**/*.md'
-      - '.github/workflows/docs.yml'
-      - '.lychee.toml'
+    paths: ['**/*.md', '.github/workflows/docs.yml', '.lychee.toml', '.dagger/**', 'dagger.json']
 
 concurrency:
   group: docs-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -24,23 +18,36 @@ permissions:
 jobs:
   links:
     name: Markdown links
+    env:
+      CACHE_PARTITION: >-
+        ${{
+          github.event_name == 'push' && 'trusted-main' ||
+          'untrusted-github'
+        }}
     runs-on: >-
       ${{
         github.event_name == 'pull_request' &&
         contains(fromJSON('["opened","synchronize","reopened","ready_for_review"]'), github.event.action) &&
-        github.event.pull_request.draft == false &&
-        github.event.pull_request.user.login == github.actor &&
-        github.event.pull_request.base.repo.full_name == github.repository &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.head.repo.fork == false &&
-        contains(fromJSON(vars.HOSTINGER_PR_ACTORS_JSON || '[]'), github.actor) &&
-        fromJSON('["self-hosted","Linux","X64","hostinger-vps"]') ||
-        'ubuntu-latest'
+        github.event.pull_request.draft == false && github.event.pull_request.user.login == github.actor &&
+        github.event.pull_request.base.repo.full_name == github.repository && github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.repo.fork == false && contains(fromJSON(vars.HOSTINGER_PR_ACTORS_JSON || '[]'), github.actor) &&
+        fromJSON('["self-hosted","Linux","X64","hostinger-vps-pr"]') || 'ubuntu-latest'
       }}
     steps:
-      - uses: actions/checkout@v7
-      - name: Check links
-        uses: lycheeverse/lychee-action@v2.9.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          args: --config .lychee.toml './**/*.md'
-          fail: true
+          persist-credentials: false
+      - name: Dagger Markdown link gate (embedded CLI)
+        if: runner.environment == 'self-hosted'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(dagger version | awk '{print $2}')" = v0.21.8
+          dagger call docs --source=. --cache-partition="$CACHE_PARTITION"
+      - name: Dagger Markdown link gate
+        if: runner.environment != 'self-hosted'
+        uses: dagger/dagger-for-github@456fc3af63a2ba6f9789af9c55045b459115541b # v8.2.1
+        with:
+          version: '0.21.8'
+          verb: call
+          args: docs --source=. --cache-partition=${{ env.CACHE_PARTITION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,18 +2,11 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    tags: ['v*']
   workflow_dispatch:
 
 permissions:
   contents: write
-
-env:
-  GO_VERSION: '1.26.5'
-  NODE_VERSION: '24.19.0'
-  TEMPL_VERSION: 'v0.3.1020'
-  PLAYWRIGHT_VERSION: 'v0.6100.0'
 
 jobs:
   pre-release:
@@ -23,106 +16,51 @@ jobs:
       coverage-percent: ${{ steps.coverage.outputs.percent }}
       coverage-color: ${{ steps.coverage.outputs.color }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref }}
-
-      - uses: actions/setup-go@v7
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Dagger release-equivalent gates
+        uses: dagger/dagger-for-github@456fc3af63a2ba6f9789af9c55045b459115541b # v8.2.1
         with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - uses: actions/setup-node@v7
+          version: '0.21.8'
+          verb: call
+          args: release-verify --source=. --cache-partition=trusted-release --run-nonce=${{ github.run_id }}-${{ github.run_attempt }} export --path=.coverage
+      - name: Upload release diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - uses: actions/cache@v6
-        with:
-          path: .cache/muamba
-          key: muamba-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('muamba.yaml') }}
-
-      - name: Install pinned templ
-        run: go install github.com/a-h/templ/cmd/templ@${{ env.TEMPL_VERSION }}
-
-      - name: Prime and verify every Muamba target
-        run: |
-          set -euo pipefail
-          for target in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64; do
-            go tool muamba sync --strict --target "$target" --cache-dir .cache/muamba tailwindcss/cli
-          done
-          go tool muamba sync --strict --target linux/amd64 --cache-dir .cache/muamba
-          go tool muamba verify --strict --all-platforms --cache-dir .cache/muamba
-          go tool muamba generate-go --strict --check --target linux/amd64 --dir assets --output muamba_gen.go
-          go run ./cmd/runtimegen -check
-
-      - name: Install Playwright + Chromium
-        run: |
-          set -euo pipefail
-          go install github.com/mxschmitt/playwright-go/cmd/playwright@${{ env.PLAYWRIGHT_VERSION }}
-          playwright_bin="$(go env GOBIN)"
-          if [[ -z "$playwright_bin" ]]; then
-            playwright_bin="$(go env GOPATH)/bin"
-          fi
-          "$playwright_bin/playwright" install --with-deps chromium
-
-      - name: Create current-source workspace
-        run: go work init . ./site
-
-      - name: Rebuild and verify generated assets
-        run: |
-          set -euo pipefail
-          templ generate
-          go run ./cmd/themegen
-          go run ./cmd/jsbuild
-          go run ./cmd/skillgen
-          .tools/tailwindcss -i css/main.css -o assets/styles.css
-          git ls-files --error-unmatch assets/styles.css assets/goshtoso-theme.css >/dev/null
-          git diff --exit-code -- \
-            '*_templ.go' assets/styles.css assets/goshtoso-theme.css assets/js/*.js \
-            .agents/skills/using-goshtoso/references/components-reference.md \
-            .claude/skills/using-goshtoso/components-reference.md
-
-      - name: Verify both site-module contracts
-        run: |
-          scripts/check-site-module current-source
-          scripts/check-site-module pinned-dependency
-
-      - name: Authoritative full component coverage
+          name: release-e2e-results
+          path: |
+            .coverage/release.log
+            .coverage/e2e-results/
+          retention-days: 14
+          if-no-files-found: ignore
+      - name: Propagate release verification status
+        run: test "$(cat .coverage/status)" = 0
+      - name: Read authoritative coverage
         id: coverage
+        shell: bash
         run: |
           set -euo pipefail
-          scripts/run-release-coverage.sh --local-dry-run
-          percent="$(cat .coverage/percentage.txt)"
-          color="$(cat .coverage/color.txt)"
-          echo "percent=$percent" >> "$GITHUB_OUTPUT"
-          echo "color=$color" >> "$GITHUB_OUTPUT"
-          {
-            echo "### Authoritative release coverage"
-            echo
-            echo "Authored Go coverage: ${percent}%"
-            echo "Full generated-inclusive coverage: $(cat .coverage/full-percentage.txt)%"
-            echo
-            echo "Packages: $(wc -l < .coverage/component-packages.txt) publishable component packages"
-          } >> "$GITHUB_STEP_SUMMARY"
-
+          echo "percent=$(cat .coverage/percentage.txt)" >> "$GITHUB_OUTPUT"
+          echo "color=$(cat .coverage/color.txt)" >> "$GITHUB_OUTPUT"
       - name: Detect Codecov configuration
         id: codecov
+        shell: bash
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
+          set -euo pipefail
           configured=false
-          if [[ -n "$CODECOV_TOKEN" ]]; then
-            configured=true
-          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            echo "::error::CODECOV_TOKEN is required for tagged releases"
-            exit 1
-          else
-            echo "::warning::CODECOV_TOKEN is not configured; authored coverage will not be published"
+          if [[ -n "$CODECOV_TOKEN" ]]; then configured=true
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then exit 1
           fi
           echo "configured=$configured" >> "$GITHUB_OUTPUT"
-
       - name: Upload authored Go coverage to Codecov
         if: steps.codecov.outputs.configured == 'true'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           disable_search: true
           fail_ci_if_error: true
@@ -130,33 +68,13 @@ jobs:
           flags: authored-go
           name: release-authored-go
           token: ${{ secrets.CODECOV_TOKEN }}
-
       - name: Upload authoritative coverage
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: release-coverage
-          path: |
-            .coverage/component-packages.txt
-            .coverage/percentage.txt
-            .coverage/full-percentage.txt
-            .coverage/coverage-percent.txt
-            .coverage/coverage.out
-            .coverage/coverage-func.txt
-            .coverage/coverage.html
-            .coverage/coverage-authored.out
-            .coverage/coverage-authored-func.txt
-            .coverage/coverage-authored.html
+          path: .coverage/
           retention-days: 30
-          if-no-files-found: ignore
-
-      - name: Upload E2E artifacts on failure
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-e2e-results
-          path: site/tests/e2e/test-results/
-          retention-days: 14
           if-no-files-found: ignore
 
   publish:
@@ -165,54 +83,29 @@ jobs:
     needs: pre-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref }}
-
-      - name: Build release notes
+          persist-credentials: false
+      - name: Download verified coverage handoff
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-coverage
+          path: .coverage
+      - name: Materialize release identity
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
-          ver="$(sed -n '/^  tailwindcss:$/,/^  [^ ]/ s/^    version: "\([^"]*\)"/\1/p' muamba.yaml)"
-          test -n "$ver"
-          awk -v heading="## [${tag}]" '
-            index($0, heading) == 1 { found = 1; next }
-            found && /^## \[/ { exit }
-            found { print }
-            END { if (!found) exit 1 }
-          ' CHANGELOG.md > release-notes.md
-          {
-            echo
-            echo "## Build artifacts"
-            echo
-            echo "Built with Tailwind CSS ${ver}."
-            echo "Assets attached: \`styles.css\` and \`goshtoso-theme.css\`."
-          } >> release-notes.md
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
+          [[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+          jq -cn --arg tag "$RELEASE_TAG" '{tag:$tag}' > .release-handoff.json
+      - name: Publish release and badges through Dagger
+        uses: dagger/dagger-for-github@456fc3af63a2ba6f9789af9c55045b459115541b # v8.2.1
         with:
-          body_path: release-notes.md
-          files: |
-            assets/styles.css
-            assets/goshtoso-theme.css
-
-      - name: Update authoritative coverage badge gist
-        uses: schneegans/dynamic-badges-action@v1.9.0
-        with:
-          auth: ${{ secrets.GIST_TOKEN }}
-          gistID: fb3843c3a13793eb6cc0af638bc00ad4
-          filename: coverage.json
-          label: authored coverage
-          message: ${{ needs.pre-release.outputs.coverage-percent }}%
-          color: ${{ needs.pre-release.outputs.coverage-color }}
-
-      - name: Update release badge gist
-        uses: schneegans/dynamic-badges-action@v1.9.0
-        with:
-          auth: ${{ secrets.GIST_TOKEN }}
-          gistID: fb3843c3a13793eb6cc0af638bc00ad4
-          filename: release.json
-          label: release
-          message: ${{ github.ref_name }}
-          color: blue
+          version: '0.21.8'
+          verb: call
+          args: publish-release --source=. --coverage=.coverage --metadata=.release-handoff.json --github-token=env:GITHUB_RELEASE_TOKEN --gist-token=env:GIST_TOKEN --run-nonce=${{ github.run_id }}-${{ github.run_attempt }}
+        env:
+          GITHUB_RELEASE_TOKEN: ${{ github.token }}
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}

--- a/.github/workflows/required.yml
+++ b/.github/workflows/required.yml
@@ -13,12 +13,15 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: '1.26.5'
-
 jobs:
   required:
     name: Required CI
+    env:
+      CACHE_PARTITION: >-
+        ${{
+          github.event_name == 'push' && 'trusted-main' ||
+          'untrusted-github'
+        }}
     runs-on: >-
       ${{
         github.event_name == 'pull_request' &&
@@ -29,20 +32,24 @@ jobs:
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.head.repo.fork == false &&
         contains(fromJSON(vars.HOSTINGER_PR_ACTORS_JSON || '[]'), github.actor) &&
-        fromJSON('["self-hosted","Linux","X64","hostinger-vps"]') ||
+        fromJSON('["self-hosted","Linux","X64","hostinger-vps-pr"]') ||
         'ubuntu-latest'
       }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-
-      - uses: actions/setup-go@v7
+      - name: Dagger pinned-dependency deployability (embedded CLI)
+        if: runner.environment == 'self-hosted'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(dagger version | awk '{print $2}')" = v0.21.8
+          dagger call required --source=. --cache-partition="$CACHE_PARTITION"
+      - name: Dagger pinned-dependency deployability
+        if: runner.environment != 'self-hosted'
+        uses: dagger/dagger-for-github@456fc3af63a2ba6f9789af9c55045b459115541b # v8.2.1
         with:
-          go-version: ${{ env.GO_VERSION }}
-          # Required CI runs on ephemeral Hostinger capacity for trusted PRs;
-          # setup-go cache finalization can otherwise strand a successful job.
-          cache: false
-
-      - name: Pinned-dependency deployability (site module)
-        run: ./scripts/check-site-module pinned-dependency
+          version: '0.21.8'
+          verb: call
+          args: required --source=. --cache-partition=${{ env.CACHE_PARTITION }}

--- a/.github/workflows/runner-smoke-test.yml
+++ b/.github/workflows/runner-smoke-test.yml
@@ -3,24 +3,32 @@ name: GitHub-hosted Runner Smoke Test
 on:
   workflow_dispatch:
   push:
-    paths:
-      - .github/workflows/runner-smoke-test.yml
+    paths: ['.github/workflows/runner-smoke-test.yml', '.dagger/**', 'dagger.json']
+
+permissions:
+  contents: read
 
 jobs:
   smoke:
     name: GitHub-hosted runner smoke test
     runs-on: ubuntu-24.04
     steps:
-      - name: Runner identity
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Audit committed Dagger bootstrap lock
+        run: npm audit --prefix .dagger --package-lock-only --omit=dev --audit-level=high
+      - name: Materialize provider Git identity
+        shell: bash
+        env:
+          REVISION: ${{ github.sha }}
         run: |
-          echo "hostname: $(hostname)"
-          echo "uname: $(uname -a)"
-          echo "whoami: $(whoami)"
-          echo "pwd: $(pwd)"
-
-      - uses: actions/checkout@v7
-
-      - name: Repo checkout sanity
-        run: |
-          echo "git rev: $(git rev-parse HEAD)"
-          ls -la | head -20
+          set -euo pipefail
+          [[ "$REVISION" =~ ^[0-9a-f]{40}$ ]]
+          jq -cn --arg revision "$REVISION" '{revision:$revision}' > .runner-identity.json
+      - name: Runner-to-Dagger smoke proof
+        uses: dagger/dagger-for-github@456fc3af63a2ba6f9789af9c55045b459115541b # v8.2.1
+        with:
+          version: '0.21.8'
+          verb: call
+          args: smoke --source=. --identity=.runner-identity.json --run-nonce=${{ github.run_id }}-${{ github.run_attempt }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ examples/getting-started/getting-started
 *.out
 .coverage/
 .e2e-impact.json
+.e2e-changes
 
 # Dependency directories (Go vendor)
 vendor/
@@ -46,6 +47,10 @@ Thumbs.db
 # Node modules (if using npm for anything)
 node_modules/
 node_modules
+.dagger/node_modules/
+.dagger/sdk/
+.dagger-output/
+.dagger-assets/
 
 # Claude Code local worktrees
 .claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -297,6 +297,37 @@ go work init . ./site
 
 ## Development
 
+### Dagger CI locally
+
+All repository CI gates are implemented by the Dagger module pinned to
+`v0.21.8`; GitHub Actions only supplies event routing, immutable identities,
+secrets, and artifact/publication adapters. Run the same safe gates locally:
+
+```bash
+nonce=$(uuidgen)
+dagger call lint-build --source=. --cache-partition=local
+dagger call required --source=. --cache-partition=local
+dagger call docs --source=. --cache-partition=local
+
+# Supply a committed range for conservative focused E2E selection. This
+# boundary file works from ordinary clones and linked Git worktrees alike.
+base=$(git merge-base origin/main HEAD)
+git diff --name-status -z -M "$base" HEAD > .e2e-changes
+dagger call tests --source=. --changes=.e2e-changes \
+  --cache-partition=local --run-nonce="$nonce" export --path=.dagger-output
+```
+
+Release verification is also safe locally and performs no publication:
+
+```bash
+dagger call release-verify --source=. --cache-partition=local \
+  --run-nonce="$(uuidgen)" export --path=.coverage
+```
+
+Cache namespaces are explicitly partitioned into `local`, trusted CI, and
+untrusted CI domains. Every effectful or externally mutable entry point also
+requires a fresh nonce; GitHub uses `run_id-run_attempt`.
+
 Useful commands from the repo root:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -309,10 +309,11 @@ dagger call lint-build --source=. --cache-partition=local
 dagger call required --source=. --cache-partition=local
 dagger call docs --source=. --cache-partition=local
 
-# Supply a committed range for conservative focused E2E selection. This
-# boundary file works from ordinary clones and linked Git worktrees alike.
+# Supply a committed range for conservative focused E2E selection. Dirty
+# staged, unstaged, or untracked source forces the full suite so selection and
+# the Dagger source snapshot cannot diverge.
 base=$(git merge-base origin/main HEAD)
-git diff --name-status -z -M "$base" HEAD > .e2e-changes
+scripts/materialize-e2e-changes "$base" HEAD .e2e-changes
 dagger call tests --source=. --changes=.e2e-changes \
   --cache-partition=local --run-nonce="$nonce" export --path=.dagger-output
 ```

--- a/cmd/e2eimpact/main.go
+++ b/cmd/e2eimpact/main.go
@@ -13,8 +13,19 @@ import (
 func main() {
 	base := flag.String("base", "", "ancestor commit at the start of the change range")
 	head := flag.String("head", "HEAD", "commit at the end of the change range")
+	changesFile := flag.String("changes-file", "", "NUL-delimited git diff --name-status -z -M stream")
 	flag.Parse()
-	result := e2eimpact.Select(context.Background(), ".", *base, *head)
+	var result e2eimpact.Result
+	if *changesFile != "" {
+		data, err := os.ReadFile(*changesFile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		result = e2eimpact.SelectNameStatus(context.Background(), ".", data)
+	} else {
+		result = e2eimpact.Select(context.Background(), ".", *base, *head)
+	}
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(result); err != nil {

--- a/dagger.json
+++ b/dagger.json
@@ -1,0 +1,8 @@
+{
+  "name": "goshtoso",
+  "engineVersion": "v0.21.8",
+  "sdk": {
+    "source": "typescript"
+  },
+  "source": ".dagger"
+}

--- a/internal/e2eimpact/select.go
+++ b/internal/e2eimpact/select.go
@@ -9,6 +9,18 @@ import (
 	"slices"
 )
 
+// SelectNameStatus calculates the safe E2E scope from a NUL-delimited
+// `git diff --name-status -z -M` stream supplied by a trusted Git boundary.
+// Keeping Git metadata outside the source Directory makes Dagger calls work
+// from both ordinary clones and linked worktrees.
+func SelectNameStatus(ctx context.Context, repoRoot string, data []byte) Result {
+	changes, err := parseNameStatus(data)
+	if err != nil {
+		return fullResult(nil, "invalid Git name-status stream: "+err.Error())
+	}
+	return selectChanges(ctx, repoRoot, changes)
+}
+
 type identityRecord struct {
 	Name  string   `json:"name"`
 	Files []string `json:"files"`

--- a/scripts/dagger_ci_contract_test.go
+++ b/scripts/dagger_ci_contract_test.go
@@ -292,7 +292,7 @@ func TestDaggerTestsAcquireTailwindBeforeCSSBuild(t *testing.T) {
 	}
 }
 
-func TestDaggerDocsExtractsLycheeFromVersionedArchiveDirectory(t *testing.T) {
+func TestDaggerDocsUsesPinnedStaticLycheeArchive(t *testing.T) {
 	t.Parallel()
 	root, err := filepath.Abs("..")
 	if err != nil {
@@ -310,12 +310,20 @@ func TestDaggerDocsExtractsLycheeFromVersionedArchiveDirectory(t *testing.T) {
 	}
 	body := module[start:end]
 	for _, expected := range []string{
-		"dir=lychee-$arch-unknown-linux-gnu",
+		`const LYCHEE_VERSION = "v0.24.2"`,
+		`const LYCHEE_X86_64_SHA256 = "73657a111819a30c47c08352896796f23d64e4eb2b3ed39b6d32149241566fc5"`,
+		`const LYCHEE_AARCH64_SHA256 = "5d0b0e3aeab240f41920c633a6eaf97599be6eedda034b36e858ede7dba5e535"`,
+		"file=lychee-$arch-unknown-linux-musl.tar.gz",
+		"dir=lychee-$arch-unknown-linux-musl",
+		`releases/download/lychee-${LYCHEE_VERSION}/$file`,
 		`--strip-components=1 "$dir/lychee"`,
 	} {
-		if !strings.Contains(body, expected) {
-			t.Fatalf("Dagger docs must extract the versioned lychee archive member %q", expected)
+		if !strings.Contains(module, expected) {
+			t.Fatalf("Dagger docs must use the pinned static lychee release contract %q", expected)
 		}
+	}
+	if strings.Contains(body, "unknown-linux-gnu") {
+		t.Fatal("Dagger docs must not use the glibc-dependent lychee archive")
 	}
 }
 

--- a/scripts/dagger_ci_contract_test.go
+++ b/scripts/dagger_ci_contract_test.go
@@ -1,0 +1,269 @@
+package scripts_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestDaggerWorkflowSecurityAndArtifactContracts(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	read := func(name string) string {
+		t.Helper()
+		data, readErr := os.ReadFile(filepath.Join(root, name))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		return string(data)
+	}
+
+	all := read(".github/workflows/araihu-assets.yml") + read(".github/workflows/ci.yml") +
+		read(".github/workflows/deploy.yml") + read(".github/workflows/docs.yml") +
+		read(".github/workflows/release.yml") + read(".github/workflows/required.yml") +
+		read(".github/workflows/runner-smoke-test.yml")
+	if strings.Contains(strings.ToLower(all), "coderabbit") {
+		t.Fatal("CodeRabbit must be absent from authored pipelines")
+	}
+	unsafeArg := regexp.MustCompile(`args:.*\$\{\{[^}]*(client_payload|workflow_run|ref_name)`) // external strings must cross a file boundary
+	if unsafeArg.MatchString(all) {
+		t.Fatal("external event data is interpolated into dagger-for-github args")
+	}
+
+	for _, expected := range []string{"runner.environment == 'self-hosted'", "dagger version | awk", "v0.21.8"} {
+		if !strings.Contains(all, expected) {
+			t.Fatalf("missing embedded-runner contract %q", expected)
+		}
+	}
+	for _, expected := range []string{".dagger-output/status", ".dagger-output/tests.log", ".coverage/status", ".coverage/release.log"} {
+		if !strings.Contains(all, expected) {
+			t.Fatalf("missing failure-artifact contract %q", expected)
+		}
+	}
+
+	module := read(".dagger/src/index.ts")
+	for _, expected := range []string{"LYCHEE_X86_64_SHA256", "LYCHEE_AARCH64_SHA256", "expect: ReturnType.Any", "private async json", "ghcr.io/jqlang/jq:1.8.2@sha256:b9c68867e5766576263a222e91db3de422d802069c7af70440e667a95344e486", "node:24.19.0-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03"} {
+		if !strings.Contains(module, expected) {
+			t.Fatalf("missing Dagger module contract %q", expected)
+		}
+	}
+	if strings.Contains(module, `"gh", "jq"`) {
+		t.Fatal("jq must come from the pinned image, not the mutable apt repository")
+	}
+	if strings.Contains(module, `"npm", "audit", "--prefix", ".dagger"`) || strings.Contains(module, `"npm", "ls"`) {
+		t.Fatal("Dagger module must not claim its skeletal local-SDK lock proves the generated runtime graph")
+	}
+	for _, authored := range []string{read("dagger.json"), module} {
+		if strings.Contains(strings.ToLower(authored), "coderabbit") {
+			t.Fatal("CodeRabbit must be absent from the authored Dagger module")
+		}
+	}
+}
+
+func TestAssetsHandoffSurvivesCheckoutAndPrecedesWriteToken(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".github/workflows/araihu-assets.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assets := string(data)
+	checkout := strings.Index(assets, "Check out Goshtoso read-only")
+	handoff := strings.Index(assets, "Validate and materialize immutable handoff")
+	token := strings.Index(assets, "Create selected-repository App token")
+	daggerCall := strings.Index(assets, "Validate and update fallback assets through Dagger")
+	if checkout < 0 || handoff <= checkout || token <= handoff || daggerCall <= token {
+		t.Fatalf("Assets provider boundary/order is unsafe: checkout=%d handoff=%d token=%d dagger=%d", checkout, handoff, token, daggerCall)
+	}
+	if strings.Count(assets, "actions/checkout@") != 1 || !strings.Contains(assets[checkout:handoff], "persist-credentials: false") {
+		t.Fatal("Assets workflow must materialize the handoff after one read-only checkout")
+	}
+}
+
+func TestDaggerBootstrapAuditPrecedesRealRuntimeSmoke(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".github/workflows/runner-smoke-test.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	smoke := string(data)
+	bootstrapAudit := strings.Index(smoke, "Audit committed Dagger bootstrap lock")
+	runtimeProof := strings.Index(smoke, "Runner-to-Dagger smoke proof")
+	if bootstrapAudit < 0 || runtimeProof <= bootstrapAudit || !strings.Contains(smoke, "npm audit --prefix .dagger --package-lock-only --omit=dev --audit-level=high") {
+		t.Fatal("runner smoke must audit only the committed bootstrap lock before the real generated-runtime Dagger proof")
+	}
+}
+
+func TestDaggerGeneratedTypescriptPackageContract(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg := readJSON(t, root, ".dagger/package.json")
+	dependencies, ok := pkg["dependencies"].(map[string]any)
+	if !ok {
+		t.Fatal("Dagger package dependencies missing")
+	}
+	if dependencies["@dagger.io/dagger"] != "./sdk" {
+		t.Fatal("Dagger TypeScript package must consume the Engine-generated local SDK")
+	}
+	if dependencies["typescript"] != "^6.0.3" {
+		t.Fatal("TypeScript must be a runtime dependency compatible with the generated SDK")
+	}
+	if _, exists := pkg["devDependencies"]; exists {
+		t.Fatal("Dagger runtime dependencies must not be hidden in devDependencies")
+	}
+	if _, exists := pkg["overrides"]; exists {
+		t.Fatal("committed bootstrap package must not override the Engine-generated SDK graph")
+	}
+}
+
+func TestDaggerGeneratedTypescriptLockContract(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock := readJSON(t, root, ".dagger/package-lock.json")
+	packages, ok := lock["packages"].(map[string]any)
+	if !ok {
+		t.Fatal("Dagger lock packages missing")
+	}
+	rootPackage, ok := packages[""].(map[string]any)
+	if !ok {
+		t.Fatal("Dagger lock root package missing")
+	}
+	lockedDependencies, ok := rootPackage["dependencies"].(map[string]any)
+	if !ok || lockedDependencies["@dagger.io/dagger"] != "./sdk" || lockedDependencies["typescript"] != "^6.0.3" {
+		t.Fatal("Dagger lock must preserve the local generated SDK and runtime TypeScript contract")
+	}
+	if _, exists := rootPackage["overrides"]; exists {
+		t.Fatal("committed bootstrap lock must not encode overrides for the generated SDK graph")
+	}
+	linkedSDK, ok := packages["node_modules/@dagger.io/dagger"].(map[string]any)
+	if !ok || linkedSDK["resolved"] != "sdk" || linkedSDK["link"] != true {
+		t.Fatal("Dagger lock must link node_modules/@dagger.io/dagger to sdk")
+	}
+}
+
+func TestDaggerGeneratedSDKIsRuntimeOnly(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracked := exec.Command("git", "ls-files", "--", ".dagger/sdk")
+	tracked.Dir = root
+	output, err := tracked.Output()
+	if err != nil {
+		t.Fatalf("inspect tracked generated SDK: %v", err)
+	}
+	if strings.TrimSpace(string(output)) != "" {
+		t.Fatal("generated Dagger SDK bytes must not be committed")
+	}
+	moduleData, err := os.ReadFile(filepath.Join(root, ".dagger/src/index.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	module := string(moduleData)
+	for _, excluded := range []string{`".dagger/sdk"`, `".dagger/sdk/**"`} {
+		if !strings.Contains(module, excluded) {
+			t.Fatalf("generated Dagger SDK must be excluded from source snapshots: %s", excluded)
+		}
+	}
+	workflowData, err := os.ReadFile(filepath.Join(root, ".github/workflows/runner-smoke-test.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	authored := strings.ToLower(module + "\n" + string(workflowData))
+	for _, forbidden := range []string{"npm audit --prefix .dagger/sdk", `"npm", "audit", "--prefix", ".dagger/sdk"`, "npm ls --prefix .dagger/sdk", `"npm", "ls", "--prefix", ".dagger/sdk"`} {
+		if strings.Contains(authored, forbidden) {
+			t.Fatalf("authored CI falsely audits the Engine-generated SDK graph: %s", forbidden)
+		}
+	}
+}
+
+func readJSON(t *testing.T, root, name string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(data, &value); err != nil {
+		t.Fatalf("decode %s: %v", name, err)
+	}
+	return value
+}
+
+func TestPullRequestsUseHostIsolatedPersistentDaggerCaches(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	read := func(name string) string {
+		t.Helper()
+		data, readErr := os.ReadFile(filepath.Join(root, name))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		return string(data)
+	}
+
+	for _, workflow := range []string{".github/workflows/ci.yml", ".github/workflows/docs.yml", ".github/workflows/required.yml"} {
+		content := read(workflow)
+		if strings.Contains(content, "'trusted-hostinger' || 'untrusted-github'") {
+			t.Fatalf("%s lets an internal PR select a persistent cache domain", workflow)
+		}
+		if !strings.Contains(content, "github.event_name == 'push' && 'trusted-main' ||\n") || !strings.Contains(content, "'untrusted-github'") {
+			t.Fatalf("%s does not map every PR to the untrusted provider domain", workflow)
+		}
+		if !strings.Contains(content, `"hostinger-vps-pr"`) || strings.Contains(content, `"hostinger-vps"`) {
+			t.Fatalf("%s does not select the exact host-owned PR lane", workflow)
+		}
+	}
+
+	module := read(".dagger/src/index.ts")
+	if !strings.Contains(module, `/^(untrusted|fork|internal)(-|$)/`) {
+		t.Fatal("Dagger module must classify fork and internal PR domains as untrusted")
+	}
+	for _, bounds := range [][2]string{
+		{"private base(", "private goProject("},
+		{"private goProject(", "private browserProject("},
+		{"private browserProject(", "private partition("},
+	} {
+		start := strings.Index(module, bounds[0])
+		end := strings.Index(module, bounds[1])
+		if start < 0 || end <= start {
+			t.Fatalf("cannot locate cache builder %q", bounds[0])
+		}
+		body := module[start:end]
+		guard := strings.Index(body, "cacheNamespace")
+		mount := strings.Index(body, "withMountedCache")
+		if guard < 0 || mount < 0 || guard > mount {
+			t.Fatalf("%s must guard before its first persistent CacheVolume mount", bounds[0])
+		}
+	}
+	if strings.Count(module, "withMountedCache") < 5 {
+		t.Fatal("trusted main, release, assets, and local domains must retain effective caches")
+	}
+	if !strings.Contains(module, "if (this.isUntrustedPartition(value)) return \"pr\"") {
+		t.Fatal("PR cache namespace must stay centralized as constant pr behind the host-owned Engine boundary")
+	}
+}

--- a/scripts/dagger_ci_contract_test.go
+++ b/scripts/dagger_ci_contract_test.go
@@ -352,6 +352,101 @@ func TestDaggerSerializesSharedToolCacheWriters(t *testing.T) {
 	}
 }
 
+func TestDaggerCachesMatchingPlaywrightDriverAndBrowsers(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".dagger/src/index.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	module := string(data)
+	for _, expected := range []string{
+		`const PLAYWRIGHT_VERSION = "v0.6100.0"`,
+		`const PLAYWRIGHT_DRIVER_VERSION = "1.61.1"`,
+		`.withEnvVariable("PLAYWRIGHT_DRIVER_PATH", "/playwright/driver")`,
+		`ready=/playwright/.chromium-${PLAYWRIGHT_DRIVER_VERSION}-ready`,
+		`! test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js"`,
+		`! test -x "$PLAYWRIGHT_DRIVER_PATH/node"`,
+		`rm -rf -- "$PLAYWRIGHT_DRIVER_PATH"; rm -f -- "$ready"`,
+		`playwright install --with-deps chromium; test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js"; test -x "$PLAYWRIGHT_DRIVER_PATH/node"`,
+		`marker_tmp="$ready.tmp.$$"; : > "$marker_tmp"; mv -f -- "$marker_tmp" "$ready"`,
+		`goshtoso-${cacheNamespace}-playwright-${PLAYWRIGHT_VERSION}`,
+	} {
+		if !strings.Contains(module, expected) {
+			t.Fatalf("missing Playwright driver/browser cache contract %q", expected)
+		}
+	}
+}
+
+func TestPlaywrightWarmMarkerWithoutDriverReinstalls(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	driver := filepath.Join(root, "playwright", "driver")
+	ready := filepath.Join(root, "playwright", ".chromium-1.61.1-ready")
+	installLog := filepath.Join(root, "install.log")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(ready), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(driver, "package"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(driver, "package", "cli.js"), []byte("partial"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(ready, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fake := `#!/bin/sh
+set -eu
+test "$*" = "install --with-deps chromium"
+test ! -e "$PLAYWRIGHT_DRIVER_PATH"
+test ! -e "$PLAYWRIGHT_READY"
+mkdir -p "$PLAYWRIGHT_DRIVER_PATH/package"
+: > "$PLAYWRIGHT_DRIVER_PATH/package/cli.js"
+printf '#!/bin/sh\n' > "$PLAYWRIGHT_DRIVER_PATH/node"
+chmod +x "$PLAYWRIGHT_DRIVER_PATH/node"
+: > "$PLAYWRIGHT_INSTALL_LOG"
+`
+	if err := os.WriteFile(filepath.Join(bin, "playwright"), []byte(fake), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	script := `set -euo pipefail
+ready="$PLAYWRIGHT_READY"
+if ! test -f "$ready" || ! test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js" || ! test -x "$PLAYWRIGHT_DRIVER_PATH/node"; then
+  rm -rf -- "$PLAYWRIGHT_DRIVER_PATH"
+  rm -f -- "$ready"
+  playwright install --with-deps chromium
+  test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js"
+  test -x "$PLAYWRIGHT_DRIVER_PATH/node"
+  marker_tmp="$ready.tmp.$$"
+  : > "$marker_tmp"
+  mv -f -- "$marker_tmp" "$ready"
+fi`
+	cmd := exec.Command("bash", "-c", script)
+	cmd.Env = append(os.Environ(),
+		"PATH="+bin+":"+os.Getenv("PATH"),
+		"PLAYWRIGHT_DRIVER_PATH="+driver,
+		"PLAYWRIGHT_READY="+ready,
+		"PLAYWRIGHT_INSTALL_LOG="+installLog,
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("warm marker recovery failed: %v\n%s", err, output)
+	}
+	for _, path := range []string{installLog, filepath.Join(driver, "package", "cli.js"), filepath.Join(driver, "node"), ready} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected recovered Playwright artifact %s: %v", path, err)
+		}
+	}
+}
+
 func TestDaggerInstallsVerifiedGolangCILintArchives(t *testing.T) {
 	t.Parallel()
 	root, err := filepath.Abs("..")

--- a/scripts/dagger_ci_contract_test.go
+++ b/scripts/dagger_ci_contract_test.go
@@ -267,3 +267,238 @@ func TestPullRequestsUseHostIsolatedPersistentDaggerCaches(t *testing.T) {
 		t.Fatal("PR cache namespace must stay centralized as constant pr behind the host-owned Engine boundary")
 	}
 }
+
+func TestDaggerTestsAcquireTailwindBeforeCSSBuild(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".dagger/src/index.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	module := string(data)
+	start := strings.Index(module, "  tests(")
+	end := strings.Index(module, "  /** Standalone site/go.mod consumer contract")
+	if start < 0 || end <= start {
+		t.Fatal("cannot locate Dagger tests pipeline")
+	}
+	body := module[start:end]
+	acquire := strings.Index(body, "go tool muamba sync --strict --target linux/amd64 --cache-dir .cache/muamba tailwindcss/cli")
+	build := strings.Index(body, ".tools/tailwindcss -i css/main.css -o assets/styles.css")
+	if acquire < 0 || build <= acquire {
+		t.Fatalf("Dagger tests must acquire locked Tailwind before CSS build: acquire=%d build=%d", acquire, build)
+	}
+}
+
+func TestDaggerDocsExtractsLycheeFromVersionedArchiveDirectory(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".dagger/src/index.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	module := string(data)
+	start := strings.Index(module, "  async docs(")
+	end := strings.Index(module, "  /** Full release-equivalent regeneration")
+	if start < 0 || end <= start {
+		t.Fatal("cannot locate Dagger docs pipeline")
+	}
+	body := module[start:end]
+	for _, expected := range []string{
+		"dir=lychee-$arch-unknown-linux-gnu",
+		`--strip-components=1 "$dir/lychee"`,
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("Dagger docs must extract the versioned lychee archive member %q", expected)
+		}
+	}
+}
+
+func TestDaggerSerializesSharedToolCacheWriters(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".dagger/src/index.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	module := string(data)
+	for _, expected := range []string{
+		"CacheSharingMode,",
+		`withMountedCache("/tools", dag.cacheVolume(`,
+		`withMountedCache("/playwright", dag.cacheVolume(`,
+	} {
+		if !strings.Contains(module, expected) {
+			t.Fatalf("missing shared tool cache contract %q", expected)
+		}
+	}
+	if strings.Count(module, "{ sharing: CacheSharingMode.Locked }") != 2 {
+		t.Fatal("tool and Playwright caches must both serialize check-then-install writers")
+	}
+}
+
+func TestDaggerInstallsVerifiedGolangCILintArchives(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".dagger/src/index.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	module := string(data)
+	if strings.Contains(module, "raw.githubusercontent.com/golangci/golangci-lint") || strings.Contains(module, "install.sh | sh") {
+		t.Fatal("golangci-lint must not execute a remote installer script")
+	}
+	for _, expected := range []string{
+		`const GOLANGCI_LINT_AMD64_SHA256 = "8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"`,
+		`const GOLANGCI_LINT_ARM64_SHA256 = "44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"`,
+		`file=golangci-lint-2.12.2-linux-$arch.tar.gz`,
+		`dir=\${file%.tar.gz}`,
+		`echo "$sha  /tmp/golangci-lint.tgz" | sha256sum -c -`,
+		`--strip-components=1 "$dir/golangci-lint"`,
+	} {
+		if !strings.Contains(module, expected) {
+			t.Fatalf("missing verified golangci-lint archive contract %q", expected)
+		}
+	}
+}
+
+func TestLocalE2EChangeProviderPreservesCleanCommittedRange(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := filepath.Join(root, "scripts/materialize-e2e-changes")
+	repo := newGitRepo(t)
+	base := strings.TrimSpace(runGitOutput(t, repo, "rev-parse", "HEAD"))
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("committed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "tracked.txt")
+	runGit(t, repo, "commit", "-qm", "change")
+	output := filepath.Join(repo, ".e2e-changes")
+	command := exec.Command(provider, base, "HEAD", output)
+	command.Dir = repo
+	if combined, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("materialize clean E2E changes: %v: %s", err, combined)
+	}
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "M\x00tracked.txt\x00" {
+		t.Fatalf("clean committed range changed bytes: %q", data)
+	}
+}
+
+func TestAssetsWorkflowPreservesDataFileModes(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".github/workflows/araihu-assets.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(data)
+	if !strings.Contains(workflow, `install -D -m 0644 ".dagger-assets/$path" "$path"`) {
+		t.Fatal("asset materialization must preserve non-executable 0644 modes")
+	}
+}
+
+func TestLocalE2EChangeProviderForcesFullForDirtySource(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider := filepath.Join(root, "scripts/materialize-e2e-changes")
+
+	for _, test := range []struct {
+		name  string
+		dirty func(t *testing.T, repo string)
+	}{
+		{name: "unstaged", dirty: func(t *testing.T, repo string) {
+			t.Helper()
+			if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("unstaged\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "staged", dirty: func(t *testing.T, repo string) {
+			t.Helper()
+			if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("staged\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			runGit(t, repo, "add", "tracked.txt")
+		}},
+		{name: "untracked", dirty: func(t *testing.T, repo string) {
+			t.Helper()
+			if err := os.WriteFile(filepath.Join(repo, "untracked.txt"), []byte("untracked\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			repo := newGitRepo(t)
+			test.dirty(t, repo)
+			output := filepath.Join(repo, ".e2e-changes")
+			command := exec.Command(provider, "HEAD", "HEAD", output)
+			command.Dir = repo
+			if combined, err := command.CombinedOutput(); err != nil {
+				t.Fatalf("materialize E2E changes: %v: %s", err, combined)
+			}
+			data, err := os.ReadFile(output)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data) != "M\x00.dagger-dirty-worktree\x00" {
+				t.Fatalf("dirty source did not force full E2E selection: %q", data)
+			}
+		})
+	}
+}
+
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-q")
+	runGit(t, repo, "config", "user.name", "Dagger contract")
+	runGit(t, repo, "config", "user.email", "dagger-contract@invalid")
+	if err := os.WriteFile(filepath.Join(repo, "tracked.txt"), []byte("clean\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "tracked.txt")
+	runGit(t, repo, "commit", "-qm", "baseline")
+	return repo
+}
+
+func runGit(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = repo
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, output)
+	}
+}
+
+func runGitOutput(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = repo
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}

--- a/scripts/materialize-e2e-changes
+++ b/scripts/materialize-e2e-changes
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: scripts/materialize-e2e-changes <base> [head] [output]" >&2
+  exit 2
+}
+
+(( $# >= 1 && $# <= 3 )) || usage
+base=$1
+head=${2:-HEAD}
+output=${3:-.e2e-changes}
+
+output_dir=$(dirname -- "$output")
+test -d "$output_dir" || { echo "output directory does not exist: $output_dir" >&2; exit 1; }
+temporary=$(mktemp "${TMPDIR:-/tmp}/goshtoso-e2e-changes.XXXXXX")
+trap 'rm -f -- "$temporary"' EXIT
+
+force_full() {
+  printf 'M\0%s\0' "$1" > "$temporary"
+  mv -f -- "$temporary" "$output"
+  trap - EXIT
+}
+
+# A committed range cannot describe staged, unstaged, or untracked bytes that
+# Dagger includes in --source=.; force a conservative full E2E selection.
+if [[ -n "$(git status --porcelain=v1 --untracked-files=all)" ]]; then
+  force_full .dagger-dirty-worktree
+  exit 0
+fi
+
+if [[ ! "$base" =~ ^[0-9a-fA-F]{40}$ ]] ||
+   ! git cat-file -e "$base^{commit}" 2>/dev/null ||
+   ! git cat-file -e "$head^{commit}" 2>/dev/null ||
+   ! git merge-base --is-ancestor "$base" "$head"; then
+  force_full .dagger-unsafe-range
+  exit 0
+fi
+
+git diff --name-status -z -M "$base" "$head" > "$temporary"
+mv -f -- "$temporary" "$output"
+trap - EXIT


### PR DESCRIPTION
## Summary

- migrate authored CI, docs, release, deploy, asset, and runner-smoke workflows to thin Dagger v0.21.8 adapters
- expose portable local/CI functions with exact CLI verification, typed secrets, effect nonces, and artifact handoffs
- isolate self-hosted PR work on `hostinger-vps-pr` and use stable `pr` cache namespaces on the host-owned Engine boundary
- add workflow/module regression coverage and local execution documentation
- remove CodeRabbit pipeline references while preserving required gates

## Related issue

N/A

## Type of change

- [ ] Bug fix
- [ ] New component / variant
- [ ] Visual-parity fix
- [x] Docs
- [x] Tests / CI
- [x] Refactor / chore

## Validation

- [x] `go test ./... -count=1`
- [x] `golangci-lint run` for root and site
- [x] Dagger workflow contract tests
- [x] `actionlint`
- [x] TypeScript `tsc --noEmit` against generated Dagger SDK fixture
- [x] npm audit for committed dependency graph reports zero high vulnerabilities
- [x] independent identity-bound review accepted the exact candidate

No deployment, release, publication, or external effect was executed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Dagger-powered automation for linting, builds, tests, documentation checks, releases, deployments, and asset updates.
  - Added focused end-to-end test selection based on changed files and repository change metadata.
  - Added local instructions for running CI and release checks.

- **Bug Fixes**
  - Improved workflow validation, security restrictions, cache isolation, artifact handling, and deployment metadata verification.
  - Added safeguards for repeatable asset updates and release publishing.

- **Documentation**
  - Documented local Dagger CI commands, cache partitions, and run requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->