### PR TITLE
fix(release): accept unquoted Tailwind versions

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -184,7 +184,7 @@ scripts/run-release-coverage.sh --local-dry-run`
     const tag = this.string(release, "tag")
     if (!/^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(tag)) throw new Error(`invalid release tag: ${tag}`)
     const script = `set -euo pipefail
-ver=$(sed -n '/^  tailwindcss:$/,/^  [^ ]/ s/^    version: "\\([^"]*\\)"/\\1/p' muamba.yaml)
+ver=$(scripts/release-tailwind-version)
 test -n "$ver"
 awk -v heading="## [$TAG]" 'index($0, heading) == 1 { found=1; next } found && /^## \\[/ { exit } found { print } END { if (!found) exit 1 }' CHANGELOG.md > /tmp/release-notes.md
 printf '\\n## Build artifacts\\n\\nBuilt with Tailwind CSS %s.\\nAssets attached: styles.css and goshtoso-theme.css.\\n' "$ver" >> /tmp/release-notes.md

--- a/scripts/release-tailwind-version
+++ b/scripts/release-tailwind-version
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Muamba serializes scalar versions either quoted or unquoted. Stay within the
+# Tailwind resource so a missing version cannot select the next dependency.
+awk '
+  /^  tailwindcss:$/ { in_resource = 1; next }
+  in_resource && /^  [^ ]/ { exit 1 }
+  in_resource && /^    version:/ {
+    version = $2
+    gsub(/["\047]/, "", version)
+    if (version !~ /^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$/) exit 1
+    print version
+    found = 1
+    exit
+  }
+  END { if (!found) exit 1 }
+' "${1:-muamba.yaml}"

--- a/scripts/release_tailwind_version_test.go
+++ b/scripts/release_tailwind_version_test.go
@@ -1,0 +1,42 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReleaseTailwindVersion(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, manifest, want string
+	}{
+		{"unquoted", "  tailwindcss:\n    version: 4.3.3\n", "4.3.3"},
+		{"double quoted", "  tailwindcss:\n    version: \"4.3.3\"\n", "4.3.3"},
+		{"single quoted", "  tailwindcss:\n    version: '4.3.3'\n", "4.3.3"},
+		{"prerelease", "  tailwindcss:\n    version: 4.4.0-beta.1\n", "4.4.0-beta.1"},
+		{"missing resource", "  alpinejs:\n    version: 3.17.2\n", ""},
+		{"missing version", "  tailwindcss:\n  alpinejs:\n    version: 3.17.2\n", ""},
+		{"invalid version", "  tailwindcss:\n    version: latest\n", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "muamba.yaml")
+			if err := os.WriteFile(path, []byte("resources:\n"+tc.manifest), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			output, err := exec.Command("bash", "release-tailwind-version", path).CombinedOutput()
+			if tc.want == "" {
+				if err == nil {
+					t.Fatalf("expected rejection, got %q", output)
+				}
+				return
+			}
+			if err != nil || strings.TrimSpace(string(output)) != tc.want {
+				t.Fatalf("version = %q, error = %v; want %q", output, err, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The v0.3.0 verification job passed, but publication stopped before creating the release because its sed expression only recognized quoted Tailwind versions. Muamba now emits `version: 4.3.3` without quotes.

Use a tested parser that accepts quoted and unquoted semantic versions and fails when the Tailwind resource or its version is missing. Keep parsing inside the Tailwind resource so a later dependency cannot supply the version accidentally.

Validation: parser regression tests and Dagger workflow contract tests pass; the current manifest resolves to 4.3.3. v0.3.0 was published separately from the exact verified tag, using its successful coverage artifact; its tag was not moved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release version detection for Tailwind CSS, including quoted and prerelease version formats.
  - Added validation to prevent releases from proceeding when the Tailwind CSS version is missing or invalid.

- **Chores**
  - Added automated checks to verify Tailwind CSS version detection across supported manifest formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->