### PR TITLE
fix(site): pin Goshtoso v0.2.6

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.2.1
+	github.com/araihu/goshtoso v0.2.6
 	github.com/araihu/goshtoso-app-shells v0.1.6
 	github.com/araihu/goshtoso-charts v0.0.2
 	github.com/coder/websocket v1.8.15

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/chroma/v2 v2.27.0 h1:FodwmyOBgJULFYmDqibcp9pvfDLWdtPRh9v/r
 github.com/alecthomas/chroma/v2 v2.27.0/go.mod h1:NjJ3ciIgrqBNeIkWZ4e46nseoLDslxU1LmfCoL+wcY8=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.2.1 h1:Ya6pH8UVP4G2Jl6j/GiGzuLHmA5AbAd/SsWz/jYMN6c=
-github.com/araihu/goshtoso v0.2.1/go.mod h1:Z3qDISgeoYdMbRXxEVYjmJ81JJvn+Ci+s5tAS3p+aRs=
+github.com/araihu/goshtoso v0.2.6 h1:gEGcCKL/27MWzwiEi+enneiZph9Y6C38iubDOLlM89w=
+github.com/araihu/goshtoso v0.2.6/go.mod h1:1t3tY/x9ggwiOsl9LeOlHo5UbXDXOWUXf+JzbvLbawU=
 github.com/araihu/goshtoso-app-shells v0.1.6 h1:xCRHa69tFkSH1RLnSCeDIJ6EseeK8s8934IlMiiUgGA=
 github.com/araihu/goshtoso-app-shells v0.1.6/go.mod h1:Us/2onRiBR84jl0jfWX/M7Fmuwornlf+2WMECoMlRLM=
 github.com/araihu/goshtoso-charts v0.0.2 h1:IfcatIJ1GariJhFy6wzSfCW4tERxBaCHvNqHy7yy6xc=


### PR DESCRIPTION
## Summary
- pin the site module to released Goshtoso v0.2.6
- refresh module checksums

## Verification
- `GOWORK=off just site-pinned-dependency-deployability`
- 84 non-E2E packages passed; server built

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated an internal dependency to a newer version for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->