### PR TITLE
fix(button): show pointer cursor on enabled buttons

### DIFF
--- a/components/button/types.go
+++ b/components/button/types.go
@@ -219,7 +219,7 @@ func sizeClasses(size Size) string {
 }
 
 func buttonClasses(cfg config) string {
-	base := "inline-flex items-center justify-center gap-2 min-h-11 min-w-11 whitespace-nowrap rounded-2xl font-medium tracking-wide transition motion-reduce:transition-none hover:contrast-125 text-center focus-visible:outline-2 focus-visible:outline-offset-2 active:contrast-100 active:outline-offset-0 disabled:opacity-75 disabled:cursor-not-allowed border"
+	base := "inline-flex cursor-pointer items-center justify-center gap-2 min-h-11 min-w-11 whitespace-nowrap rounded-2xl font-medium tracking-wide transition motion-reduce:transition-none hover:contrast-125 text-center focus-visible:outline-2 focus-visible:outline-offset-2 active:contrast-100 active:outline-offset-0 disabled:opacity-75 disabled:cursor-not-allowed border"
 	outline := focusOutlineClasses(cfg.tone)
 	return base + " " + toneClasses(cfg.tone) + " " + sizeClasses(cfg.size) + " " + outline + " " + cfg.rootClass
 }


### PR DESCRIPTION
Add the pointer cursor to the shared button classes. Enabled buttons show a hand; disabled buttons retain the not-allowed cursor. Button tests pass; the cursor utility is already bundled.