### PR TITLE
ci: publish versioned release images and latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,8 @@ jobs:
         run: |
           docker build --platform linux/amd64 -t goshtoso-site:test .
           scripts/check-site-image goshtoso-site:test
+      - name: Build and test release version override
+        run: |
+          docker build --platform linux/amd64 --build-arg GOSHTOSO_DOCS_VERSION=v0.0.0 \
+            -t goshtoso-site:release-test .
+          scripts/check-site-image goshtoso-site:release-test v0.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,3 +111,31 @@ jobs:
         env:
           GITHUB_RELEASE_TOKEN: ${{ github.token }}
           GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+
+  publish-image:
+    name: Publish release image and latest
+    needs: publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    concurrency:
+      group: publish-goshtoso-release-image
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+          persist-credentials: false
+      - name: Build, test and publish released image
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: bash scripts/publish-release-image
+      - name: Preserve immutable release image for GitOps
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: image-goshtoso-release
+          path: image-goshtoso-release.txt
+          retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Goshtoso are documented in this file.
 
+## [v0.3.2] - 2026-09-11
+
+### Release images
+
+- Publish the documentation site image under the release version after the
+  full release gates and GitHub release publication succeed.
+- Point the GHCR `latest` tag to the latest stable GitHub release, preventing
+  older release reruns and main-branch builds from replacing it.
+- Display the released library version in release images. No consumer API,
+  runtime asset, or migration changes are required.
+
 ## [v0.3.1] - 2026-09-11
 
 ### Iconpack memory and integrity

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM --platform=$BUILDPLATFORM golang:1.27.0-bookworm@sha256:484ef6066fa69acb059fdfeda7ba2b8f7391f2ef6abc6f9b8411e669ebd56466 AS builder
 ARG TARGETARCH=amd64
+ARG GOSHTOSO_DOCS_VERSION
 
 WORKDIR /src
 
@@ -14,7 +15,7 @@ COPY site/go.mod site/go.sum ./site/
 RUN go work init . ./site && go mod download
 
 COPY . .
-RUN GOSHTOSO_DOCS_VERSION="$(cd site && GOWORK=off go list -m -f '{{.Version}}' github.com/araihu/goshtoso)" && \
+RUN GOSHTOSO_DOCS_VERSION="${GOSHTOSO_DOCS_VERSION:-$(cd site && GOWORK=off go list -m -f '{{.Version}}' github.com/araihu/goshtoso)}" && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
       -ldflags "-X github.com/araihu/goshtoso/site/internal/buildinfo.goDocsVersion=${GOSHTOSO_DOCS_VERSION}" \
       -o /out/server ./site/cmd/server

--- a/README.md
+++ b/README.md
@@ -399,11 +399,17 @@ MIT. See [LICENSE](LICENSE).
 This repository builds and publishes `ghcr.io/araihu/goshtoso` after Code CI
 passes on `main`. The image tag is the complete source commit SHA; the
 `image-goshtoso` workflow artifact contains the immutable digest for deployment.
+After a stable GitHub release is published, the release workflow also builds
+and tests its image, publishes the version tag (for example `v0.3.2`), and
+updates `latest` only if that version is still the latest GitHub release.
+Main builds and reruns of older releases do not replace `latest`. The release
+digest is retained in the `image-goshtoso-release` workflow artifact.
 The package should remain private. Kubernetes uses its existing GHCR pull secret.
 
 The Docker image serves port 8090 as UID/GID 10001 and is tested with a read-only
 root filesystem and writable `/tmp`. It builds the root library and site from
-one checkout; `site/go.mod` supplies the displayed documentation version.
+one checkout; release images display the released tag, while main images use
+the documentation version pinned in `site/go.mod`.
 
 Update `k8s/goshtoso/deployment.yaml` in `guilycst/home-lab` with the produced
 digest through a reviewed GitOps change. Argo CD owns the rollout. Publishing an

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,6 +11,7 @@ is retained in this table.
 
 | Goshtoso | Tailwind CSS |
 |----------|--------------|
+| v0.3.2   | 4.3.3        |
 | v0.3.1   | 4.3.3        |
 | v0.3.0   | 4.3.3        |
 | v0.2.10  | 4.3.3        |

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -75,6 +75,10 @@ many of these steps, but the checklist keeps the public release story coherent.
   protected `main` branch.
 - Confirm `VERSIONS.md` has a row for the released tag.
 - Confirm the documentation site deploy completed or was intentionally skipped.
+- Confirm the release image job passed, the version tag and `latest` resolve to
+  the same GHCR digest for the latest stable release, and the
+  `image-goshtoso-release` artifact contains that digest. Image publication does
+  not perform a homelab rollout.
 - Confirm `npx skills add araihu/goshtoso --list` discovers the released
   consumer-agent skill.
 

--- a/scripts/publish-release-image
+++ b/scripts/publish-release-image
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Called only after the release verification and GitHub publication succeed.
+[[ "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+gh api "repos/araihu/goshtoso/releases/tags/$RELEASE_TAG" \
+  --jq 'select(.draft == false and .prerelease == false) | .tag_name' | grep -Fxq "$RELEASE_TAG"
+revision=$(git rev-parse HEAD)
+image="ghcr.io/araihu/goshtoso:$RELEASE_TAG"
+docker build --platform linux/amd64 \
+  --build-arg "GOSHTOSO_DOCS_VERSION=$RELEASE_TAG" \
+  --label org.opencontainers.image.source=https://github.com/araihu/goshtoso \
+  --label "org.opencontainers.image.revision=$revision" \
+  --label "org.opencontainers.image.version=$RELEASE_TAG" \
+  -t "$image" .
+bash scripts/check-site-image "$image" "$RELEASE_TAG"
+printf '%s' "$GH_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+trap 'docker logout ghcr.io >/dev/null' EXIT
+docker push "$image"
+digest=$(docker inspect --format '{{index .RepoDigests 0}}' "$image")
+[[ "$digest" =~ ^ghcr.io/araihu/goshtoso@sha256:[0-9a-f]{64}$ ]]
+printf '%s\n' "$digest" > image-goshtoso-release.txt
+
+# Serialize this job and recheck immediately before promotion: rerunning an old
+# release must not move latest backwards. Main CI never writes this alias.
+latest=$(gh api repos/araihu/goshtoso/releases/latest --jq .tag_name)
+if [[ "$latest" == "$RELEASE_TAG" ]]; then
+  docker tag "$image" ghcr.io/araihu/goshtoso:latest
+  docker push ghcr.io/araihu/goshtoso:latest
+  printf 'Published `%s` and `latest`: `%s`\n' "$RELEASE_TAG" "$digest" >> "$GITHUB_STEP_SUMMARY"
+else
+  printf 'Published `%s`: `%s`; latest belongs to `%s`.\n' "$RELEASE_TAG" "$digest" "$latest" >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/release_image_test.go
+++ b/scripts/release_image_test.go
@@ -1,0 +1,88 @@
+package scripts_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReleaseImagePublication(t *testing.T) {
+	script, err := os.ReadFile("publish-release-image")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, tag, latest, failure string
+		wantError, wantLatest      bool
+	}{
+		{"latest stable", "v0.3.2", "v0.3.2", "", false, true},
+		{"old rerun", "v0.3.1", "v0.3.2", "", false, false},
+		{"prerelease", "v0.3.3-rc.1", "v0.3.2", "", true, false},
+		{"unpublished", "v0.3.2", "v0.3.2", "release", true, false},
+		{"smoke failure", "v0.3.2", "v0.3.2", "smoke", true, false},
+		{"version push failure", "v0.3.2", "v0.3.2", "push", true, false},
+		{"latest lookup failure", "v0.3.2", "v0.3.2", "latest", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.Mkdir(filepath.Join(dir, "scripts"), 0700); err != nil {
+				t.Fatal(err)
+			}
+			files := map[string]string{
+				"publish": string(script),
+				"gh": `#!/usr/bin/env bash
+set -eu
+if [[ "$2" == */latest ]]; then
+  [[ "$FAILURE" != latest ]]
+  echo "$LATEST"
+else
+  [[ "$FAILURE" != release ]]
+  echo "$RELEASE_TAG"
+fi
+`,
+				"git": "#!/usr/bin/env bash\necho 123abc\n",
+				"docker": `#!/usr/bin/env bash
+set -eu
+echo "$*" >> "$CALLS"
+case "$1" in
+  login) cat >/dev/null ;;
+  push) [[ "$FAILURE" != push ]] ;;
+  inspect) printf 'ghcr.io/araihu/goshtoso@sha256:%064d\n' 1 ;;
+esac
+`,
+				"scripts/check-site-image": "#!/usr/bin/env bash\nset -eu\n[[ \"$2\" == \"$RELEASE_TAG\" ]]\n[[ \"$FAILURE\" != smoke ]]\n",
+			}
+			for name, body := range files {
+				if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			cmd := exec.Command("bash", "publish")
+			cmd.Dir = dir
+			cmd.Env = append(os.Environ(), "PATH="+dir+":"+os.Getenv("PATH"),
+				"RELEASE_TAG="+tc.tag, "LATEST="+tc.latest, "FAILURE="+tc.failure,
+				"GH_TOKEN=test", "GITHUB_ACTOR=test", "CALLS="+filepath.Join(dir, "calls"),
+				"GITHUB_STEP_SUMMARY="+filepath.Join(dir, "summary"))
+			out, err := cmd.CombinedOutput()
+			if (err != nil) != tc.wantError {
+				t.Fatalf("err=%v, output=%s", err, out)
+			}
+			calls, _ := os.ReadFile(filepath.Join(dir, "calls"))
+			if got := strings.Contains(string(calls), "push ghcr.io/araihu/goshtoso:latest"); got != tc.wantLatest {
+				t.Fatalf("latest push=%v, want %v; calls=%s", got, tc.wantLatest, calls)
+			}
+			if !tc.wantError {
+				for _, want := range []string{"--build-arg GOSHTOSO_DOCS_VERSION=" + tc.tag, "push ghcr.io/araihu/goshtoso:" + tc.tag} {
+					if !strings.Contains(string(calls), want) {
+						t.Errorf("missing %q in %s", want, calls)
+					}
+				}
+				if _, err := os.Stat(filepath.Join(dir, "image-goshtoso-release.txt")); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stable releases currently publish library assets but no versioned container or `latest` tag. Add an image job after successful release verification and GitHub publication: build the tagged source, test the restricted runtime and displayed release version, push `vX.Y.Z`, and update `latest` only when GitHub still identifies that tag as its latest stable release. Serialize release image jobs so an older rerun cannot replace the current release alias. Main builds retain their SHA-only tags.

Prepare the v0.3.2 changelog and compatibility row, and document the release digest artifact and tag policy.

Validation: publisher tests cover current and stale releases, prereleases, unpublished releases, smoke failures, push failures, and latest lookup failures; actionlint, root lint, workspace tests, GOWORK=off vet, both site module contracts, and diff checks pass. GitHub CI successfully built and smoke-tested both the default site image and the release version override. CodeQL passed for Go, JavaScript/TypeScript, and Actions. GOWORK=off root tests reproduce the existing internal/e2eimpact dependency on the site workspace; the workspace suite passes. The local Docker daemon rejected an overlay mount, so real image validation ran successfully on the GitHub runner.
