### PR TITLE
ci: smoke test reusable Reviewdog action

### DIFF
--- a/.github/workflows/reviewdog-smoke.yml
+++ b/.github/workflows/reviewdog-smoke.yml
@@ -27,7 +27,7 @@ jobs:
           printf '0\n' > .reviewdog/status
 
       - name: Publish smoke annotation
-        uses: araihu/dagger/actions/reviewdog@e17a36dea4d92ec9f1e8498d4281f5ab7de6e535
+        uses: araihu/dagger/actions/reviewdog@2513b9f8f9afc7e5166fc695f5d2a8be4f955d5f
         with:
           manifest: .reviewdog/manifest.json
           token: ${{ github.token }}

--- a/.github/workflows/reviewdog-smoke.yml
+++ b/.github/workflows/reviewdog-smoke.yml
@@ -1,0 +1,36 @@
+name: Reviewdog smoke
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  annotate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Prepare synthetic Dagger-compatible reports
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .reviewdog
+          printf '%s\n' '{"schema":1,"reports":[{"name":"reviewdog-smoke","path":"diagnostics.rdjsonl","format":"rdjsonl","level":"info","filter_mode":"nofilter"}]}' > .reviewdog/manifest.json
+          printf '%s\n' '{"message":"Arai Hû Reviewdog smoke annotation","location":{"path":"README.md","range":{"start":{"line":1,"column":1}}},"severity":"INFO","code":{"value":"reviewdog-smoke"}}' > .reviewdog/diagnostics.rdjsonl
+          printf '0\n' > .reviewdog/status
+
+      - name: Publish smoke annotation
+        uses: araihu/dagger/actions/reviewdog@e17a36dea4d92ec9f1e8498d4281f5ab7de6e535
+        with:
+          manifest: .reviewdog/manifest.json
+          token: ${{ github.token }}
+
+      - name: Preserve producer gate
+        run: test "$(cat .reviewdog/status)" = 0


### PR DESCRIPTION
Validates one PR annotation from the immutable Arai Hû Reviewdog action.

Action: e17a36dea4d92ec9f1e8498d4281f5ab7de6e535
Pilot: 0acc93f37d739efc6c4d50cb876b00188af89c90

Scope: one synthetic Dagger-compatible RDJSONL report, read-only permissions, and preserved producer status gate.

Smoke result:
- Run: https://github.com/araihu/goshtoso/actions/runs/32199429378
- Check run: 95909871195
- Exactly one `warning` annotation at `README.md:1`
- Message/code: `Arai Hû Reviewdog smoke annotation` / `reviewdog-smoke`
- Reviewdog v0.21.0 checksum verification: pass
- Secret-pattern log scan: clean

No merge requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an automated smoke check for pull requests targeting the main branch.
  * Verifies that review annotations are published successfully and the reporting process completes without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->