### PR TITLE
fix: bound iconpack memory with verified disk-backed sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Goshtoso are documented in this file.
 
+## [v0.3.1] - 2026-09-11
+
+### Iconpack memory and integrity
+
+- Generate icon libraries from verified disk-backed sources, reading and
+  copying one image at a time instead of retaining the complete pack in memory.
+- Preserve deterministic catalog, manifest, provenance, licensing and image
+  bytes, with hash verification during publication and no overwrite of output.
+- Capture source provenance under the mutation lock and propagate cancellation
+  through source acquisition and cache publication using Muamba v0.0.6.
+- Existing iconpack consumers require no configuration or API migration.
+
 ## [v0.3.0] - 2026-09-10
 
 ### Breaking runtime migration

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,6 +11,7 @@ is retained in this table.
 
 | Goshtoso | Tailwind CSS |
 |----------|--------------|
+| v0.3.1   | 4.3.3        |
 | v0.3.0   | 4.3.3        |
 | v0.2.10  | 4.3.3        |
 | v0.2.9   | 4.3.3        |

--- a/docs/ICONPACK.md
+++ b/docs/ICONPACK.md
@@ -11,7 +11,7 @@ The general contract uses Muamba as a Go library; consumers do not install a
 Muamba executable and the command never searches for or changes `muamba.yaml`,
 `.muamba.yaml`, or `.muamba.lock.yaml`. The generated Muamba adapter
 declaration is kept in memory. Only the explicit `.iconpack.lock.yaml` and the
-consumer-owned output are durable. The Goshtoso integration uses Muamba
+consumer-owned output are durable. The Goshtoso integration uses Muamba through
 the `source.Engine.Walk` API; the adapter never creates a
 `.iconpack.engine.yaml` file.
 

--- a/docs/ICONPACK.md
+++ b/docs/ICONPACK.md
@@ -12,7 +12,17 @@ Muamba executable and the command never searches for or changes `muamba.yaml`,
 `.muamba.yaml`, or `.muamba.lock.yaml`. The generated Muamba adapter
 declaration is kept in memory. Only the explicit `.iconpack.lock.yaml` and the
 consumer-owned output are durable. The Goshtoso integration uses Muamba
-`v0.0.5` or newer; the adapter never creates a `.iconpack.engine.yaml` file.
+the `source.Engine.Walk` API; the adapter never creates a
+`.iconpack.engine.yaml` file.
+
+Muamba-backed sources are captured to private temporary disk storage, one
+verified file at a time. Library generation retains source metadata and the
+catalog, validates one image at a time, and streams image bytes to unpublished
+output staging while checking their size and SHA-256 again. Checking an
+existing output also hashes files individually. Neither path retains the PNG
+collection in memory. The catalog, provenance, manifest, ordering, and refusal
+to overwrite an existing different output remain unchanged. Temporary source
+and output staging are removed on errors or cancellation.
 
 For Arai Hû Assets, the input is an extracted release root or release archive.
 A Goshtoso checkout, GitHub source archive, `internal/acquisition/vendor` tree,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/a-h/templ v0.3.1020
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/araihu/assets v0.2.3
-	github.com/araihu/muamba v0.0.5
+	github.com/araihu/muamba v0.0.6-0.20260911181149-86271baf604f
 	github.com/evanw/esbuild v0.28.2
 	github.com/gofrs/flock v0.13.1
 	github.com/stretchr/testify v1.12.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/a-h/templ v0.3.1020
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/araihu/assets v0.2.3
-	github.com/araihu/muamba v0.0.6-0.20260911181149-86271baf604f
+	github.com/araihu/muamba v0.0.6-0.20260911182820-644454aa9f3b
 	github.com/evanw/esbuild v0.28.2
 	github.com/gofrs/flock v0.13.1
 	github.com/stretchr/testify v1.12.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/a-h/templ v0.3.1020
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/araihu/assets v0.2.3
-	github.com/araihu/muamba v0.0.6-0.20260911182820-644454aa9f3b
+	github.com/araihu/muamba v0.0.6
 	github.com/evanw/esbuild v0.28.2
 	github.com/gofrs/flock v0.13.1
 	github.com/stretchr/testify v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/araihu/assets v0.2.3 h1:PoQ3xfAT58uH+aMLGEyJvzQ8VzqDxBlg66tDfNIA2i4=
 github.com/araihu/assets v0.2.3/go.mod h1:VM1Mx/AHKYDz7SMpaUWS9EDNUmw/aJ5OpyHEpucbihg=
-github.com/araihu/muamba v0.0.6-0.20260911181149-86271baf604f h1:f2XHhnC1VDUzHBgBXduNRFRZ/tEiZQZDe545VaiU1cM=
-github.com/araihu/muamba v0.0.6-0.20260911181149-86271baf604f/go.mod h1:7aymWYw4g+NDhWnqulbVJDGZMg+pLga5w8fe1YNudZ4=
+github.com/araihu/muamba v0.0.6-0.20260911182820-644454aa9f3b h1:lmuwBHP3Hfe8fuL+uuAga6Ps63f6peksxPBwqkWPOAg=
+github.com/araihu/muamba v0.0.6-0.20260911182820-644454aa9f3b/go.mod h1:7aymWYw4g+NDhWnqulbVJDGZMg+pLga5w8fe1YNudZ4=
 github.com/dlclark/regexp2/v2 v2.2.1 h1:mf4KkFUj0gJuarK8P+LgiS+Lit7m9N1yAwEfPbee7R0=
 github.com/dlclark/regexp2/v2 v2.2.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/evanw/esbuild v0.28.2 h1:A2uETn4jrQTcXaT/shwTDTYBxDjl7fV7nXmUrJxfA2w=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/araihu/assets v0.2.3 h1:PoQ3xfAT58uH+aMLGEyJvzQ8VzqDxBlg66tDfNIA2i4=
 github.com/araihu/assets v0.2.3/go.mod h1:VM1Mx/AHKYDz7SMpaUWS9EDNUmw/aJ5OpyHEpucbihg=
-github.com/araihu/muamba v0.0.5 h1:trn4AXXhk0jPdA5hsobEiHA5bs1/awkboZVFLbKlvV8=
-github.com/araihu/muamba v0.0.5/go.mod h1:HWgw9kWiYam0Y8Ulmej5aW/AvLd8L2GWUmO6WlYNsVQ=
+github.com/araihu/muamba v0.0.6-0.20260911181149-86271baf604f h1:f2XHhnC1VDUzHBgBXduNRFRZ/tEiZQZDe545VaiU1cM=
+github.com/araihu/muamba v0.0.6-0.20260911181149-86271baf604f/go.mod h1:7aymWYw4g+NDhWnqulbVJDGZMg+pLga5w8fe1YNudZ4=
 github.com/dlclark/regexp2/v2 v2.2.1 h1:mf4KkFUj0gJuarK8P+LgiS+Lit7m9N1yAwEfPbee7R0=
 github.com/dlclark/regexp2/v2 v2.2.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/evanw/esbuild v0.28.2 h1:A2uETn4jrQTcXaT/shwTDTYBxDjl7fV7nXmUrJxfA2w=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/araihu/assets v0.2.3 h1:PoQ3xfAT58uH+aMLGEyJvzQ8VzqDxBlg66tDfNIA2i4=
 github.com/araihu/assets v0.2.3/go.mod h1:VM1Mx/AHKYDz7SMpaUWS9EDNUmw/aJ5OpyHEpucbihg=
-github.com/araihu/muamba v0.0.6-0.20260911182820-644454aa9f3b h1:lmuwBHP3Hfe8fuL+uuAga6Ps63f6peksxPBwqkWPOAg=
-github.com/araihu/muamba v0.0.6-0.20260911182820-644454aa9f3b/go.mod h1:7aymWYw4g+NDhWnqulbVJDGZMg+pLga5w8fe1YNudZ4=
+github.com/araihu/muamba v0.0.6 h1:dyXHGLoh7YNmLBKWHuFae77kTEj+xev/N5YMb6G3yZU=
+github.com/araihu/muamba v0.0.6/go.mod h1:7aymWYw4g+NDhWnqulbVJDGZMg+pLga5w8fe1YNudZ4=
 github.com/dlclark/regexp2/v2 v2.2.1 h1:mf4KkFUj0gJuarK8P+LgiS+Lit7m9N1yAwEfPbee7R0=
 github.com/dlclark/regexp2/v2 v2.2.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/evanw/esbuild v0.28.2 h1:A2uETn4jrQTcXaT/shwTDTYBxDjl7fV7nXmUrJxfA2w=

--- a/iconpack/file_data.go
+++ b/iconpack/file_data.go
@@ -1,0 +1,125 @@
+package iconpack
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	muambasource "github.com/araihu/muamba/source"
+)
+
+// fileData retains small generated documents or the identity of a private disk
+// file. Every disk read verifies the bytes consumed, including publication.
+type fileData struct {
+	data []byte
+	path string
+	size int64
+	hash string
+}
+
+func memoryFile(data []byte) fileData {
+	return fileData{data: data, size: int64(len(data)), hash: hashBytes(data)}
+}
+
+func (f fileData) copy(ctx context.Context, w io.Writer) error {
+	var r io.Reader = bytes.NewReader(f.data)
+	if f.path != "" {
+		file, err := os.Open(f.path)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = file.Close() }()
+		info, err := file.Stat()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("source is not a regular file")
+		}
+		r = file
+	}
+	h := sha256.New()
+	n, err := io.Copy(io.MultiWriter(w, h), cancelReader{ctx, io.LimitReader(r, f.size+1)})
+	if err != nil {
+		return err
+	}
+	if n != f.size || fmt.Sprintf("%x", h.Sum(nil)) != f.hash {
+		return fmt.Errorf("source integrity mismatch")
+	}
+	return ctx.Err()
+}
+
+func (f fileData) read(ctx context.Context) ([]byte, error) {
+	var b bytes.Buffer
+	if err := f.copy(ctx, &b); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+func (f fileData) decodeJSON(ctx context.Context, value any) error {
+	data, err := f.read(ctx)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, value)
+}
+
+type cancelReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (r cancelReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.r.Read(p)
+}
+
+func captureMuambaFiles(ctx context.Context, engine *muambasource.Engine, sources []resolvedConfigSource, staging, lockPath string) (map[string]fileData, []byte, error) {
+	files := map[string]fileData{}
+	var lockBytes []byte
+	err := engine.Walk(ctx, nil, func(meta muambasource.File, r io.Reader) error {
+		// Capture provenance while Walk still owns the namespace mutation lock.
+		// Another cooperative Lock cannot replace the lockfile between the
+		// source snapshot and this read.
+		if lockBytes == nil {
+			var err error
+			lockBytes, err = os.ReadFile(lockPath)
+			if err != nil {
+				return fmt.Errorf("read iconpack lock: %w", err)
+			}
+		}
+		key, err := snapshotKey(meta.Path, sources)
+		if err != nil {
+			return err
+		}
+		if _, exists := files[key]; exists {
+			return fmt.Errorf("iconpack source files resolve to duplicate path %q", key)
+		}
+		file, err := os.CreateTemp(staging, "source-*")
+		if err != nil {
+			return err
+		}
+		h := sha256.New()
+		n, copyErr := io.Copy(io.MultiWriter(file, h), r)
+		closeErr := file.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if n != meta.Size {
+			return fmt.Errorf("source size mismatch")
+		}
+		files[key] = fileData{path: file.Name(), size: n, hash: fmt.Sprintf("%x", h.Sum(nil))}
+		return nil
+	})
+	return files, lockBytes, err
+}

--- a/iconpack/file_data_test.go
+++ b/iconpack/file_data_test.go
@@ -1,0 +1,67 @@
+package iconpack
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiskFileRejectsChangesBeforePublication(t *testing.T) {
+	for _, mode := range []string{"rewrite", "replace", "grow", "cancel"} {
+		t.Run(mode, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, "source")
+			data := []byte("verified")
+			if err := os.WriteFile(path, data, 0600); err != nil {
+				t.Fatal(err)
+			}
+			file := fileData{path: path, size: int64(len(data)), hash: hashBytes(data)}
+			if _, err := file.read(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			if mode == "cancel" {
+				cancel()
+			} else {
+				if mode == "replace" {
+					if err := os.Remove(path); err != nil {
+						t.Fatal(err)
+					}
+				}
+				replacement := []byte("modified")
+				if mode == "grow" {
+					replacement = append(data, '!')
+				}
+				if err := os.WriteFile(path, replacement, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			output := filepath.Join(root, "output")
+			if _, _, err := publishFileOutput(ctx, output, map[string]fileData{"images/a.png": file}, false); err == nil {
+				t.Fatal("published unverified bytes")
+			}
+			if _, err := os.Stat(output); !os.IsNotExist(err) {
+				t.Fatalf("output exists: %v", err)
+			}
+			matches, err := filepath.Glob(filepath.Join(root, ".output.tmp-*"))
+			if err != nil || len(matches) != 0 {
+				t.Fatalf("staging leaked: %v %v", matches, err)
+			}
+		})
+	}
+}
+
+func TestDiskFileReadDoesNotTrustReplacementPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(path, []byte("bad"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	file := fileData{path: path, size: 3, hash: hashBytes([]byte("old"))}
+	if err := file.copy(t.Context(), io.Discard); err == nil || !strings.Contains(err.Error(), "integrity mismatch") {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/iconpack/generate.go
+++ b/iconpack/generate.go
@@ -407,6 +407,13 @@ func readVerifiedReleaseFile(boundary releaseBoundary, relative string) ([]byte,
 		return nil, fmt.Errorf("required release file %q is absent from checksums.txt", relative)
 	}
 	b, ok := boundary.files[relative]
+	if boundary.diskFiles != nil {
+		file, exists := boundary.diskFiles[relative]
+		if !exists || file.hash != expected {
+			return nil, fmt.Errorf("required release file %q is absent or has changed identity", relative)
+		}
+		return file.read(boundary.ctx)
+	}
 	if !ok {
 		return nil, fmt.Errorf("required release file %q is absent from captured release boundary", relative)
 	}

--- a/iconpack/library.go
+++ b/iconpack/library.go
@@ -3,7 +3,6 @@ package iconpack
 import (
 	"cmp"
 	"context"
-	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -34,50 +33,48 @@ func generateLibrary(ctx context.Context, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	snapshot, err := engine.Snapshot(ctx, nil)
+	staging, err := os.MkdirTemp("", "goshtoso-library-*")
 	if err != nil {
 		return Result{}, err
 	}
-	files, _, err := captureMuambaFiles(snapshot, input.sources)
+	defer func() { _ = os.RemoveAll(staging) }()
+	files, lock, err := captureMuambaFiles(ctx, engine, input.sources, staging, input.lockPath)
 	if err != nil {
 		return Result{}, err
 	}
-	output, catalog, err := libraryOutputs(input.sources, files)
+	output, catalog, err := libraryOutputs(ctx, input.sources, files)
 	if err != nil {
 		return Result{}, err
 	}
-	lock, err := os.ReadFile(input.lockPath)
-	if err != nil {
-		return Result{}, err
-	}
-	output["PROVENANCE/config.yaml"] = input.configBytes
-	output["PROVENANCE/lock.yaml"] = lock
+	output["PROVENANCE/config.yaml"] = memoryFile(input.configBytes)
+	output["PROVENANCE/lock.yaml"] = memoryFile(lock)
 	release := "iconpack-" + hashBytes(input.configBytes)[:12]
-	catalogHash := hashBytes(output["catalog.json"])
+	catalogHash := output["catalog.json"].hash
 	manifest := outputManifest{SchemaVersion: OutputSchemaVersion, Tool: toolName, Release: release, CatalogSchemaVersion: catalog.SchemaVersion, CatalogSHA256: catalogHash, SourceKind: "muamba-snapshot", SourceConfigSHA256: hashBytes(input.configBytes), SourceLockSHA256: hashBytes(lock)}
 	for name, data := range output {
-		manifest.Files = append(manifest.Files, outputFile{Path: name, Mode: "0644", Bytes: len(data), SHA256: hashBytes(data)})
+		manifest.Files = append(manifest.Files, outputFile{Path: name, Mode: "0644", Bytes: int(data.size), SHA256: data.hash})
 	}
 	sort.Slice(manifest.Files, func(i, j int) bool { return manifest.Files[i].Path < manifest.Files[j].Path })
-	output["manifest.json"], err = marshalDocument(manifest)
+	manifestBytes, err := marshalDocument(manifest)
 	if err != nil {
 		return Result{}, err
 	}
-	published, path, err := publishOutput(ctx, opts.OutputDir, output, opts.Check)
+	output["manifest.json"] = memoryFile(manifestBytes)
+	published, path, err := publishFileOutput(ctx, opts.OutputDir, output, opts.Check)
 	return Result{Release: release, OutputDir: path, Published: published, SelectedCount: len(catalog.Icons), CatalogSHA256: catalogHash}, err
 }
 
-func libraryOutputs(sources []resolvedConfigSource, files map[string][]byte) (map[string][]byte, iconlibrary.Catalog, error) {
-	out := map[string][]byte{}
+func libraryOutputs(ctx context.Context, sources []resolvedConfigSource, files map[string]fileData) (map[string]fileData, iconlibrary.Catalog, error) {
+	out := map[string]fileData{}
 	catalog := iconlibrary.Catalog{SchemaVersion: 1}
 	seen := map[string]bool{}
 	for _, source := range sources {
-		icons, err := sourceLibraryIcons(source, files)
+		icons, err := sourceLibraryIcons(ctx, source, files)
 		if err != nil {
 			return nil, catalog, err
 		}
 		license := files[source.ID+"/"+source.LicensePath]
-		if len(license) == 0 {
+		if license.size == 0 {
 			return nil, catalog, fmt.Errorf("missing license for %s", source.ID)
 		}
 		out["LICENSES/"+source.ID+".txt"] = license
@@ -88,9 +85,16 @@ func libraryOutputs(sources []resolvedConfigSource, files map[string][]byte) (ma
 			seen[entry.ID] = true
 			for i := range entry.Variants {
 				v := &entry.Variants[i]
-				raw, ok := files[source.ID+"/"+v.Path]
+				file, ok := files[source.ID+"/"+v.Path]
 				if !ok {
 					return nil, catalog, fmt.Errorf("missing icon %s", v.Path)
+				}
+				if file.size == 0 || file.size > iconlibrary.MaxImageBytes {
+					return nil, catalog, fmt.Errorf("%s: icon must be between 1 byte and 2 MiB", v.Path)
+				}
+				raw, err := file.read(ctx)
+				if err != nil {
+					return nil, catalog, err
 				}
 				mime, w, h, err := iconlibrary.ValidateImage(raw)
 				if err != nil {
@@ -99,7 +103,7 @@ func libraryOutputs(sources []resolvedConfigSource, files map[string][]byte) (ma
 				v.MIME, v.Width, v.Height, v.SHA256 = mime, w, h, hashBytes(raw)
 				ext := map[string]string{"image/png": ".png", "image/jpeg": ".jpg", "image/webp": ".webp", "image/svg+xml": ".svg"}[mime]
 				v.Path = "images/" + v.SHA256 + ext
-				out[v.Path] = raw
+				out[v.Path] = file
 			}
 			catalog.Icons = append(catalog.Icons, entry)
 		}
@@ -112,18 +116,18 @@ func libraryOutputs(sources []resolvedConfigSource, files map[string][]byte) (ma
 	if err != nil {
 		return nil, catalog, err
 	}
-	out["catalog.json"] = data
+	out["catalog.json"] = memoryFile(data)
 	var notice strings.Builder
 	for _, s := range sources {
 		fmt.Fprintf(&notice, "%s: %s\nSource: %s\nLicense: LICENSES/%s.txt\n\n", s.ID, s.License, s.URL, s.ID)
 	}
-	out["NOTICE"] = []byte(strings.TrimSpace(notice.String()) + "\n")
+	out["NOTICE"] = memoryFile([]byte(strings.TrimSpace(notice.String()) + "\n"))
 	return out, catalog, nil
 }
 
-func sourceLibraryIcons(s resolvedConfigSource, files map[string][]byte) ([]iconlibrary.Icon, error) {
+func sourceLibraryIcons(ctx context.Context, s resolvedConfigSource, files map[string]fileData) ([]iconlibrary.Icon, error) {
 	if s.MetadataFormat == "selfhst" {
-		return selfhstIcons(s, files)
+		return selfhstIcons(ctx, s, files)
 	}
 	var result []iconlibrary.Icon
 	byReference := map[string]int{}
@@ -164,9 +168,9 @@ func libraryFormat(path string) string {
 	return format
 }
 
-func selfhstIcons(s resolvedConfigSource, files map[string][]byte) ([]iconlibrary.Icon, error) {
+func selfhstIcons(ctx context.Context, s resolvedConfigSource, files map[string]fileData) ([]iconlibrary.Icon, error) {
 	var rows []struct{ Name, Reference, SVG, PNG, Light, Dark, Category, Tags string }
-	if err := json.Unmarshal(files[s.ID+"/"+s.MetadataPath], &rows); err != nil {
+	if err := files[s.ID+"/"+s.MetadataPath].decodeJSON(ctx, &rows); err != nil {
 		return nil, fmt.Errorf("selfhst metadata: %w", err)
 	}
 	formats := s.Formats

--- a/iconpack/library_test.go
+++ b/iconpack/library_test.go
@@ -125,8 +125,13 @@ func assertLibraryManifestAndDeterminism(t *testing.T, opts Options, result Resu
 	if _, err := Generate(t.Context(), second); err != nil {
 		t.Fatal(err)
 	}
-	for name, data := range readFixtureTree(t, second.OutputDir) {
-		if !bytes.Equal(first[name], data) {
+	secondFiles := readFixtureTree(t, second.OutputDir)
+	if len(first) != len(secondFiles) {
+		t.Fatalf("nondeterministic output count: %d != %d", len(first), len(secondFiles))
+	}
+	for name, data := range first {
+		other, ok := secondFiles[name]
+		if !ok || !bytes.Equal(data, other) {
 			t.Fatalf("nondeterministic output: %s", name)
 		}
 	}

--- a/iconpack/library_test.go
+++ b/iconpack/library_test.go
@@ -52,6 +52,7 @@ func TestLibraryLockedCatalogWithRasterAndVariants(t *testing.T) {
 	if manifest.Release != result.Release || manifest.CatalogSchemaVersion != catalog.SchemaVersion || manifest.CatalogSHA256 != result.CatalogSHA256 {
 		t.Fatalf("manifest does not identify its catalog: %+v", manifest)
 	}
+	assertLibraryManifestAndDeterminism(t, opts, result, manifest, root)
 	opts.Trust = false
 	opts.Check = true
 	if _, err := Generate(t.Context(), opts); err != nil {
@@ -68,7 +69,7 @@ func TestLibraryLockedCatalogWithRasterAndVariants(t *testing.T) {
 func TestLibraryGroupsFormatsDeterministically(t *testing.T) {
 	source := resolvedConfigSource{ID: "local", Formats: []string{"svg", "png"}}
 	files := map[string][]byte{"local/foo.png": {}, "local/foo.svg": {}, "local/bar.svg": {}}
-	icons, err := sourceLibraryIcons(source, files)
+	icons, err := sourceLibraryIcons(t.Context(), source, memoryFiles(files))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,10 +99,35 @@ func TestSelfhstAvailabilityStillRequiresDeclaredFiles(t *testing.T) {
 				files = map[string][]byte{}
 			}
 			files["selfhst/index.json"] = []byte(fmt.Sprintf(`[{"Name":"Demo","Reference":"demo","SVG":"Yes","PNG":%q,"Light":%q}]`, tc.png, tc.light))
-			icons, err := selfhstIcons(resolvedConfigSource{ID: "selfhst", MetadataPath: "index.json"}, files)
+			icons, err := selfhstIcons(t.Context(), resolvedConfigSource{ID: "selfhst", MetadataPath: "index.json"}, memoryFiles(files))
 			if (err != nil) != tc.wantError || len(icons) != tc.wantIcons {
 				t.Fatalf("icons=%+v, err=%v", icons, err)
 			}
 		})
+	}
+}
+
+func assertLibraryManifestAndDeterminism(t *testing.T, opts Options, result Result, manifest outputManifest, root string) {
+	t.Helper()
+	for _, file := range manifest.Files {
+		data := mustReadFile(t, filepath.Join(result.OutputDir, file.Path))
+		if len(data) != file.Bytes || hashBytes(data) != file.SHA256 || file.Mode != "0644" {
+			t.Fatalf("manifest mismatch: %+v", file)
+		}
+	}
+	if len(manifest.Files) != 6 {
+		t.Fatalf("unexpected output count: %d", len(manifest.Files))
+	}
+	first := readFixtureTree(t, result.OutputDir)
+	second := opts
+	second.Trust = false
+	second.OutputDir = filepath.Join(root, "second")
+	if _, err := Generate(t.Context(), second); err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range readFixtureTree(t, second.OutputDir) {
+		if !bytes.Equal(first[name], data) {
+			t.Fatalf("nondeterministic output: %s", name)
+		}
 	}
 }

--- a/iconpack/muamba.go
+++ b/iconpack/muamba.go
@@ -56,26 +56,33 @@ func openMuambaPack(ctx context.Context, opts Options) (releaseBoundary, error) 
 	if err != nil {
 		return releaseBoundary{}, err
 	}
-	snapshot, err := engine.Snapshot(ctx, nil)
+	staging, err := os.MkdirTemp("", "goshtoso-sources-*")
 	if err != nil {
 		return releaseBoundary{}, fmt.Errorf("verify iconpack sources: %w", err)
 	}
-	lockBytes, err := os.ReadFile(input.lockPath)
-	if err != nil {
-		return releaseBoundary{}, fmt.Errorf("read iconpack lock: %w", err)
-	}
-	configHash := hashBytes(input.configBytes)
-	files, checksums, err := captureMuambaFiles(snapshot, input.sources)
+	keep := false
+	defer func() {
+		if !keep {
+			_ = os.RemoveAll(staging)
+		}
+	}()
+	files, lockBytes, err := captureMuambaFiles(ctx, engine, input.sources, staging, input.lockPath)
 	if err != nil {
 		return releaseBoundary{}, err
 	}
-	families, assets, err := buildMuambaAssets(input.sources, files)
+	configHash := hashBytes(input.configBytes)
+	checksums := make(map[string]string, len(files))
+	for key, file := range files {
+		checksums[key] = file.hash
+	}
+	families, assets, err := buildMuambaAssets(ctx, input.sources, files)
 	if err != nil {
 		return releaseBoundary{}, err
 	}
 	if len(assets) == 0 {
 		return releaseBoundary{}, fmt.Errorf("iconpack sources contain no selected SVG files")
 	}
+	keep = true
 	return releaseBoundary{
 		sourceKind: "muamba-snapshot",
 		catalog: iconcatalog.Catalog{
@@ -83,12 +90,13 @@ func openMuambaPack(ctx context.Context, opts Options) (releaseBoundary, error) 
 			Assets: assets, Hash: configHash,
 		},
 		checksums: checksums,
-		files:     files,
+		diskFiles: files,
+		ctx:       ctx,
 		muamba: &muambaPack{
 			config: input.config, configBytes: append([]byte(nil), input.configBytes...), manifestPath: filepath.Base(opts.ConfigPath), configHash: hashBytes(input.configBytes),
 			lockHash: hashBytes(lockBytes), families: families,
 		},
-		cleanup: func() {},
+		cleanup: func() { _ = os.RemoveAll(staging) },
 	}, nil
 }
 
@@ -163,24 +171,6 @@ func openMuambaEngine(ctx context.Context, input muambaInput, opts Options) (*mu
 	return engine, nil
 }
 
-func captureMuambaFiles(snapshot []muambasource.SnapshotFile, sources []resolvedConfigSource) (map[string][]byte, map[string]string, error) {
-	files := make(map[string][]byte, len(snapshot))
-	checksums := make(map[string]string, len(snapshot))
-	for _, file := range snapshot {
-		key, err := snapshotKey(file.Path, sources)
-		if err != nil {
-			return nil, nil, err
-		}
-		if _, duplicate := files[key]; duplicate {
-			return nil, nil, fmt.Errorf("iconpack source files resolve to duplicate path %q", key)
-		}
-		contents := append([]byte(nil), file.Contents...)
-		files[key] = contents
-		checksums[key] = hashBytes(contents)
-	}
-	return files, checksums, nil
-}
-
 func rejectMuambaPath(filename string) error {
 	base := strings.ToLower(filepath.Base(filename))
 	switch base {
@@ -207,12 +197,12 @@ func snapshotKey(target string, sources []resolvedConfigSource) (string, error) 
 	return "", fmt.Errorf("muamba snapshot path %q does not belong to a declared iconpack source", target)
 }
 
-func buildMuambaAssets(sources []resolvedConfigSource, files map[string][]byte) (map[string]sourceFamily, []iconcatalog.Asset, error) {
+func buildMuambaAssets(ctx context.Context, sources []resolvedConfigSource, files map[string]fileData) (map[string]sourceFamily, []iconcatalog.Asset, error) {
 	families := make(map[string]sourceFamily, len(sources))
 	assets := make([]iconcatalog.Asset, 0)
 	seenNames := make(map[string]string)
 	for _, source := range sortedConfigSources(sources) {
-		family, sourceAssets, err := buildMuambaSourceAssets(source, files, seenNames)
+		family, sourceAssets, err := buildMuambaSourceAssets(ctx, source, files, seenNames)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -227,7 +217,7 @@ func buildMuambaAssets(sources []resolvedConfigSource, files map[string][]byte) 
 	return families, assets, nil
 }
 
-func buildMuambaSourceAssets(source resolvedConfigSource, files map[string][]byte, seenNames map[string]string) (sourceFamily, []iconcatalog.Asset, error) {
+func buildMuambaSourceAssets(ctx context.Context, source resolvedConfigSource, files map[string]fileData, seenNames map[string]string) (sourceFamily, []iconcatalog.Asset, error) {
 	familyProduct := source.PackName
 	if familyProduct == "" {
 		familyProduct = source.ID
@@ -238,7 +228,7 @@ func buildMuambaSourceAssets(source resolvedConfigSource, files map[string][]byt
 		LicenseOutput: "LICENSES/" + sourcePackFileName(familyProduct) + "-LICENSE.txt",
 	}
 	licenseBytes, ok := files[family.LicensePath]
-	if !ok || len(licenseBytes) == 0 {
+	if !ok || licenseBytes.size == 0 {
 		return sourceFamily{}, nil, fmt.Errorf("iconpack source %q license %q was not found in the verified snapshot", source.ID, source.LicensePath)
 	}
 	wanted := make(map[string]struct{}, len(source.Paths))
@@ -247,13 +237,17 @@ func buildMuambaSourceAssets(source resolvedConfigSource, files map[string][]byt
 	}
 	assets := make([]iconcatalog.Asset, 0)
 	base := source.ID + "/"
-	for key, raw := range files {
+	for key, file := range files {
 		if !strings.HasPrefix(key, base) {
 			continue
 		}
 		relative := strings.TrimPrefix(key, base)
 		if !isSelectedMuambaIcon(source, relative, wanted) {
 			continue
+		}
+		raw, err := file.read(ctx)
+		if err != nil {
+			return sourceFamily{}, nil, err
 		}
 		viewBox, err := svgViewBox(raw, relative)
 		if err != nil {

--- a/iconpack/muamba_test.go
+++ b/iconpack/muamba_test.go
@@ -161,10 +161,10 @@ func TestNonGitSourceWithoutPackNameUsesNormalizedPath(t *testing.T) {
 	if resolved.PackName != "" {
 		t.Fatalf("non-Git fallback pack name = %q, want empty path-prefix marker", resolved.PackName)
 	}
-	families, assets, err := buildMuambaAssets([]resolvedConfigSource{resolved}, map[string][]byte{
+	families, assets, err := buildMuambaAssets(t.Context(), []resolvedConfigSource{resolved}, memoryFiles(map[string][]byte{
 		"bootstrap-source/LICENSE":         []byte("MIT"),
 		"bootstrap-source/icons/alarm.svg": []byte(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"/>`),
-	})
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/iconpack/publish.go
+++ b/iconpack/publish.go
@@ -1,10 +1,11 @@
 package iconpack
 
 import (
-	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -14,6 +15,18 @@ import (
 )
 
 func publishOutput(ctx context.Context, requested string, files map[string][]byte, check bool) (bool, string, error) {
+	return publishFileOutput(ctx, requested, memoryFiles(files), check)
+}
+
+func memoryFiles(files map[string][]byte) map[string]fileData {
+	result := make(map[string]fileData, len(files))
+	for name, data := range files {
+		result[name] = memoryFile(data)
+	}
+	return result
+}
+
+func publishFileOutput(ctx context.Context, requested string, files map[string]fileData, check bool) (bool, string, error) {
 	location, err := resolveOutputLocation(requested)
 	if err != nil {
 		return false, "", err
@@ -27,7 +40,7 @@ func publishOutput(ctx context.Context, requested string, files map[string][]byt
 		_ = lock.Close()
 	}()
 
-	identical, exists, err := compareOwnedOutput(location.output, files)
+	identical, exists, err := compareFileOutput(ctx, location.output, files)
 	if err != nil {
 		return false, "", err
 	}
@@ -43,7 +56,7 @@ func publishOutput(ctx context.Context, requested string, files map[string][]byt
 		}
 		return false, "", fmt.Errorf("output %s already exists with different or unrelated files; refusing to overwrite", location.output)
 	}
-	if err := stageAndPublish(location, files); err != nil {
+	if err := stageFilesAndPublish(ctx, location, files, nil); err != nil {
 		return false, "", err
 	}
 	return true, location.output, nil
@@ -91,11 +104,11 @@ func acquireOutputLock(ctx context.Context, location outputLocation) (*flock.Flo
 	return lock, nil
 }
 
-func stageAndPublish(location outputLocation, files map[string][]byte) error {
-	return stageAndPublishWithHook(location, files, nil)
+func stageAndPublishWithHook(location outputLocation, files map[string][]byte, beforeFinalize func() error) error {
+	return stageFilesAndPublish(context.Background(), location, memoryFiles(files), beforeFinalize)
 }
 
-func stageAndPublishWithHook(location outputLocation, files map[string][]byte, beforeFinalize func() error) error {
+func stageFilesAndPublish(ctx context.Context, location outputLocation, files map[string]fileData, beforeFinalize func() error) error {
 	staging, err := os.MkdirTemp(location.parent, "."+location.base+".tmp-*")
 	if err != nil {
 		return fmt.Errorf("create staged output directory: %w", err)
@@ -112,7 +125,7 @@ func stageAndPublishWithHook(location outputLocation, files map[string][]byte, b
 	}
 	sort.Strings(paths)
 	for _, relative := range paths {
-		if err := writeStagedFile(staging, relative, files[relative]); err != nil {
+		if err := writeStagedData(ctx, staging, relative, files[relative]); err != nil {
 			return err
 		}
 	}
@@ -124,6 +137,9 @@ func stageAndPublishWithHook(location outputLocation, files map[string][]byte, b
 			return fmt.Errorf("prepare final output publication: %w", err)
 		}
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := renameNoReplace(staging, location.output); err != nil {
 		return fmt.Errorf("atomically publish output directory without replacement: %w", err)
 	}
@@ -131,7 +147,7 @@ func stageAndPublishWithHook(location outputLocation, files map[string][]byte, b
 	return nil
 }
 
-func writeStagedFile(staging, relative string, contents []byte) error {
+func writeStagedData(ctx context.Context, staging, relative string, contents fileData) error {
 	if err := safeRelativePath(relative); err != nil {
 		return fmt.Errorf("generated output path: %w", err)
 	}
@@ -143,7 +159,7 @@ func writeStagedFile(staging, relative string, contents []byte) error {
 	if err != nil {
 		return fmt.Errorf("create staged output %q: %w", relative, err)
 	}
-	if _, err := file.Write(contents); err != nil {
+	if err := contents.copy(ctx, file); err != nil {
 		_ = file.Close()
 		return fmt.Errorf("write staged output %q: %w", relative, err)
 	}
@@ -157,7 +173,7 @@ func writeStagedFile(staging, relative string, contents []byte) error {
 	return nil
 }
 
-func compareOwnedOutput(output string, expected map[string][]byte) (bool, bool, error) {
+func compareFileOutput(ctx context.Context, output string, expected map[string]fileData) (bool, bool, error) {
 	info, err := os.Lstat(output)
 	if os.IsNotExist(err) {
 		return false, false, nil
@@ -171,41 +187,13 @@ func compareOwnedOutput(output string, expected map[string][]byte) (bool, bool, 
 	if err := validateOwnedMarker(output); err != nil {
 		return false, true, err
 	}
-	actual, err := readOutputFiles(output)
-	if err != nil {
-		return false, true, err
-	}
-	if len(actual) != len(expected) {
-		return false, true, nil
-	}
-	for relative, contents := range expected {
-		if !bytes.Equal(actual[relative], contents) {
-			return false, true, nil
-		}
-	}
-	return true, true, nil
-}
-
-func validateOwnedMarker(output string) error {
-	manifestBytes, err := os.ReadFile(filepath.Join(output, "manifest.json"))
-	if err != nil {
-		return fmt.Errorf("output exists without readable iconpack manifest; refusing to overwrite")
-	}
-	var marker struct {
-		SchemaVersion int    `json:"schemaVersion"`
-		Tool          string `json:"tool"`
-	}
-	if err := json.Unmarshal(manifestBytes, &marker); err != nil || marker.SchemaVersion != OutputSchemaVersion || marker.Tool != toolName {
-		return fmt.Errorf("output manifest is not owned by %s; refusing to overwrite", toolName)
-	}
-	return nil
-}
-
-func readOutputFiles(output string) (map[string][]byte, error) {
-	actual := map[string][]byte{}
-	err := filepath.WalkDir(output, func(path string, entry os.DirEntry, walkErr error) error {
+	count, identical := 0, true
+	err = filepath.WalkDir(output, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 		if path == output {
 			return nil
@@ -227,15 +215,52 @@ func readOutputFiles(output string) (map[string][]byte, error) {
 		if err != nil {
 			return err
 		}
-		contents, err := os.ReadFile(path)
+		want, ok := expected[filepath.ToSlash(relative)]
+		count++
+		if !ok || info.Size() != want.size {
+			identical = false
+			return nil
+		}
+		matches, err := matchesFile(ctx, path, want)
 		if err != nil {
 			return err
 		}
-		actual[filepath.ToSlash(relative)] = contents
+		if !matches {
+			identical = false
+		}
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("inspect owned output: %w", err)
+		return false, true, fmt.Errorf("inspect owned output: %w", err)
 	}
-	return actual, nil
+	return identical && count == len(expected), true, nil
+}
+
+func validateOwnedMarker(output string) error {
+	manifestBytes, err := os.ReadFile(filepath.Join(output, "manifest.json"))
+	if err != nil {
+		return fmt.Errorf("output exists without readable iconpack manifest; refusing to overwrite")
+	}
+	var marker struct {
+		SchemaVersion int    `json:"schemaVersion"`
+		Tool          string `json:"tool"`
+	}
+	if err := json.Unmarshal(manifestBytes, &marker); err != nil || marker.SchemaVersion != OutputSchemaVersion || marker.Tool != toolName {
+		return fmt.Errorf("output manifest is not owned by %s; refusing to overwrite", toolName)
+	}
+	return nil
+}
+
+func matchesFile(ctx context.Context, path string, want fileData) (bool, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = file.Close() }()
+	h := sha256.New()
+	size, err := io.Copy(h, cancelReader{ctx, io.LimitReader(file, want.size+1)})
+	if err != nil {
+		return false, err
+	}
+	return size == want.size && fmt.Sprintf("%x", h.Sum(nil)) == want.hash, nil
 }

--- a/iconpack/source.go
+++ b/iconpack/source.go
@@ -49,6 +49,8 @@ type releaseBoundary struct {
 	release       releaseDocument
 	checksums     map[string]string
 	files         map[string][]byte
+	diskFiles     map[string]fileData
+	ctx           context.Context
 	generic       *genericPack
 	muamba        *muambaPack
 }


### PR DESCRIPTION
Generating the selfhst library previously retained the complete Muamba snapshot, copied source bytes into another map, and retained image bytes throughout generation and output comparison. Use Muamba's verified Walk API and private disk-backed sources for both library and SVG generation. Validate one image at a time, stream publication with size/SHA-256 verification, and hash existing output files individually.

Capture the provenance lockfile while the source mutation lock is held. Preserve catalog/manifest bytes, source identity, licensing, ordering, cancellation, staging cleanup, and atomic publication without overwrite.

Uses published Muamba v0.0.6 from araihu/muamba#20, including cancellation-aware cache seeding, with regenerated go.sum and no local replace. Includes the dated v0.3.1 changelog and compatibility row for the authorized patch release.

Validation:
- Focused iconpack/iconlibrary tests, race, vet, lint, full root suite with the repository workspace, and both site module contracts.
- Integrity tests cover same-inode rewrites, path replacement, growth, cancelled publication and cleanup.
- Real pinned selfhst generation: 2,893 catalog icons and 7,508 byte-identical output files versus the previous generator; all manifest file sizes/hashes verified.
- Measured generator RSS: 536.8 MiB before (sources already materialized), 71.3 MiB for the new cold cache including download. Balemoh integration verifies the actual icon route's 503-to-200 transition and returned SHA-256.
- Known baseline limitation: GOWORK=off go test ./... fails in internal/e2eimpact because those tests require a workspace to inspect ./site/...; reproduced unchanged on origin/main. Focused module tests and GOWORK=off go vet ./... pass.
- Remote CI limitation: Tests + coverage failed twice on landing-page/charts E2E timeouts (including the suite's 15-minute timeout on the unchanged retry). CodeQL and all other checks passed. The affected landing-page tests/code are unchanged by this PR; the cause of the timeouts has not been established. See workflow run 34634502180, attempts 1 and 2.

No Balemoh deployment or resource reduction is included. Goshtoso v0.3.1 publication uses the repository release workflow and its complete verification gates.
