### PR TITLE
docs: repair author credit link blocking release verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ coverage, generated templ output, CSS output, and usage reference in sync.
 ## Credits
 
 Goshtoso began as a hard fork of [PenguinUI](https://www.penguinui.com) by
-[Salar Houshvand](https://x.com/salar_houshvand), transformed from static
+[Salar Houshvand](https://github.com/SalarHoushvand), transformed from static
 HTML/Alpine.js examples into an importable Go component library.
 
 ## License


### PR DESCRIPTION
Main docs verification repeatedly receives HTTP 403 from the existing X/Twitter author profile. Preserve the exact credit text and point to the author GitHub profile linked from the official PenguinUI homepage footer (https://www.penguinui.com). Both the official footer and https://github.com/SalarHoushvand were verified. No link-check exclusions or accepted-status changes. This bounded docs correction unblocks the green-main release prerequisite for v0.2.9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Credits section to link to Salar Houshvand’s GitHub profile instead of their X profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->