### PR TITLE
Own Goshtoso GHCR image publication and homelab handoff

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -209,26 +209,12 @@ echo "published $TAG and badge documents"`
       .stdout()
   }
 
-  /** Dispatch the verified main SHA to the central Fly deployment repository. */
-  @func({ cache: "never" })
-  async dispatchFly(metadata: File, token: Secret, runNonce: string): Promise<string> {
-    const handoff = await this.json(metadata, ["source_repository", "source_run_id", "source_sha"])
-    const sourceSha = this.string(handoff, "source_sha")
-    const sourceRunId = this.string(handoff, "source_run_id")
-    if (!/^[0-9a-f]{40}$/.test(sourceSha)) throw new Error("invalid Fly source SHA")
-    if (!/^[1-9][0-9]*$/.test(sourceRunId)) throw new Error("invalid Fly source run ID")
-    if (this.string(handoff, "source_repository") !== "araihu/goshtoso") throw new Error("invalid Fly source repository")
-    const payload = JSON.stringify({ event_type: "goshtoso-main", client_payload: { goshtoso_ref: sourceSha, goshtoso_sha: sourceSha, goshtoso_run_id: sourceRunId, source_repository: "araihu/goshtoso" } })
-    return dag.container().from(GO_IMAGE)
-      .withExec(["apt-get", "update"])
-      .withExec(["apt-get", "install", "-y", "--no-install-recommends", "ca-certificates", "curl"])
-      .withExec(["rm", "-rf", "/var/lib/apt/lists/*"])
-      .withSecretVariable("GH_TOKEN", token)
-      .withNewFile("/tmp/payload.json", payload)
-      .withEnvVariable("GOSHTOSO_RUN_NONCE", runNonce)
-      .withExec(["bash", "-euo", "pipefail", "-c", "curl -fsS -X POST -H 'Accept: application/vnd.github+json' -H \"Authorization: Bearer $GH_TOKEN\" -H 'X-GitHub-Api-Version: 2022-11-28' --data-binary @/tmp/payload.json https://api.github.com/repos/araihu/fly-deploy/dispatches"])
-      .withExec(["echo", "Fly dispatch accepted"])
-      .stdout()
+  /** Build the homelab site image from this repository. */
+  @func()
+  siteImage(
+    @argument({ defaultPath: ".", ignore: SOURCE_EXCLUDES }) source: Directory,
+  ): Container {
+    return source.dockerBuild({ dockerfile: "Dockerfile", platform: "linux/amd64" })
   }
 
   /** Validate immutable Assets handoff, update allowlisted files, and return the patch tree. */

--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,12 @@ node_modules
 .idea
 justfile
 og-site
+
+.tools
+.coverage
+.codex
+.claude
+.agents
+.dagger
+**/.env*
+server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,3 +133,16 @@ jobs:
       - name: Propagate test status
         if: always()
         run: test "$(cat .dagger-output/status)" = 0
+
+  site-image:
+    name: Site image smoke test
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Build and test site image
+        run: |
+          docker build --platform linux/amd64 -t goshtoso-site:test .
+          scripts/check-site-image goshtoso-site:test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,41 +1,62 @@
-name: Fly deploy
+name: Publish site image
 
 on:
   workflow_run:
     workflows: [Code CI]
     types: [completed]
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
+  actions: read
+  packages: write
+
+concurrency:
+  group: publish-goshtoso-site
+  cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Trigger Fly deploy
-    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
+  publish:
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-24.04
-    concurrency: deploy-group
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-          ref: ${{ github.event.workflow_run.head_sha }}
-      - name: Materialize verified deployment handoff
-        shell: bash
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+      - name: Verify source passed Code CI
         env:
-          SOURCE_SHA: ${{ github.event.workflow_run.head_sha }}
-          SOURCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
-          jq -cn --arg source_repository araihu/goshtoso --arg source_sha "$SOURCE_SHA" --arg source_run_id "$SOURCE_RUN_ID" \
-            '{source_repository:$source_repository,source_run_id:$source_run_id,source_sha:$source_sha}' > .fly-handoff.json
-      - name: Dispatch central deployment through Dagger
-        uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.2.1
-        with:
-          version: '0.21.8'
-          verb: call
-          args: dispatch-fly --metadata=.fly-handoff.json --token=env:FLY_DEPLOY_DISPATCH_TOKEN --run-nonce=${{ github.run_id }}-${{ github.run_attempt }}
+          revision=$(git rev-parse HEAD)
+          gh run list --workflow ci.yml --commit "$revision" --status success --json databaseId --jq 'length > 0' | grep -qx true
+          printf 'IMAGE=ghcr.io/araihu/goshtoso:%s\n' "$revision" >> "$GITHUB_ENV"
+          printf 'REVISION=%s\n' "$revision" >> "$GITHUB_ENV"
+      - name: Build site image
+        run: |
+          docker build --platform linux/amd64 \
+            --label org.opencontainers.image.source=https://github.com/araihu/goshtoso \
+            --label "org.opencontainers.image.revision=$REVISION" \
+            -t "$IMAGE" .
+      - name: Test image with homelab security settings
+        run: scripts/check-site-image "$IMAGE"
+      - name: Publish to GHCR
         env:
-          FLY_DEPLOY_DISPATCH_TOKEN: ${{ secrets.FLY_DEPLOY_DISPATCH_TOKEN }}
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          trap 'docker logout ghcr.io >/dev/null' EXIT
+          docker push "$IMAGE"
+          digest=$(docker inspect --format '{{index .RepoDigests 0}}' "$IMAGE")
+          [[ "$digest" =~ ^ghcr.io/araihu/goshtoso@sha256:[0-9a-f]{64}$ ]]
+          printf '%s\n' "$digest" > image-goshtoso.txt
+          printf 'Homelab image: `%s`\n' "$digest" >> "$GITHUB_STEP_SUMMARY"
+      - name: Preserve immutable image for GitOps
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: image-goshtoso
+          path: image-goshtoso.txt
+          retention-days: 90

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   publish:
-    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success')
+    if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -31,7 +31,7 @@ jobs:
         run: |
           set -euo pipefail
           revision=$(git rev-parse HEAD)
-          gh run list --workflow ci.yml --commit "$revision" --status success --json databaseId --jq 'length > 0' | grep -qx true
+          gh run list --workflow ci.yml --event push --branch main --commit "$revision" --status success --json databaseId --jq 'length > 0' | grep -qx true
           printf 'IMAGE=ghcr.io/araihu/goshtoso:%s\n' "$revision" >> "$GITHUB_ENV"
           printf 'REVISION=%s\n' "$revision" >> "$GITHUB_ENV"
       - name: Build site image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.27.0-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.27.0-bookworm@sha256:484ef6066fa69acb059fdfeda7ba2b8f7391f2ef6abc6f9b8411e669ebd56466 AS builder
+ARG TARGETARCH=amd64
 
 WORKDIR /src
 
@@ -14,14 +15,16 @@ RUN go work init . ./site && go mod download
 
 COPY . .
 RUN GOSHTOSO_DOCS_VERSION="$(cd site && GOWORK=off go list -m -f '{{.Version}}' github.com/araihu/goshtoso)" && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
       -ldflags "-X github.com/araihu/goshtoso/site/internal/buildinfo.goDocsVersion=${GOSHTOSO_DOCS_VERSION}" \
       -o /out/server ./site/cmd/server
 # Drop the build-only workspace so it is never baked into the runtime image
 # (the final stage copies all of /src for its assets/).
 RUN rm -f go.work go.work.sum
 
-FROM alpine:3.24
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+
+RUN apk add --no-cache ca-certificates && adduser -D -H -u 10001 appuser
 
 WORKDIR /app
 
@@ -30,6 +33,7 @@ WORKDIR /app
 COPY --from=builder /src /app
 COPY --from=builder /out/server /app/server
 
+USER 10001:10001
 EXPOSE 8090
 
 CMD ["/app/server", "-port", "8090"]

--- a/README.md
+++ b/README.md
@@ -393,3 +393,26 @@ HTML/Alpine.js examples into an importable Go component library.
 ## License
 
 MIT. See [LICENSE](LICENSE).
+
+## Homelab container image
+
+This repository builds and publishes `ghcr.io/araihu/goshtoso` after Code CI
+passes on `main`. The image tag is the complete source commit SHA; the
+`image-goshtoso` workflow artifact contains the immutable digest for deployment.
+The package should remain private. Kubernetes uses its existing GHCR pull secret.
+
+The Docker image serves port 8090 as UID/GID 10001 and is tested with a read-only
+root filesystem and writable `/tmp`. It builds the root library and site from
+one checkout; `site/go.mod` supplies the displayed documentation version.
+
+Update `k8s/goshtoso/deployment.yaml` in `guilycst/home-lab` with the produced
+digest through a reviewed GitOps change. Argo CD owns the rollout. Publishing an
+image does not itself change the running Deployment. Roll back by reverting the
+digest pin. The old `araihu/fly-deploy` repository no longer owns this publisher.
+
+For a local check:
+
+```bash
+docker build --platform linux/amd64 -t goshtoso-site:test .
+scripts/check-site-image goshtoso-site:test
+```

--- a/scripts/check-site-image
+++ b/scripts/check-site-image
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Exercise the image under the homelab Deployment's security restrictions.
+set -euo pipefail
+image=${1:?usage: check-site-image IMAGE}
+test "$(docker inspect --format '{{.Config.User}}' "$image")" = 10001:10001
+expected_version=${2:-$(awk '$1 == "github.com/araihu/goshtoso" {print $2}' site/go.mod)}
+test -n "$expected_version"
+container_id=$(docker run -d --platform linux/amd64 --read-only \
+  --user 10001:10001 --tmpfs /tmp:uid=10001,gid=10001,mode=1777 \
+  --cap-drop ALL --security-opt no-new-privileges "$image")
+trap 'docker rm -f "$container_id" >/dev/null' EXIT
+for attempt in {1..30}; do
+  if docker exec "$container_id" wget -q -O /tmp/page.html http://127.0.0.1:8090/components/accordion; then
+    docker exec "$container_id" sh -ec 'test "$(id -u)" = 10001; grep -q Accordion /tmp/page.html; test ! -e /app/go.work'
+    docker exec "$container_id" grep -q -F "$expected_version" /tmp/page.html
+    docker exec "$container_id" wget -q -O /dev/null http://127.0.0.1:8090/modules/app-shells/live/componentdocshell/overview
+    printf 'Site image HTTP and restricted runtime checks: PASS\n'
+    exit 0
+  fi
+  sleep 1
+done
+docker logs "$container_id"
+exit 1

--- a/site/go.mod
+++ b/site/go.mod
@@ -4,7 +4,7 @@ go 1.27.0
 
 require (
 	github.com/a-h/templ v0.3.1020
-	github.com/araihu/goshtoso v0.2.11-0.20260910225952-4a5e3df76225
+	github.com/araihu/goshtoso v0.3.0
 	github.com/araihu/goshtoso-app-shells v0.1.9-0.20260910224508-5b2222e54637
 	github.com/araihu/goshtoso-charts v0.0.3
 	github.com/coder/websocket v1.8.15

--- a/site/go.sum
+++ b/site/go.sum
@@ -12,6 +12,8 @@ github.com/araihu/goshtoso v0.2.11-0.20260910222250-b9e434e3f393 h1:2WNAE6raT6oT
 github.com/araihu/goshtoso v0.2.11-0.20260910222250-b9e434e3f393/go.mod h1:9gg3IPPU1C1gJZUZts+AUDfbV/iYb0N5mSbL5NtyRzU=
 github.com/araihu/goshtoso v0.2.11-0.20260910225952-4a5e3df76225 h1:pnFtu2HT2DDkqmXCPb1/DuD2+fVcflP4KuxRFiyGER0=
 github.com/araihu/goshtoso v0.2.11-0.20260910225952-4a5e3df76225/go.mod h1:9gg3IPPU1C1gJZUZts+AUDfbV/iYb0N5mSbL5NtyRzU=
+github.com/araihu/goshtoso v0.3.0 h1:6+fTBCzDHFCfEtw8UGH3IePfrDsCyDvaZPIEn3V85i8=
+github.com/araihu/goshtoso v0.3.0/go.mod h1:9gg3IPPU1C1gJZUZts+AUDfbV/iYb0N5mSbL5NtyRzU=
 github.com/araihu/goshtoso-app-shells v0.1.9-0.20260910213838-cacbfabe8724 h1:dP/6L+EYnWSj2X4LUvqejilFMSrA1Zb/hOy7J/8WTkE=
 github.com/araihu/goshtoso-app-shells v0.1.9-0.20260910213838-cacbfabe8724/go.mod h1:vme6qwadyuneFflKQsnvIWYp8D/oFhJSux0YOxPMvhg=
 github.com/araihu/goshtoso-app-shells v0.1.9-0.20260910221700-55245c718fa6 h1:/4H5pub17UGf2AbINzz1xiJKqwAl7tOoFZCpiZrmBaQ=


### PR DESCRIPTION
Own the Goshtoso site image in this repository and publish it to `ghcr.io/araihu/goshtoso` after successful main Code CI. Replace the obsolete central deployment dispatch with a build, restricted-runtime smoke test, GHCR push, and immutable digest artifact for the homelab GitOps rollout.

The image runs as UID/GID 10001, serves port 8090, and supports the homelab read-only root filesystem with writable /tmp. Container CI tests both a component page and a live shell route. The documentation dependency pin is v0.3.0 (includes #301).

Validated: linux/amd64 image build; restricted-runtime smoke test and displayed v0.3.0; workflow lint; scripts tests; both site module contracts. Homelab consumes the resulting digest in a separate GitOps change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published the homelab site as a container image through the GitHub Container Registry.
  * Added support for manually triggered image publishing after successful CI validation.
  * Added local and CI checks for secure, read-only container execution.

* **Security**
  * Site containers now run as a non-root user with restricted privileges.

* **Documentation**
  * Added container usage, deployment, rollback, and local verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->