### PR TITLE
fix: read unquoted Tailwind version during release publication

### DIFF
--- a/.dagger/src/index.ts
+++ b/.dagger/src/index.ts
@@ -184,7 +184,7 @@ scripts/run-release-coverage.sh --local-dry-run`
     const tag = this.string(release, "tag")
     if (!/^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(tag)) throw new Error(`invalid release tag: ${tag}`)
     const script = `set -euo pipefail
-ver=$(sed -n '/^  tailwindcss:$/,/^  [^ ]/ s/^    version: "\\([^"]*\\)"/\\1/p' muamba.yaml)
+ver=$(sed -nE '/^  tailwindcss:$/,/^  [^ ]/ s/^    version: "?([^"[:space:]]+)"?[[:space:]]*$/\\1/p' muamba.yaml)
 test -n "$ver"
 awk -v heading="## [$TAG]" 'index($0, heading) == 1 { found=1; next } found && /^## \\[/ { exit } found { print } END { if (!found) exit 1 }' CHANGELOG.md > /tmp/release-notes.md
 printf '\\n## Build artifacts\\n\\nBuilt with Tailwind CSS %s.\\nAssets attached: styles.css and goshtoso-theme.css.\\n' "$ver" >> /tmp/release-notes.md

--- a/scripts/release_version_test.go
+++ b/scripts/release_version_test.go
@@ -1,0 +1,57 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/araihu/goshtoso/assets"
+)
+
+func TestReleasePublisherReadsTailwindVersion(t *testing.T) {
+	module, err := os.ReadFile("../.dagger/src/index.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := regexp.MustCompile(`(?m)^ver=\$\(sed .*\)$`).FindString(string(module))
+	if line == "" {
+		t.Fatal("release publisher version command not found")
+	}
+	// Decode the escaped backslashes in the TypeScript template literal, then
+	// execute the actual publisher command against the manifest fixtures.
+	command := strings.ReplaceAll(line, `\\`, `\`) + "\ntest -n \"$ver\"\nprintf '%s' \"$ver\""
+	manifest, err := os.ReadFile("../muamba.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, manifest, want string
+	}{
+		{"repository manifest", string(manifest), assets.TailwindVersion()},
+		{"unquoted", "resources:\n  other:\n    version: 1.2.3\n  tailwindcss:\n    version: 9.8.7\n  after:\n    version: 2.3.4\n", "9.8.7"},
+		{"quoted", "resources:\n  tailwindcss:\n    version: \"9.8.7\"\n", "9.8.7"},
+		{"missing", "resources:\n  other:\n    version: 1.2.3\n", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "muamba.yaml"), []byte(tc.manifest), 0600); err != nil {
+				t.Fatal(err)
+			}
+			cmd := exec.Command("bash", "-euc", command)
+			cmd.Dir = dir
+			output, err := cmd.CombinedOutput()
+			if tc.want == "" {
+				if err == nil {
+					t.Fatal("publisher accepted a missing Tailwind version")
+				}
+				return
+			}
+			if err != nil || string(output) != tc.want {
+				t.Fatalf("publisher version = %q, err = %v; want %q", output, err, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Release publication fails before creating notes because the Tailwind version extractor requires double quotes, while the current verified muamba.yaml contains `version: 4.3.3`. Accept the existing quoted form and the unquoted form; keep failure on a missing version.

The regression test executes the actual shell command extracted from the Dagger template against the repository manifest and isolated fixtures, including adjacent resources. It failed against the repository manifest before the fix and now passes. `go test ./scripts -count=1`, `go vet ./scripts`, scoped lint and `git diff --check` pass.

This is required to complete the authorized v0.3.1 patch release following #305. Release verification, coverage, signing/publication permissions and E2E gates are unchanged. CodeRabbit was explicitly waived by the requester.
