### PR TITLE
fix(schematree): polish branch guides and prepare v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Goshtoso are documented in this file.
 
+## [v0.2.10] - 2026-09-09
+
+### SchemaTree fixes
+
+- Keep constraint code borderless when embedded in prose-styled pages, without
+  resetting caller-owned rich description styling.
+- Anchor nesting guides below disclosure chevrons independently of descriptions,
+  constraints, and other branch content, preserving the original disclosure gap.
+- Verify guide placement and code styling across mobile and desktop layouts,
+  light and dark modes, and the Goshtoso and Minimal themes.
+
 ## [v0.2.9] - 2026-09-08
 
 ### SchemaTree

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,6 +11,7 @@ is retained in this table.
 
 | Goshtoso | Tailwind CSS |
 |----------|--------------|
+| v0.2.10  | 4.3.3        |
 | v0.2.9   | 4.3.3        |
 | v0.2.8   | 4.3.3        |
 | v0.2.7   | 4.3.3        |

--- a/assets/goshtoso-theme.css
+++ b/assets/goshtoso-theme.css
@@ -978,6 +978,13 @@
 .gs-schema-tree .gs-schema-tree-list { list-style: none; margin: 0; padding: 0; }
 .gs-schema-tree .gs-schema-tree-item { list-style: none; margin: 0; padding: 0; border-block: 0; }
 .gs-schema-tree .gs-schema-tree-node { min-inline-size: 0; margin: 0; padding-block: .5rem; border: 0; }
+.gs-schema-tree details.gs-schema-tree-node { position: relative; }
+/* Anchor the guide below the disclosure marker, across all branch content. */
+.gs-schema-tree details[open].gs-schema-tree-node::before {
+  content: ""; position: absolute; pointer-events: none;
+  inset-inline-start: .8125rem; inset-block-start: 3.25rem; inset-block-end: .5rem;
+  border-inline-start: 1px solid var(--gs-tree-outline);
+}
 .gs-schema-tree .gs-schema-tree-row {
   position: relative;
   display: grid;
@@ -1028,12 +1035,12 @@
 .gs-schema-tree .gs-schema-tree-constraints dt { font-weight: 500; }
 .gs-schema-tree .gs-schema-tree-constraints dd { margin: 0; min-inline-size: 0; max-inline-size: 100%; }
 .gs-schema-tree .gs-schema-tree-constraints pre { margin: .25rem 0; padding: .75rem; background: var(--gs-tree-hover); border-radius: var(--radius-radius); max-inline-size: 100%; overflow: auto; }
-.gs-schema-tree .gs-schema-tree-constraints code { font-family: var(--font-mono, monospace); font-size: inherit; color: inherit; background: none; padding: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
-.gs-schema-tree .gs-schema-tree-children { margin-inline-start: .8125rem; padding-inline-start: .9375rem; border-inline-start: 1px solid var(--gs-tree-outline); }
+.gs-schema-tree .gs-schema-tree-constraints code { font-family: var(--font-mono, monospace); font-size: inherit; color: inherit; background: none; border: 0; border-radius: 0; padding: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+.gs-schema-tree .gs-schema-tree-children { margin-inline-start: .8125rem; padding-inline-start: 1rem; }
 .gs-schema-tree .gs-schema-tree-empty { color: var(--gs-tree-muted); margin-block: .75rem; }
 @container (max-width: 28rem) {
   .gs-schema-tree .gs-schema-tree-row { column-gap: .5rem; }
-  .gs-schema-tree .gs-schema-tree-children { margin-inline-start: .375rem; padding-inline-start: .375rem; }
+  .gs-schema-tree .gs-schema-tree-children { margin-inline-start: .375rem; padding-inline-start: .4375rem; }
 }
 @media print {
   .gs-schema-tree details > :not(summary) { display: block !important; }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -7609,6 +7609,18 @@
   padding-block: .5rem;
   border: 0;
 }
+.gs-schema-tree details.gs-schema-tree-node {
+  position: relative;
+}
+.gs-schema-tree details[open].gs-schema-tree-node::before {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  inset-inline-start: .8125rem;
+  inset-block-start: 3.25rem;
+  inset-block-end: .5rem;
+  border-inline-start: 1px solid var(--gs-tree-outline);
+}
 .gs-schema-tree .gs-schema-tree-row {
   position: relative;
   display: grid;
@@ -7764,14 +7776,15 @@
   font-size: inherit;
   color: inherit;
   background: none;
+  border: 0;
+  border-radius: 0;
   padding: 0;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 .gs-schema-tree .gs-schema-tree-children {
   margin-inline-start: .8125rem;
-  padding-inline-start: .9375rem;
-  border-inline-start: 1px solid var(--gs-tree-outline);
+  padding-inline-start: 1rem;
 }
 .gs-schema-tree .gs-schema-tree-empty {
   color: var(--gs-tree-muted);
@@ -7783,7 +7796,7 @@
   }
   .gs-schema-tree .gs-schema-tree-children {
     margin-inline-start: .375rem;
-    padding-inline-start: .375rem;
+    padding-inline-start: .4375rem;
   }
 }
 @media print {

--- a/css/schematree.css
+++ b/css/schematree.css
@@ -29,6 +29,13 @@
 .gs-schema-tree .gs-schema-tree-list { list-style: none; margin: 0; padding: 0; }
 .gs-schema-tree .gs-schema-tree-item { list-style: none; margin: 0; padding: 0; border-block: 0; }
 .gs-schema-tree .gs-schema-tree-node { min-inline-size: 0; margin: 0; padding-block: .5rem; border: 0; }
+.gs-schema-tree details.gs-schema-tree-node { position: relative; }
+/* Anchor the guide below the disclosure marker, across all branch content. */
+.gs-schema-tree details[open].gs-schema-tree-node::before {
+  content: ""; position: absolute; pointer-events: none;
+  inset-inline-start: .8125rem; inset-block-start: 3.25rem; inset-block-end: .5rem;
+  border-inline-start: 1px solid var(--gs-tree-outline);
+}
 .gs-schema-tree .gs-schema-tree-row {
   position: relative;
   display: grid;
@@ -79,12 +86,12 @@
 .gs-schema-tree .gs-schema-tree-constraints dt { font-weight: 500; }
 .gs-schema-tree .gs-schema-tree-constraints dd { margin: 0; min-inline-size: 0; max-inline-size: 100%; }
 .gs-schema-tree .gs-schema-tree-constraints pre { margin: .25rem 0; padding: .75rem; background: var(--gs-tree-hover); border-radius: var(--radius-radius); max-inline-size: 100%; overflow: auto; }
-.gs-schema-tree .gs-schema-tree-constraints code { font-family: var(--font-mono, monospace); font-size: inherit; color: inherit; background: none; padding: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
-.gs-schema-tree .gs-schema-tree-children { margin-inline-start: .8125rem; padding-inline-start: .9375rem; border-inline-start: 1px solid var(--gs-tree-outline); }
+.gs-schema-tree .gs-schema-tree-constraints code { font-family: var(--font-mono, monospace); font-size: inherit; color: inherit; background: none; border: 0; border-radius: 0; padding: 0; white-space: pre-wrap; overflow-wrap: anywhere; }
+.gs-schema-tree .gs-schema-tree-children { margin-inline-start: .8125rem; padding-inline-start: 1rem; }
 .gs-schema-tree .gs-schema-tree-empty { color: var(--gs-tree-muted); margin-block: .75rem; }
 @container (max-width: 28rem) {
   .gs-schema-tree .gs-schema-tree-row { column-gap: .5rem; }
-  .gs-schema-tree .gs-schema-tree-children { margin-inline-start: .375rem; padding-inline-start: .375rem; }
+  .gs-schema-tree .gs-schema-tree-children { margin-inline-start: .375rem; padding-inline-start: .4375rem; }
 }
 @media print {
   .gs-schema-tree details > :not(summary) { display: block !important; }

--- a/site/tests/e2e/schematree_test.go
+++ b/site/tests/e2e/schematree_test.go
@@ -65,10 +65,34 @@ func TestSchemaTreeThemesResponsiveAndNativeDisclosure(t *testing.T) {
 						return [...tree.querySelectorAll('.gs-schema-tree-item')].every(item => {
 							const style = getComputedStyle(item);
 							return style.borderBlockStartWidth === '0px' && style.borderBlockEndWidth === '0px';
-						}) && getComputedStyle(tree.querySelector('.gs-schema-tree-children')).borderInlineStartWidth === '1px';
+						}) && [...tree.querySelectorAll('details[open]')].every(branch => {
+							const guide = getComputedStyle(branch, '::before');
+							const marker = getComputedStyle(branch.querySelector(':scope > summary'), '::before');
+							const gap = parseFloat(guide.top) - parseFloat(getComputedStyle(branch).paddingTop) - parseFloat(marker.top) - parseFloat(marker.height);
+							return guide.borderInlineStartWidth === '1px' && Math.abs(gap - 22) <= 1 &&
+								getComputedStyle(branch.querySelector(':scope > .gs-schema-tree-children')).borderInlineStartWidth === '0px';
+						});
 					}`)
 					require.NoError(t, err)
 					require.Equal(t, true, rails, "only vertical nesting guides should remain")
+					codeOwnership, err := page.Evaluate(`() => {
+						const host = document.querySelector('#schema-tree-response');
+						host.classList.add('schema-prose-host');
+						const style = document.createElement('style');
+						style.textContent = '.schema-prose-host code { border: 2px solid red; border-radius: 8px; }';
+						document.head.append(style);
+						const owned = [...host.querySelectorAll('.gs-schema-tree-name, .gs-schema-tree-constraints code')];
+						const description = host.querySelector('.gs-schema-tree-description code');
+						const valid = owned.length > 0 && !!description && owned.every(node => {
+							const computed = getComputedStyle(node);
+							return computed.borderTopWidth === '0px' && computed.borderTopLeftRadius === '0px';
+						}) && getComputedStyle(description).borderTopWidth === '2px';
+						style.remove();
+						host.classList.remove('schema-prose-host');
+						return valid;
+					}`)
+					require.NoError(t, err)
+					require.Equal(t, true, codeOwnership, "tree-owned code stays borderless while descriptions retain host prose styling")
 					if width == 1440 && theme == "goshtoso" {
 						_, err = page.Locator("#schema-tree-response").Screenshot(playwright.LocatorScreenshotOptions{Path: playwright.String(fmt.Sprintf("/tmp/schema-tree-dark-%t.png", dark))})
 						require.NoError(t, err)

--- a/site/tests/e2e/table_coverage_test.go
+++ b/site/tests/e2e/table_coverage_test.go
@@ -3,7 +3,7 @@
 package e2e
 
 import (
-	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mxschmitt/playwright-go"
@@ -154,27 +154,33 @@ func TestTableCoverageDemo(t *testing.T) {
 	})
 
 	t.Run("infinite scroll sentinel appends rows", func(t *testing.T) {
-		container := page.Locator("#table-infinite")
-		require.NoError(t, container.WaitFor())
-
-		sentinel := page.Locator("#infinite-table-sentinel")
-		require.NoError(t, sentinel.WaitFor())
-		// Sentinel carries the next-page URL for the IntersectionObserver script.
-		hxGet, err := sentinel.Evaluate("el => el.getAttribute('data-hx-get')", nil)
+		// Earlier subtests can scroll past this demo and exhaust its pages. Also,
+		// the observer prefetches within 400px, so the sentinel may disappear
+		// before any locator wait. Observe the request from a fresh page instead.
+		page := newIsolatedPage(t)
+		response, err := page.ExpectResponse(func(response playwright.Response) bool {
+			return strings.Contains(response.URL(), "/api/components/table/rows?") &&
+				strings.Contains(response.URL(), "variant=infinite")
+		}, func() error {
+			if _, err := page.Goto(baseURL+"/components/table", playwright.PageGotoOptions{
+				WaitUntil: playwright.WaitUntilStateDomcontentloaded,
+			}); err != nil {
+				return err
+			}
+			return page.Locator("#table-infinite").ScrollIntoViewIfNeeded()
+		})
 		require.NoError(t, err)
-		assert.Contains(t, hxGet, "variant=infinite")
-
-		initial, err := page.Locator("#infinite-table-tbody tr").Count()
-		require.NoError(t, err)
-
-		// Reveal the sentinel inside its capped 300px scroller to trip the
-		// IntersectionObserver and append the next page.
-		require.NoError(t, sentinel.ScrollIntoViewIfNeeded())
+		require.Equal(t, 200, response.Status())
+		// The fixture starts with three data rows. Exclude the loading sentinel
+		// and require appended data, not merely a successful network response.
 		_, err = page.WaitForFunction(
-			fmt.Sprintf("() => document.querySelectorAll('#infinite-table-tbody tr').length > %d", initial),
+			`() => document.querySelectorAll('#infinite-table-tbody tr:not([data-table-scroll-sentinel])').length > 3`,
 			nil, playwright.PageWaitForFunctionOptions{Timeout: playwright.Float(4000)},
 		)
 		require.NoError(t, err, "infinite scroll should append more rows past the sentinel")
+		firstID, err := page.Locator("#infinite-table-tbody tr:first-child td:first-child").InnerText()
+		require.NoError(t, err)
+		require.Equal(t, "2335", strings.TrimSpace(firstID), "appending must preserve the initial rows")
 	})
 
 	t.Run("sortable header carries an HTMX sort URL", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Keep schema constraint code borderless without resetting rich descriptions.
- Anchor nesting guides independently of branch descriptions with the approved disclosure gap.
- Regenerate both distributed CSS assets and document v0.2.10.

## Verification
- Root Go test suite passed.
- SchemaTree browser tests passed across mobile/desktop, light/dark, Goshtoso/Minimal.
- Current-source and pinned-dependency site contract checks run locally.

Requested release: v0.2.10 after merge and successful CI.