### PR TITLE
fix(release): publish refreshed consumer skill

### DIFF
--- a/.agents/skills/using-goshtoso/SKILL.md
+++ b/.agents/skills/using-goshtoso/SKILL.md
@@ -68,7 +68,7 @@ Use this path unless the app deliberately owns a custom Tailwind build.
 Goshtoso requires **Go 1.26.5 or newer**.
 
 ```bash
-GOSHTOSO_VERSION="${GOSHTOSO_VERSION:?set a release such as v0.1.13}"
+GOSHTOSO_VERSION="${GOSHTOSO_VERSION:?set an explicit Goshtoso release}"
 go get github.com/araihu/goshtoso@"$GOSHTOSO_VERSION"
 go get github.com/a-h/templ
 TEMPL_VERSION="$(go list -m -f '{{.Version}}' github.com/a-h/templ)"
@@ -178,6 +178,23 @@ between constructors or configuration fields. It documents the common
 component interface, concrete return values, constructor styles, stable Kind
 identity, and rendered defaults.
 
+Choose action and overlay primitives by behavior:
+
+- Use `button` or `link` for one action or destination.
+- Use `dropdown` for a menu of actions or destinations.
+- Use `popover` for arbitrary consumer-owned content anchored to one trigger;
+  do not rebuild a menu with it when `dropdown` already supplies menu semantics.
+- Use `splitbutton` for one always-visible dominant action plus a related
+  `dropdown` menu.
+- Use `actiongroup` for one required primary action plus prioritized secondary
+  actions that may move into overflow.
+
+For two-level navigation, use `navbar.Config.Secondary` when the row belongs to
+the Navbar, or `navbar.SecondaryRow` when an App Shell owns the primary frame.
+Use primitive `SecondaryConfig.Links` for ordinary navigation and `Content`
+only for a consumer-owned replacement. Give the secondary landmark a distinct
+accessible name and keep responsive substitution consumer-owned.
+
 For short install and command snippets, use the component-owned compact
 density. Keep multiline manifests and source examples at default density:
 
@@ -185,7 +202,7 @@ density. Keep multiline manifests and source examples at default density:
 @codeblock.CodeBlock(codeblock.Config{
 	Language: "bash",
 	Label: "Install",
-	Code: "go get github.com/araihu/goshtoso@v0.1.5",
+	Code: "go get github.com/araihu/goshtoso@v0.2.6",
 	Density: codeblock.DensityCompact,
 })
 

--- a/.agents/skills/using-goshtoso/references/ecosystem-discovery.md
+++ b/.agents/skills/using-goshtoso/references/ecosystem-discovery.md
@@ -4,10 +4,21 @@ Run this pass before implementing custom HTML, CSS, JavaScript, or a new templ
 primitive. Search the consumer's selected versions, not an unrelated checkout
 or an unreleased `main` branch.
 
+## Contents
+
+- [Verified public baseline](#verified-public-baseline)
+- [Evidence order](#evidence-order)
+- [Goshtoso components and patterns](#1-goshtoso-components-and-patterns)
+- [Goshtoso Charts](#2-goshtoso-charts)
+- [Margo](#3-margo)
+- [Goshtoso App Shells](#4-goshtoso-app-shells)
+- [Icons and Iconpack](#5-icons-and-iconpack)
+- [Fallback boundary](#fallback-boundary)
+
 ## Verified Public Baseline
 
-This reference was reconciled on 2026-08-11 against Goshtoso `v0.1.13`,
-Goshtoso App Shells `v0.1.4`, Margo `v0.0.5`, and the Goshtoso Charts `v0.0.1`
+This reference was reconciled on 2026-08-19 against Goshtoso `v0.2.5`,
+Goshtoso App Shells `v0.1.6`, Margo `v0.0.6`, and Goshtoso Charts `v0.0.2`
 module tag. These versions describe the review baseline, not a command to
 downgrade or upgrade. Recheck public versions and honor the consumer's `go.mod`
 before using an API.
@@ -66,8 +77,8 @@ Check core surfaces before creating equivalents:
 
 - structure and navigation: `appshell`, `navbar`, `sidebar`, `breadcrumbs`,
   `pageheader`, `tabs`, `steps`, and `pagination`;
-- actions and overlays: `actiongroup`, `button`, `link`, `dropdown`, `drawer`,
-  `modal`, `toast`, and `tooltip`;
+- actions and overlays: `actiongroup`, `button`, `link`, `dropdown`, `popover`,
+  `splitbutton`, `drawer`, `modal`, `toast`, and `tooltip`;
 - data and state: `table`, `toolbar`, `search`, `emptystate`, `skeleton`,
   `spinner`, `badge`, `alert`, and `panel`;
 - forms: `form`, `textinput`, `textarea`, `select`, `combobox`, `checkbox`,
@@ -89,12 +100,12 @@ render accessible server-side SVG and still need adjacent exact data when users
 must read precise values.
 
 Use the selected release's interactive API only for real browser exploration,
-large interactive surfaces, 3D, maps, graphs, or live data. Charts `v0.0.1`
-exposes constructors in `components/interactive`; later releases may expose
-chart-specific subpackages. Inspect the selected release before importing.
-Mount the Charts asset handler separately from Goshtoso. Interactive charts also
-render `components/dependencies.Dependencies()`; local vendored runtime is the
-default and CDN delivery is explicit.
+large interactive surfaces, 3D, maps, graphs, or live data. Charts `v0.0.2`
+exposes convenience constructors in `components/interactive` and focused APIs
+under `components/interactive/<type>`. Inspect the selected release before
+importing. Mount the Charts asset handler separately from Goshtoso. Interactive
+charts also render `components/dependencies.Dependencies()`; local vendored
+runtime is the default and CDN delivery is explicit.
 
 Use `chartcontrol` and `charttheme` instead of custom expand, fullscreen,
 export, or palette code. Keep renderer types out of application contracts.
@@ -107,6 +118,8 @@ link validator.
 
 - root `margo`: compile, check, render, and produce standalone HTML;
 - `margo/site`: deterministic linked multi-page sites;
+- `margo/ssg`: layout-neutral frame, shell, binding, and resource contracts for
+  extensible static sites;
 - `margo/deck`: accessible HTML presentation decks;
 - `margo/pdf` plus an explicit engine: PDF contracts and export;
 - `margo/charts`: optional static Goshtoso chart fences;

--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -326,7 +326,7 @@ echo "published $TAG and badge documents"`
       project = project.withMountedCache("/playwright", dag.cacheVolume(`goshtoso-${cacheNamespace}-playwright-${PLAYWRIGHT_VERSION}`), { sharing: CacheSharingMode.Locked })
     }
     return project
-      .withExec(["bash", "-euo", "pipefail", "-c", `test -x /tools/bin/playwright || go install github.com/mxschmitt/playwright-go/cmd/playwright@${PLAYWRIGHT_VERSION}; ready=/playwright/.chromium-${PLAYWRIGHT_DRIVER_VERSION}-ready; if ! test -f "$ready" || ! test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js" || ! test -x "$PLAYWRIGHT_DRIVER_PATH/node"; then rm -rf -- "$PLAYWRIGHT_DRIVER_PATH"; rm -f -- "$ready"; playwright install --with-deps chromium; test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js"; test -x "$PLAYWRIGHT_DRIVER_PATH/node"; marker_tmp="$ready.tmp.$$"; : > "$marker_tmp"; mv -f -- "$marker_tmp" "$ready"; fi`])
+      .withExec(["bash", "-euo", "pipefail", "-c", `test -x /tools/bin/playwright || go install github.com/mxschmitt/playwright-go/cmd/playwright@${PLAYWRIGHT_VERSION}; playwright install-deps chromium; ready=/playwright/.chromium-${PLAYWRIGHT_DRIVER_VERSION}-ready; if ! test -f "$ready" || ! test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js" || ! test -x "$PLAYWRIGHT_DRIVER_PATH/node"; then rm -rf -- "$PLAYWRIGHT_DRIVER_PATH"; rm -f -- "$ready"; playwright install chromium; test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js"; test -x "$PLAYWRIGHT_DRIVER_PATH/node"; marker_tmp="$ready.tmp.$$"; : > "$marker_tmp"; mv -f -- "$marker_tmp" "$ready"; fi`])
   }
 
   private partition(value: string): string {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
             .coverage/e2e-results/
           retention-days: 14
           if-no-files-found: ignore
+          include-hidden-files: true
       - name: Propagate release verification status
         run: test "$(cat .coverage/status)" = 0
       - name: Read authoritative coverage
@@ -76,6 +77,7 @@ jobs:
           path: .coverage/
           retention-days: 30
           if-no-files-found: ignore
+          include-hidden-files: true
 
   publish:
     name: Publish verified release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to Goshtoso are documented in this file.
 
+## [v0.2.6] - 2026-08-19
+
+### Consumer-agent guidance
+
+- Reconciled the `using-goshtoso` ecosystem baseline with Goshtoso `v0.2.5`,
+  Goshtoso Charts `v0.0.2`, Goshtoso App Shells `v0.1.6`, and Margo `v0.0.6`.
+- Added selection guidance for Dropdown, Popover, Split Button, Action Group,
+  and Navbar secondary navigation.
+- Documented the current focused Charts APIs and Margo's layout-neutral `ssg`
+  package.
+
+### Release integrity
+
+- Preserved hidden `.coverage/` files when uploading release artifacts so the
+  verified coverage handoff reaches the publishing job.
+
+### Upgrade note
+
+- No Go API or runtime changes are required. Consumer agents should reinstall
+  the released `using-goshtoso` skill to receive the updated guidance and API
+  reference.
+
 ## [v0.2.5] - 2026-08-18
 
 ### Site navigation and module showcases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to Goshtoso are documented in this file.
 
 - Preserved hidden `.coverage/` files when uploading release artifacts so the
   verified coverage handoff reaches the publishing job.
+- Installed Playwright's system dependencies in every Dagger browser container
+  so a warm browser cache cannot omit required shared libraries.
 
 ### Upgrade note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to Goshtoso are documented in this file.
   verified coverage handoff reaches the publishing job.
 - Installed Playwright's system dependencies in every Dagger browser container
   so a warm browser cache cannot omit required shared libraries.
+- Raised the shared E2E action and navigation budgets to tolerate observed
+  self-hosted runner latency without retrying assertions.
 
 ### Upgrade note
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,6 +11,7 @@ is retained in this table.
 
 | Goshtoso | Tailwind CSS |
 |----------|--------------|
+| v0.2.6   | 4.3.3        |
 | v0.2.5   | 4.3.3        |
 | v0.2.4   | 4.3.3        |
 | v0.2.3   | 4.3.3        |

--- a/docs/application_guidance_contract_test.go
+++ b/docs/application_guidance_contract_test.go
@@ -56,6 +56,57 @@ func TestAgentSkillDiscoveryPassIsStreamingSafe(t *testing.T) {
 	}
 }
 
+func TestAgentSkillChoosesCurrentNavigationAndActionPrimitives(t *testing.T) {
+	skill := readDoc(t, "../.agents/skills/using-goshtoso/SKILL.md")
+	for _, want := range []string{
+		"Use `dropdown` for a menu",
+		"Use `popover` for arbitrary consumer-owned content",
+		"Use `splitbutton` for one always-visible dominant action",
+		"Use `actiongroup` for one required primary action",
+		"`navbar.Config.Secondary`",
+		"`navbar.SecondaryRow`",
+		"keep responsive substitution consumer-owned",
+	} {
+		if !strings.Contains(skill, want) {
+			t.Errorf("agent skill missing component-selection guidance %q", want)
+		}
+	}
+}
+
+func TestEcosystemDiscoveryRecordsCurrentPublicBaseline(t *testing.T) {
+	discovery := readDoc(t, "../.agents/skills/using-goshtoso/references/ecosystem-discovery.md")
+	for _, want := range []string{
+		"Goshtoso `v0.2.5`",
+		"Goshtoso App Shells `v0.1.6`",
+		"Margo `v0.0.6`",
+		"Goshtoso Charts `v0.0.2`",
+		"`components/interactive/<type>`",
+		"`margo/ssg`",
+	} {
+		if !strings.Contains(discovery, want) {
+			t.Errorf("ecosystem discovery missing current public baseline %q", want)
+		}
+	}
+
+	for _, stale := range []string{
+		"Goshtoso `v0.1.13`",
+		"Goshtoso App Shells `v0.1.4`",
+		"Margo `v0.0.5`",
+		"Goshtoso Charts `v0.0.1`",
+	} {
+		if strings.Contains(discovery, stale) {
+			t.Errorf("ecosystem discovery retains stale baseline %q", stale)
+		}
+	}
+}
+
+func TestAgentSkillInstallExampleTargetsCurrentRelease(t *testing.T) {
+	skill := readDoc(t, "../.agents/skills/using-goshtoso/SKILL.md")
+	if !strings.Contains(skill, "go get github.com/araihu/goshtoso@v0.2.6") {
+		t.Error("agent skill install example must target v0.2.6")
+	}
+}
+
 func TestAgentSkillDistributionCLI(t *testing.T) {
 	npx, err := exec.LookPath("npx")
 	if err != nil {

--- a/scripts/dagger_ci_contract_test.go
+++ b/scripts/dagger_ci_contract_test.go
@@ -67,6 +67,36 @@ func TestDaggerWorkflowSecurityAndArtifactContracts(t *testing.T) {
 	}
 }
 
+func TestReleaseCoverageHandoffIncludesHiddenFiles(t *testing.T) {
+	t.Parallel()
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".github/workflows/release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := string(data)
+	if count := strings.Count(release, "include-hidden-files: true"); count != 2 {
+		t.Fatalf("release hidden-artifact inclusions = %d, want 2", count)
+	}
+	for _, artifact := range []string{"release-e2e-results", "release-coverage"} {
+		name := strings.Index(release, "name: "+artifact)
+		if name < 0 {
+			t.Fatalf("release workflow missing artifact %q", artifact)
+		}
+		block := release[name:]
+		nextStep := strings.Index(block, "\n      - name:")
+		if nextStep >= 0 {
+			block = block[:nextStep]
+		}
+		if !strings.Contains(block, "include-hidden-files: true") {
+			t.Fatalf("release artifact %q excludes hidden files", artifact)
+		}
+	}
+}
+
 func TestAssetsHandoffSurvivesCheckoutAndPrecedesWriteToken(t *testing.T) {
 	t.Parallel()
 	root, err := filepath.Abs("..")

--- a/scripts/dagger_ci_contract_test.go
+++ b/scripts/dagger_ci_contract_test.go
@@ -401,7 +401,8 @@ func TestDaggerCachesMatchingPlaywrightDriverAndBrowsers(t *testing.T) {
 		`! test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js"`,
 		`! test -x "$PLAYWRIGHT_DRIVER_PATH/node"`,
 		`rm -rf -- "$PLAYWRIGHT_DRIVER_PATH"; rm -f -- "$ready"`,
-		`playwright install --with-deps chromium; test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js"; test -x "$PLAYWRIGHT_DRIVER_PATH/node"`,
+		`playwright install-deps chromium; ready=/playwright/.chromium-${PLAYWRIGHT_DRIVER_VERSION}-ready`,
+		`playwright install chromium; test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js"; test -x "$PLAYWRIGHT_DRIVER_PATH/node"`,
 		`marker_tmp="$ready.tmp.$$"; : > "$marker_tmp"; mv -f -- "$marker_tmp" "$ready"`,
 		`goshtoso-${cacheNamespace}-playwright-${PLAYWRIGHT_VERSION}`,
 	} {
@@ -418,6 +419,7 @@ func TestPlaywrightWarmMarkerWithoutDriverReinstalls(t *testing.T) {
 	driver := filepath.Join(root, "playwright", "driver")
 	ready := filepath.Join(root, "playwright", ".chromium-1.62.1-ready")
 	installLog := filepath.Join(root, "install.log")
+	depsLog := filepath.Join(root, "deps.log")
 	if err := os.MkdirAll(bin, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -435,7 +437,11 @@ func TestPlaywrightWarmMarkerWithoutDriverReinstalls(t *testing.T) {
 	}
 	fake := `#!/bin/sh
 set -eu
-test "$*" = "install --with-deps chromium"
+if test "$*" = "install-deps chromium"; then
+  : > "$PLAYWRIGHT_DEPS_LOG"
+  exit 0
+fi
+test "$*" = "install chromium"
 test ! -e "$PLAYWRIGHT_DRIVER_PATH"
 test ! -e "$PLAYWRIGHT_READY"
 mkdir -p "$PLAYWRIGHT_DRIVER_PATH/package"
@@ -449,11 +455,12 @@ chmod +x "$PLAYWRIGHT_DRIVER_PATH/node"
 	}
 
 	script := `set -euo pipefail
+playwright install-deps chromium
 ready="$PLAYWRIGHT_READY"
 if ! test -f "$ready" || ! test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js" || ! test -x "$PLAYWRIGHT_DRIVER_PATH/node"; then
   rm -rf -- "$PLAYWRIGHT_DRIVER_PATH"
   rm -f -- "$ready"
-  playwright install --with-deps chromium
+  playwright install chromium
   test -f "$PLAYWRIGHT_DRIVER_PATH/package/cli.js"
   test -x "$PLAYWRIGHT_DRIVER_PATH/node"
   marker_tmp="$ready.tmp.$$"
@@ -466,11 +473,12 @@ fi`
 		"PLAYWRIGHT_DRIVER_PATH="+driver,
 		"PLAYWRIGHT_READY="+ready,
 		"PLAYWRIGHT_INSTALL_LOG="+installLog,
+		"PLAYWRIGHT_DEPS_LOG="+depsLog,
 	)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("warm marker recovery failed: %v\n%s", err, output)
 	}
-	for _, path := range []string{installLog, filepath.Join(driver, "package", "cli.js"), filepath.Join(driver, "node"), ready} {
+	for _, path := range []string{depsLog, installLog, filepath.Join(driver, "package", "cli.js"), filepath.Join(driver, "node"), ready} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected recovered Playwright artifact %s: %v", path, err)
 		}

--- a/site/tests/e2e/e2e_test.go
+++ b/site/tests/e2e/e2e_test.go
@@ -370,9 +370,19 @@ func (failures *pageFailures) RequireEmpty(t *testing.T) {
 func clickUntil(t *testing.T, page playwright.Page, loc playwright.Locator, jsCondition string) {
 	t.Helper()
 	for attempt := 1; attempt <= 5; attempt++ {
-		require.NoError(t, loc.Click())
+		if err := loc.Click(); err != nil {
+			current, currentErr := loc.GetAttribute("aria-current")
+			if currentErr == nil && current == "page" {
+				if _, waitErr := page.WaitForFunction(jsCondition, nil, playwright.PageWaitForFunctionOptions{
+					Timeout: playwright.Float(defaultActionTimeoutMilliseconds),
+				}); waitErr == nil {
+					return
+				}
+			}
+			require.NoError(t, err)
+		}
 		if _, err := page.WaitForFunction(jsCondition, nil, playwright.PageWaitForFunctionOptions{
-			Timeout: playwright.Float(2000),
+			Timeout: playwright.Float(defaultActionTimeoutMilliseconds),
 		}); err == nil {
 			return
 		}

--- a/site/tests/e2e/e2e_test.go
+++ b/site/tests/e2e/e2e_test.go
@@ -29,7 +29,11 @@ var (
 
 const avatarBrokenImagePath = "/assets/images/does-not-exist-404.png"
 
-const pageSettleGraceMilliseconds = 250
+const (
+	pageSettleGraceMilliseconds          = 250
+	defaultActionTimeoutMilliseconds     = 5000
+	defaultNavigationTimeoutMilliseconds = 10000
+)
 
 // Shared singleton state — initialized once in TestMain, shared across all tests.
 var (
@@ -233,7 +237,7 @@ func setupPlaywright(t *testing.T) (*playwright.Playwright, playwright.Browser, 
 	return sharedPW, sharedBrowser, func() {}
 }
 
-// newPage creates a new page (tab) in the shared browser with short timeouts.
+// newPage creates a new page (tab) in the shared browser with bounded timeouts.
 // The caller should defer page.Close() to clean up the tab.
 func newPage(t *testing.T, browser playwright.Browser, opts ...playwright.BrowserNewPageOptions) playwright.Page {
 	var page playwright.Page
@@ -244,8 +248,8 @@ func newPage(t *testing.T, browser playwright.Browser, opts ...playwright.Browse
 		page, err = browser.NewPage()
 	}
 	require.NoError(t, err)
-	page.SetDefaultTimeout(2000)
-	page.SetDefaultNavigationTimeout(3000)
+	page.SetDefaultTimeout(defaultActionTimeoutMilliseconds)
+	page.SetDefaultNavigationTimeout(defaultNavigationTimeoutMilliseconds)
 	t.Cleanup(func() { _ = page.Close() })
 	return page
 }
@@ -254,7 +258,7 @@ func waitForPageSettled(t *testing.T, page playwright.Page) {
 	t.Helper()
 	require.NoError(t, page.WaitForLoadState(playwright.PageWaitForLoadStateOptions{
 		State:   playwright.LoadStateNetworkidle,
-		Timeout: playwright.Float(3000),
+		Timeout: playwright.Float(defaultActionTimeoutMilliseconds),
 	}))
 	// Network idle may already have been reached before the caller starts
 	// waiting. Give timers and Playwright's asynchronous event callbacks one

--- a/site/tests/e2e/shared_support_test.go
+++ b/site/tests/e2e/shared_support_test.go
@@ -28,15 +28,15 @@ func newIsolatedPage(t *testing.T) playwright.Page {
 
 	page, err := ctx.NewPage()
 	require.NoError(t, err)
-	page.SetDefaultTimeout(3000)
-	page.SetDefaultNavigationTimeout(5000)
+	page.SetDefaultTimeout(defaultActionTimeoutMilliseconds)
+	page.SetDefaultNavigationTimeout(defaultNavigationTimeoutMilliseconds)
 	t.Cleanup(func() { _ = page.Close() })
 	return page
 }
 
 func waitForAlpine(page playwright.Page) error {
 	_, err := page.WaitForFunction("() => typeof Alpine !== 'undefined'", nil, playwright.PageWaitForFunctionOptions{
-		Timeout: playwright.Float(3000),
+		Timeout: playwright.Float(defaultActionTimeoutMilliseconds),
 	})
 	return err
 }


### PR DESCRIPTION
## Summary
- refresh the public using-goshtoso skill with current component and ecosystem guidance
- add v0.2.6 release metadata and regression contracts
- preserve hidden coverage files in the GitHub Actions release handoff

## Release blocker fixed
The v0.2.5 tag verification passed, but publication failed because upload-artifact excluded the hidden .coverage directory. Both release handoffs now opt into hidden files.

## Verification
- skill quick validation and local discovery/install output
- generator/runtime strict checks and zero generated drift
- site current-source and pinned-dependency deployability
- release coverage local dry-run: E2E pass; generated-inclusive 75.0%; authored Go 97.1%
- actionlint; git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to target the v0.2.6 release.
  * Expanded guidance for navigation, actions, overlays, Charts, and supported ecosystem packages.
  * Added compatibility information for v0.2.6 and Tailwind CSS 4.3.3.
  * Published the v0.2.6 changelog with updated guidance and release notes.

* **Bug Fixes**
  * Release artifacts now preserve hidden files, including coverage results.

* **Tests**
  * Added coverage to verify current documentation, version references, package guidance, and hidden-file artifact handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->