### PR TITLE
chore(site): pin Goshtoso v0.3.0

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.27.0
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.2.11-0.20260910225952-4a5e3df76225
+	github.com/araihu/goshtoso v0.3.0
 	github.com/araihu/goshtoso-app-shells v0.1.9-0.20260910224508-5b2222e54637
 	github.com/araihu/goshtoso-charts v0.0.3
 	github.com/coder/websocket v1.8.15

--- a/site/go.sum
+++ b/site/go.sum
@@ -12,6 +12,8 @@ github.com/araihu/goshtoso v0.2.11-0.20260910222250-b9e434e3f393 h1:2WNAE6raT6oT
 github.com/araihu/goshtoso v0.2.11-0.20260910222250-b9e434e3f393/go.mod h1:9gg3IPPU1C1gJZUZts+AUDfbV/iYb0N5mSbL5NtyRzU=
 github.com/araihu/goshtoso v0.2.11-0.20260910225952-4a5e3df76225 h1:pnFtu2HT2DDkqmXCPb1/DuD2+fVcflP4KuxRFiyGER0=
 github.com/araihu/goshtoso v0.2.11-0.20260910225952-4a5e3df76225/go.mod h1:9gg3IPPU1C1gJZUZts+AUDfbV/iYb0N5mSbL5NtyRzU=
+github.com/araihu/goshtoso v0.3.0 h1:6+fTBCzDHFCfEtw8UGH3IePfrDsCyDvaZPIEn3V85i8=
+github.com/araihu/goshtoso v0.3.0/go.mod h1:9gg3IPPU1C1gJZUZts+AUDfbV/iYb0N5mSbL5NtyRzU=
 github.com/araihu/goshtoso-app-shells v0.1.9-0.20260910213838-cacbfabe8724 h1:dP/6L+EYnWSj2X4LUvqejilFMSrA1Zb/hOy7J/8WTkE=
 github.com/araihu/goshtoso-app-shells v0.1.9-0.20260910213838-cacbfabe8724/go.mod h1:vme6qwadyuneFflKQsnvIWYp8D/oFhJSux0YOxPMvhg=
 github.com/araihu/goshtoso-app-shells v0.1.9-0.20260910221700-55245c718fa6 h1:/4H5pub17UGf2AbINzz1xiJKqwAl7tOoFZCpiZrmBaQ=


### PR DESCRIPTION
Pin the documentation site to Goshtoso v0.3.0 so standalone builds and generated API links use the published HTMX 4 release instead of a development pseudo-version.

Validation: current-source integration passed (86 packages and server build); pinned-dependency deployability passed (85 packages and standalone server build).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal module dependency to a stable tagged release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->