### PR TITLE
Update public consumer skill for Goshtoso v0.3.0

### DIFF
--- a/.agents/skills/using-goshtoso/LICENSE
+++ b/.agents/skills/using-goshtoso/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Goshtoso contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/using-goshtoso/SKILL.md
+++ b/.agents/skills/using-goshtoso/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: using-goshtoso
-description: Use when building, designing, redesigning, integrating, or updating an external Go/templ application in the Goshtoso ecosystem. Triggers for discovery and reuse of Goshtoso components, Goshtoso Charts, Margo Markdown/document rendering, Goshtoso App Shells, consumer icon packs, application shells, dashboards, operations lists, detail pages, settings, onboarding, workflows, public content, metadata, social previews, component selection, visual direction, state design, asset serving, Tailwind CSS, Alpine.js, HTMX, or component API debugging. Requires checking supported ecosystem solutions before writing custom HTML, CSS, or JavaScript.
+description: Build, integrate, or upgrade external Go/templ applications using Goshtoso components, assets, HTMX, and Alpine.js. Discover supported App Shells, Charts, Margo, and Iconpack APIs before adding custom UI. Use for consumer applications, not library maintenance.
+license: MIT
 ---
 
 # Using Goshtoso
@@ -12,6 +13,14 @@ as a library dependency: consumers import pre-generated components, serve the
 embedded assets, and run `templ generate` only for their own `.templ` files.
 This skill is for integrating Goshtoso into external applications, not for
 modifying the Goshtoso component library or demo site itself.
+
+## Release baseline
+
+This skill targets **Goshtoso v0.3.0**, with **htmx 4.0.0** and
+**Alpine.js 3.17.2**. For a new application, start with this explicit release;
+for an existing application, inspect `go.mod` before changing dependencies.
+Read [the v0.3.0 migration reference](references/migration-v0.3.0.md) when
+upgrading a 0.2.x consumer. Do not add HTMX 2 compatibility shims to a v0.3.0 app.
 
 ## When to Use
 
@@ -68,7 +77,7 @@ Use this path unless the app deliberately owns a custom Tailwind build.
 Goshtoso requires **Go 1.27.0 or newer**.
 
 ```bash
-GOSHTOSO_VERSION="${GOSHTOSO_VERSION:?set an explicit Goshtoso release}"
+GOSHTOSO_VERSION=v0.3.0
 go get github.com/araihu/goshtoso@"$GOSHTOSO_VERSION"
 go get github.com/a-h/templ
 TEMPL_VERSION="$(go list -m -f '{{.Version}}' github.com/a-h/templ)"
@@ -139,7 +148,7 @@ safe default social image. Render metadata in initial HTML, not through client
 JavaScript or HTMX fragments.
 
 `head.Dependencies()` emits Goshtoso CSS and an ordered loader for Alpine.js,
-its collapse/focus/mask plugins, HTMX, and the first-party
+its collapse/focus/mask plugins, HTMX 4, `hx-alpine-compat`, and the first-party
 `/assets/js/goshtoso.min.js` bundle. Third-party dependencies try
 version-pinned CDN URLs first and create a fresh script for the exact embedded
 version when a CDN download fails. Keep `assets.Handler()` mounted even when
@@ -202,7 +211,7 @@ density. Keep multiline manifests and source examples at default density:
 @codeblock.CodeBlock(codeblock.Config{
 	Language: "bash",
 	Label: "Install",
-	Code: "go get github.com/araihu/goshtoso@v0.2.6",
+	Code: "go get github.com/araihu/goshtoso@v0.3.0",
 	Density: codeblock.DensityCompact,
 })
 

--- a/.agents/skills/using-goshtoso/references/application-patterns.md
+++ b/.agents/skills/using-goshtoso/references/application-patterns.md
@@ -99,8 +99,10 @@ skip navigation.
 - Return breadcrumbs or counters out of band when they belong to the shell.
 - After a navigation swap, focus `#main-content` and move its scroll position to
   the top.
-- Do not cache pages whose Alpine state cannot be reconstructed. Prefer a full
-  body boost or `hx-history="false"` for those routes.
+- HTMX 4 history snapshots require the optional `hx-history-cache` extension.
+  Keep it out of the runtime when page state cannot be safely restored; test
+  Back/Forward with the actual navigation strategy. Do not copy HTMX 2 history
+  configuration into a v0.3.0 consumer.
 
 ### Responsive contract
 

--- a/.agents/skills/using-goshtoso/references/ecosystem-discovery.md
+++ b/.agents/skills/using-goshtoso/references/ecosystem-discovery.md
@@ -17,11 +17,15 @@ or an unreleased `main` branch.
 
 ## Verified Public Baseline
 
-This reference was reconciled on 2026-08-19 against Goshtoso `v0.2.5`,
-Goshtoso App Shells `v0.1.6`, Margo `v0.0.6`, and Goshtoso Charts `v0.0.2`
-module tag. These versions describe the review baseline, not a command to
-downgrade or upgrade. Recheck public versions and honor the consumer's `go.mod`
-before using an API.
+Goshtoso's baseline is `v0.3.0`, checked against its published tag on
+2026-09-11. The HTMX 4 site pairs it with App Shells
+`v0.1.9-0.20260910224508-5b2222e54637`; App Shells `v0.1.8` still uses HTMX 2
+events. Use this exact compatible pseudo-version until selecting a newer
+verified compatible release; do not infer compatibility from `@latest`.
+
+Charts `v0.0.2` and Margo `v0.0.6` remain the earlier API review baselines,
+not claims about their latest releases. Recheck each selected public version
+and honor the consumer's `go.mod` before using an API.
 
 ## Evidence Order
 

--- a/.agents/skills/using-goshtoso/references/migration-v0.3.0.md
+++ b/.agents/skills/using-goshtoso/references/migration-v0.3.0.md
@@ -1,0 +1,61 @@
+# Migrating consumers to Goshtoso v0.3.0
+
+Verified against the public Goshtoso v0.3.0 tag and its `muamba.yaml` on
+2026-09-11. This is a breaking runtime upgrade from the 0.2.x line.
+
+## Dependencies and delivery
+
+Pin `github.com/araihu/goshtoso@v0.3.0`. Its supported runtime is htmx 4.0.0,
+Alpine.js 3.17.2 and matching Collapse, Focus, and Mask plugins. Keep
+`head.Dependencies()` and `assets.Handler()` together: the loader includes
+`hx-alpine-compat` and same-version local fallbacks. Remove app-owned duplicate
+runtime tags. Use `head.WithLocalRuntime()` for an explicit no-CDN requirement.
+
+For App Shells, the compatible version used by the released site's integration
+is `v0.1.9-0.20260910224508-5b2222e54637`. Pin that commit when adding shells
+unless a newer release has been verified with HTMX 4. The older `v0.1.8` tag
+still uses HTMX 2 events. Inspect the selected public APIs with `go doc`; do not
+copy shell internals into the consumer.
+
+## Consumer-owned markup and handlers
+
+- Use colon-separated lifecycle events: `htmx:before:request`,
+  `htmx:after:swap`, `htmx:after:settle`, and `htmx:config:request`. Audit custom
+  listeners and Alpine `x-on` handlers for old camel-case event names.
+- Request event data is in `event.detail.ctx`; the transport uses Fetch.
+  Rewrite XHR-dependent handlers against the selected event's documented
+  context rather than blindly renaming fields.
+- Attribute inheritance is explicit. If child requests rely on a parent target,
+  declare `hx-target:inherited="#content"`; test the actual child request.
+- Use `hx-disable` for request-time disabling, including
+  `hx-disable="find button[type='submit']"` on a form-owned request.
+- All response statuses except 204/304 swap by default. Return useful validation
+  and recovery HTML for 4xx/5xx responses; deliberately cancel unwanted swaps
+  with `htmx:before:swap` instead of preserving a blanket HTMX 2 error workaround.
+- Extensions activate when loaded. Remove `hx-ext` and use the HTMX 4 SSE/WS
+  extensions supplied by the manifest; old extension packages are incompatible.
+- Use native `innerMorph` or `outerMorph` when preserving local state is desired.
+  `hx-alpine-compat` coordinates Alpine during settlement and morphing. A
+  replacement swap remains appropriate when state should reset. Do not add
+  blanket Alpine reinitialization or a separate Alpine Morph plugin.
+
+Keep changes scoped to the consumer's actual integration. Server-owned business
+rules, validation, and authorization remain server-owned.
+
+## Validation before shipping the consumer
+
+Regenerate the app's templ files, tidy its modules, and run its Go tests. In a
+browser, exercise direct entry, fragment navigation, Back/Forward, repeated
+swaps, edited inputs, focus, and any open overlays. Hold a submission pending
+to check disabling and deduplication; exercise validation and server-error
+responses. Check console errors and CDN failure/local fallback. Test SSE/WS
+only when the app uses them. Do not treat a static screenshot as lifecycle
+coverage.
+
+## Sources
+
+- [Goshtoso v0.3.0](https://github.com/araihu/goshtoso/releases/tag/v0.3.0)
+- [Locked runtime inputs](https://github.com/araihu/goshtoso/blob/v0.3.0/muamba.yaml)
+- [Runtime ordering](https://github.com/araihu/goshtoso/blob/v0.3.0/assets/runtime.overlay.yaml)
+- [HTMX 4 reference](https://four.htmx.org/reference)
+- [Alpine compatibility extension](https://four.htmx.org/extensions/hx-alpine-compat)

--- a/.agents/skills/using-goshtoso/references/runtime-integration.md
+++ b/.agents/skills/using-goshtoso/references/runtime-integration.md
@@ -27,7 +27,8 @@ defer, and readiness semantics. Cache stylesheet and loader URLs separately.
 Execute either the loader or direct local scripts, never both.
 
 Custom roles must remain unique and safe. Preserve Alpine plugin and first-party
-ordering before Alpine, plus HTMX before SSE/WS. For custom local-only loading,
+ordering before Alpine. Load HTMX, then `hx-alpine-compat`, then Alpine core;
+keep SSE/WS after HTMX. The default manifest already supplies this order. For custom local-only loading,
 set each `PrimaryURL` to its `LocalURL`, keep the loader local, and use
 `WithoutLocalFallback()`. `WithLocalRuntime` applies only to the default
 manifest. Invalid manifests fail before emitting HTML.
@@ -36,6 +37,18 @@ Goshtoso guarantees its pinned runtime combination, not arbitrary overrides.
 Bind same-version caches only when `assets.GoshtosoVersion().Status` is
 `assets.VersionExact`; development, replacement, and unavailable builds do not
 identify exact Goshtoso bytes.
+
+## Alpine and fragment lifecycle
+
+The bundled `hx-alpine-compat` extension coordinates Alpine with HTMX settling
+and preserves reactive scope during `innerMorph` / `outerMorph` swaps. Register
+app providers before Alpine starts. Do not add a second Alpine runtime,
+`@alpinejs/morph`, or unconditional `Alpine.initTree()` after each swap.
+Replacement swaps still destroy the replaced state. Keep stable IDs for morphs
+and test edited fields, focus, reactive IDs, and repeated navigation.
+
+See [the release migration reference](migration-v0.3.0.md) for request/event
+changes and the App Shells dependency boundary.
 
 ## CSP
 


### PR DESCRIPTION
Update the publicly installable `using-goshtoso` skill for Goshtoso v0.3.0, HTMX 4.0.0, and Alpine 3.17.2. Add focused migration guidance, the compatible App Shells pseudo-version, runtime ordering, and remove obsolete history guidance. Narrow discovery wording and include the MIT license for redistributed copies.

Validation: skill validator passed; generated component reference unchanged; `go test ./internal/skillgen -count=1` passed; `git diff --check` passed. The same skill is being distributed through guilycst/skills to Codex installations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Goshtoso integration guidance for the v0.3.0 baseline, including HTMX 4 and Alpine.js 3.17.2 compatibility.
  * Added a migration guide covering required runtime, event, targeting, request, swapping, and extension updates.
  * Clarified dependency loading order, Alpine lifecycle handling, morphing behavior, and history snapshot considerations.
  * Added guidance for verifying compatible published versions and honoring consumer dependency constraints.

* **Chores**
  * Added MIT licensing information for the skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->