### PR TITLE
chore(site): upgrade Goshtoso to v0.2.10

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.27.0
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.2.9
+	github.com/araihu/goshtoso v0.2.10
 	github.com/araihu/goshtoso-app-shells v0.1.8
 	github.com/araihu/goshtoso-charts v0.0.3
 	github.com/coder/websocket v1.8.15

--- a/site/go.sum
+++ b/site/go.sum
@@ -6,8 +6,8 @@ github.com/alecthomas/chroma/v2 v2.27.0 h1:FodwmyOBgJULFYmDqibcp9pvfDLWdtPRh9v/r
 github.com/alecthomas/chroma/v2 v2.27.0/go.mod h1:NjJ3ciIgrqBNeIkWZ4e46nseoLDslxU1LmfCoL+wcY8=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/araihu/goshtoso v0.2.9 h1:S5qdMtQiiffmMoO1Uo4l8gRqZ7Hqj9RSGG1vxvsr3IM=
-github.com/araihu/goshtoso v0.2.9/go.mod h1:n+Jlx+WLx81gk2fq0nhgt1PhtdltbQrmv07mJx1aNQM=
+github.com/araihu/goshtoso v0.2.10 h1:3yGxwRlyvf858ppVfX+XRsQcGevoK/Cd99lojBcTMpI=
+github.com/araihu/goshtoso v0.2.10/go.mod h1:n+Jlx+WLx81gk2fq0nhgt1PhtdltbQrmv07mJx1aNQM=
 github.com/araihu/goshtoso-app-shells v0.1.8 h1:ItAgoO7AqMQ51nbhLFLCtNQzukK07/T3n7Fn6e5R0gs=
 github.com/araihu/goshtoso-app-shells v0.1.8/go.mod h1:vLzFYLXBpGuKYUjjkPsTlSksxSxwj9ZhJmwDpafqmv0=
 github.com/araihu/goshtoso-charts v0.0.3 h1:dWWAyLCAkgHZET+HOXwOuD02H+je16xJY4LjhH9bQKQ=


### PR DESCRIPTION
Update the standalone demo site to the published v0.2.10 component library so SchemaTree examples use the approved guide and constraint styling.

Verification: standalone site tests passed; current-source integration passed; pinned-dependency deployability check run locally. No component API changes.